### PR TITLE
feat: Claude Code Actionsにフル権限を付与

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -32,4 +32,4 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--max-turns 30"
+          claude_args: "--max-turns 30 --dangerously-skip-permissions"

--- a/docs/specs/claude-code-actions.md
+++ b/docs/specs/claude-code-actions.md
@@ -44,6 +44,7 @@ GitHub PRやIssueで `@claude` メンションすることでClaude Codeを呼�
 - [x] AC2: becky3ユーザーのみ実行可能（セキュリティガード）
 - [x] AC3: OAuth認証でAPIアクセスする
 - [x] AC4: `--max-turns 30` でターン数を制限する
+- [x] AC6: `--dangerously-skip-permissions` でツール実行確認をスキップする
 - [x] AC5: ワークフローファイルが `.github/workflows/claude.yml` に配置される
 
 ## 認証方式
@@ -65,6 +66,7 @@ GitHub PRやIssueで `@claude` メンションすることでClaude Codeを呼�
 | イベントフィルタリング | `@claude` メンションがある場合のみ実行 |
 | トークン保護 | シークレット経由で参照（ハードコードしない） |
 | ターン制限 | `--max-turns 30` で無限ループ防止 |
+| フル権限 | `--dangerously-skip-permissions` で確認スキップ（ユーザー制限があるため許容） |
 
 ## 関連ファイル
 


### PR DESCRIPTION
## Summary
- `--dangerously-skip-permissions` を追加し、ツール実行時の確認をスキップ
- 実装タスクやIssue編集などの操作が自動で実行可能に

## セキュリティ
- `github.actor == 'becky3'` でユーザー制限済み（becky3のみ起動可能）
- GitHub Actions環境は毎回クリーンなサンドボックス
- `--max-turns 30` でターン制限済み

## 変更内容
- `.github/workflows/claude.yml`: `--dangerously-skip-permissions` 追加
- `docs/specs/claude-code-actions.md`: 仕様書更新

## Test plan
- [ ] マージ後、Issue #35 で `@claude 実装計画を概要欄に記載して` を再試行
- [ ] 確認なしで `gh issue edit` が実行されることを確認

Refs #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)