### PR TITLE
fix(hooks): Notification の matcher を idle_prompt のみに限定 (#59)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -3,11 +3,11 @@
   "hooks": {
     "Notification": [
       {
-        "matcher": "*",
+        "matcher": "idle_prompt",
         "hooks": [
           {
             "type": "command",
-            "command": "./.claude/scripts/notify.sh 入力待ち 確認が必要です"
+            "command": "./.claude/scripts/notify.sh 入力待ち アイドル状態です"
           }
         ]
       }


### PR DESCRIPTION
## Summary

- `Notification` イベントの matcher を `"*"` → `"idle_prompt"` に変更
- `permission_prompt` と `PermissionRequest` の重複発火を防止
- 通知メッセージをアイドル状態に適した内容に更新

Closes #59

🤖 Generated with [Claude Code](https://claude.ai/code)