### PR TITLE
fix: .gitattributes追加によるシェルスクリプトの改行コード問題を修正

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Shell scripts must use LF line endings
+*.sh text eol=lf


### PR DESCRIPTION
## 概要

Windows環境で `core.autocrlf=true` が設定されている場合、シェルスクリプトの改行コードが自動的にCRLFに変換され、実行エラーになる問題を修正しました。

## 問題

```
./.claude/scripts/notify.sh: line 4: $'\r': command not found
./.claude/scripts/notify.sh: line 53: syntax error: unexpected end of file
```

## 原因

- リポジトリ内のファイルはLF改行（正常）
- Windows gitの `core.autocrlf=true` により、checkout時にCRLFに変換される
- `.gitattributes` がないため、シェルスクリプトも変換対象になっていた

## 解決策

`.gitattributes` を追加し、`*.sh` ファイルを常にLF改行で保持するよう設定。

```
*.sh text eol=lf
```

## テスト結果

- 改行コード変換後、notify.sh が正常に実行できることを確認

Closes #49

---

🤖 Generated with [Claude Code](https://claude.ai/code)