### PR TITLE
fix: uv.lock を types-PyYAML 追加に合わせて更新

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -637,6 +637,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "ruff" },
+    { name = "types-pyyaml" },
 ]
 
 [package.dev-dependencies]
@@ -662,6 +663,7 @@ requires-dist = [
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.2" },
     { name = "slack-bolt", specifier = ">=1.18,<2" },
     { name = "sqlalchemy", specifier = ">=2.0,<3" },
+    { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0" },
 ]
 provides-extras = ["dev"]
 


### PR DESCRIPTION
## Summary
- PR #17 で `types-PyYAML` を `optional-dependencies.dev` に追加した際、`uv.lock` のコミットが漏れていたため追加

## Test plan
- [x] `uv sync` が正常に完了すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)