### PR TITLE
feat: サービスごとのLLM選択を.envで設定可能に

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,8 +6,14 @@ SLACK_APP_TOKEN=xapp-your-app-token
 # Delivery Channel
 SLACK_NEWS_CHANNEL_ID=C0123456789
 
-# LLM Provider Selection ("openai" or "anthropic")
+# LLM Provider Selection ("openai" or "anthropic") - used when service is set to "online"
 ONLINE_LLM_PROVIDER=openai
+
+# Per-service LLM selection ("local" or "online", default: local)
+CHAT_LLM_PROVIDER=local
+PROFILER_LLM_PROVIDER=local
+TOPIC_LLM_PROVIDER=local
+SUMMARIZER_LLM_PROVIDER=local
 
 # OpenAI Configuration
 OPENAI_API_KEY=sk-your-openai-key

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,9 +4,13 @@
 
 ## LLM使い分けルール
 
-- **ローカル (LM Studio)**: 記事要約、ユーザー情報抽出 — 単純・定型タスク
-- **オンライン (OpenAI/Claude)**: チャット応答、情報源探索、トピック提案 — 推論力が必要なタスク
-- ローカル不可時はオンラインにフォールバック
+- **デフォルト**: 全サービスでローカルLLM（LM Studio）を使用
+- **設定変更**: `.env` で各サービスごとにLLMを変更可能
+  - `CHAT_LLM_PROVIDER` — ChatService用
+  - `PROFILER_LLM_PROVIDER` — UserProfiler用
+  - `TOPIC_LLM_PROVIDER` — TopicRecommender用
+  - `SUMMARIZER_LLM_PROVIDER` — Summarizer用
+- 各設定は `"local"` または `"online"` を指定（デフォルト: `"local"`）
 
 ## 開発ルール
 

--- a/docs/specs/overview.md
+++ b/docs/specs/overview.md
@@ -29,19 +29,37 @@ Learning Companionは、Slack上で動作するAI学習支援アシスタント�
 | RSS | feedparser |
 | 設定管理 | pydantic-settings (.env) + YAML (アシスタント性格) |
 
-## 4. LLM使い分けルール（タスクベース）
+## 4. LLM使い分けルール
 
-コスト最適化のため、タスクの性質に応じてLLMを使い分ける。
+全サービスでローカルLLM（LM Studio）をデフォルトで使用する。
+各サービスごとに `.env` ファイルで使用するLLMを変更可能。
 
-| タスク | プロバイダー | 理由 |
-|--------|-------------|------|
-| 記事要約 | ローカル (LM Studio) | 単純作業・大量処理向き |
-| ユーザー情報抽出 | ローカル | 定型的な抽出タスク |
-| 質問への回答 | オンライン (OpenAI/Claude) | 高品質な応答が必要 |
-| 情報源探索・提案 | オンライン | 推論力が必要 |
-| 学習トピック提案 | オンライン | パーソナライズに推論力が必要 |
+### サービスごとのLLM設定
 
-**フォールバック**: ローカルLLMが利用不可の場合、オンラインLLMにフォールバックする。
+| 環境変数 | 対象サービス | デフォルト | 説明 |
+|----------|-------------|-----------|------|
+| `CHAT_LLM_PROVIDER` | ChatService | local | チャット応答 |
+| `PROFILER_LLM_PROVIDER` | UserProfiler | local | ユーザー情報抽出 |
+| `TOPIC_LLM_PROVIDER` | TopicRecommender | local | トピック提案 |
+| `SUMMARIZER_LLM_PROVIDER` | Summarizer | local | 記事要約 |
+
+各設定には `"local"` または `"online"` を指定する。
+`"online"` の場合、`ONLINE_LLM_PROVIDER` の設定（`"openai"` or `"anthropic"`）が使用される。
+
+### 設定例
+
+```env
+# 全てローカル（デフォルト）
+CHAT_LLM_PROVIDER=local
+PROFILER_LLM_PROVIDER=local
+TOPIC_LLM_PROVIDER=local
+SUMMARIZER_LLM_PROVIDER=local
+
+# チャットとトピック提案のみオンライン
+CHAT_LLM_PROVIDER=online
+TOPIC_LLM_PROVIDER=online
+ONLINE_LLM_PROVIDER=openai
+```
 
 ## 5. DB設計
 

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -28,8 +28,14 @@ class Settings(BaseSettings):
     slack_app_token: str = ""
     slack_news_channel_id: str = ""
 
