### PR TITLE
fix: claude-code-action の bot_id 修正と Opus モデル指定

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -32,4 +32,6 @@ jobs:
       - uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          claude_args: "--max-turns 30 --dangerously-skip-permissions"
+          bot_name: "claude[bot]"
+          bot_id: "209825114"
+          claude_args: "--model claude-opus-4-5-20251101 --max-turns 30 --dangerously-skip-permissions"


### PR DESCRIPTION
## Summary
- `bot_name: "claude[bot]"`, `bot_id: "209825114"` を明示的に設定（デフォルトの `41898282` は `github-actions[bot]` の ID で不正）
- `--model claude-opus-4-5-20251101` を `claude_args` に追加し、Opus 4.5 を使用するよう変更

## 背景
- ref: https://github.com/anthropics/claude-code-action/issues/759
- デフォルトの `bot_id` が `github-actions[bot]` の ID になっており、コミット署名が正しく行われないバグへの対応

## Test plan
- [ ] GitHub Actions で claude-code-action が正常に動作すること
- [ ] コミットが `claude[bot]` 名義で作成されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)