-    # LLM Provider Selection
+    # LLM Provider Selection (global online provider)
     online_llm_provider: Literal["openai", "anthropic"] = "openai"
+
+    # Per-service LLM selection ("local" or "online", default: local)
+    chat_llm_provider: Literal["local", "online"] = "local"
+    profiler_llm_provider: Literal["local", "online"] = "local"
+    topic_llm_provider: Literal["local", "online"] = "local"
+    summarizer_llm_provider: Literal["local", "online"] = "local"
 
     # OpenAI
     openai_api_key: str = ""

--- a/src/llm/__init__.py
+++ b/src/llm/__init__.py
@@ -1,5 +1,5 @@
 from src.llm.base import LLMProvider, LLMResponse, Message
-from src.llm.factory import create_local_provider, create_online_provider, get_provider_with_fallback
+from src.llm.factory import create_local_provider, create_online_provider, get_provider_for_service
 
 __all__ = [
     "LLMProvider",
@@ -7,5 +7,5 @@ __all__ = [
     "Message",
     "create_local_provider",
     "create_online_provider",
-    "get_provider_with_fallback",
+    "get_provider_for_service",
 ]

--- a/src/llm/factory.py
+++ b/src/llm/factory.py
@@ -4,15 +4,13 @@
 
 from __future__ import annotations
 
-import logging
+from typing import Literal
 
 from src.config.settings import Settings
 from src.llm.anthropic_provider import AnthropicProvider
 from src.llm.base import LLMProvider
 from src.llm.lmstudio_provider import LMStudioProvider
 from src.llm.openai_provider import OpenAIProvider
-
-logger = logging.getLogger(__name__)
 
 
 def create_online_provider(settings: Settings) -> LLMProvider:
@@ -36,12 +34,19 @@ def create_local_provider(settings: Settings) -> LMStudioProvider:
     )
 
 
-async def get_provider_with_fallback(
-    local: LLMProvider,
-    online: LLMProvider,
+def get_provider_for_service(
+    settings: Settings,
+    service_llm_setting: Literal["local", "online"],
 ) -> LLMProvider:
-    """ローカル優先で、利用不可ならオンラインにフォールバックする."""
-    if await local.is_available():
-        return local
-    logger.info("Local LLM unavailable, falling back to online provider")
-    return online
+    """サービスごとの設定に基づいてLLMプロバイダーを返す.
+
+    Args:
+        settings: アプリケーション設定
+        service_llm_setting: サービスごとのLLM設定（"local" or "online"）
+
+    Returns:
+        対応するLLMプロバイダー
+    """
+    if service_llm_setting == "online":
+        return create_online_provider(settings)
+    return create_local_provider(settings)


### PR DESCRIPTION
## Summary

- 全サービスでローカルLLM（LM Studio）をデフォルトに変更
- `.env`で各サービスごとの利用LLMを変更可能に
  - `CHAT_LLM_PROVIDER` — ChatService用
  - `PROFILER_LLM_PROVIDER` — UserProfiler用
  - `TOPIC_LLM_PROVIDER` — TopicRecommender用
  - `SUMMARIZER_LLM_PROVIDER` — Summarizer用
- フォールバック処理（`get_provider_with_fallback`）を削除

## Changes

| ファイル | 変更内容 |
|---------|---------|
| `src/config/settings.py` | サービスごとのLLM設定を追加 |
| `src/llm/factory.py` | `get_provider_for_service`関数を追加、フォールバック関数を削除 |
| `src/main.py` | 設定に基づいてLLMプロバイダーを選択 |
| `tests/test_llm.py` | 新設定のテストを追加、フォールバックテストを削除 |
| `.env.example` | 新設定項目を追加 |
| `docs/specs/overview.md` | LLM使い分けルールを更新 |
| `CLAUDE.md` | LLM使い分けルールを更新 |

## Test plan

- [x] 全テスト通過（127 passed）
- [x] ruff lint 通過
- [x] mypy 型チェック通過

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)