### PR TITLE
feat: Bot停止スクリプト作成とプロセス検証の追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -113,15 +113,19 @@ Bot の重複起動を防止する仕組みが組み込まれています。
 - **仕様**: `docs/specs/bot-process-guard.md`
 - **プロセスガードモジュール**: `src/process_guard.py`
 - **起動スクリプト**: `scripts/bot_start.sh`
+- **停止スクリプト**: `scripts/bot_stop.sh`
 
-### 起動方法
+### 起動・停止方法
 
 ```bash
-# 推奨: 起動スクリプト経由（PIDチェック + 既存プロセス停止 + 起動）
+# 推奨: 起動スクリプト経由（既存プロセス停止 + 起動）
 bash scripts/bot_start.sh
 
 # 直接起動（Python側のプロセスガードが動作）
 uv run python -m src.main
+
+# Bot停止（プロセス検証付き）
+bash scripts/bot_stop.sh
 ```
 
 ### 動作の仕組み
@@ -130,11 +134,17 @@ uv run python -m src.main
 2. **実行中**: `bot.pid` に現在のPIDを記録
 3. **終了時**: 子プロセス（MCPサーバー等）をクリーンアップし、PIDファイルを削除
 
+### プロセス検証
+
+- PIDファイルのプロセスがBotかどうか、コマンドライン文字列に `src.main` が含まれるかで検証
+- PID再利用により無関係プロセスがPIDファイルに記録されている場合、killせずPIDファイルのみ削除
+- `bot_stop.sh`（シェル側）と `process_guard.py`（Python側）の両方で検証を実施
+
 ### 注意事項
 
 - `bot.pid` は `.gitignore` に登録済み
-- Windows（Git Bash）環境でも動作する（`taskkill` を使用）
-- `scripts/bot_start.sh` はLF改行コードで保存すること
+- Windows（Git Bash）環境でも動作する（`taskkill` / `wmic` を使用）
+- `scripts/bot_start.sh`, `scripts/bot_stop.sh` はLF改行コードで保存すること
 
 ## Claude Code 拡張機能
 

--- a/scripts/bot_start.sh
+++ b/scripts/bot_start.sh
@@ -5,88 +5,21 @@
 # 使い方:
 #   bash scripts/bot_start.sh
 #
-# PIDファイル（bot.pid）で既存プロセスを検出し、
-# 生存していれば停止してから新しいBotを起動する。
+# 既存プロセスの停止を bot_stop.sh に委譲し、
+# 新しいBotを起動する。
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-PID_FILE="$PROJECT_ROOT/bot.pid"
-
-# --- ヘルパー関数 ---
-
-detect_os() {
-    case "$(uname -s)" in
-        MINGW*|MSYS*|CYGWIN*)
-            echo "windows"
-            ;;
-        Darwin*)
-            echo "macos"
-            ;;
-        *)
-            echo "linux"
-            ;;
-    esac
-}
-
-is_process_alive() {
-    local pid=$1
-    local os_type
-    os_type=$(detect_os)
-
-    if [ "$os_type" = "windows" ]; then
-        tasklist //FI "PID eq $pid" 2>/dev/null | grep -wq "$pid"
-    else
-        kill -0 "$pid" 2>/dev/null
-    fi
-}
-
-kill_process_tree() {
-    local pid=$1
-    local os_type
-    os_type=$(detect_os)
-
-    if [ "$os_type" = "windows" ]; then
-        taskkill //F //T //PID "$pid" > /dev/null 2>&1 || true
-    else
-        # まず子プロセスを停止
-        pkill -P "$pid" 2>/dev/null || true
-        # 親プロセスに SIGTERM で graceful に停止
-        kill "$pid" 2>/dev/null || true
-        sleep 1
-        # まだ生きていれば SIGKILL
-        if is_process_alive "$pid"; then
-            pkill -9 -P "$pid" 2>/dev/null || true
-            kill -9 "$pid" 2>/dev/null || true
-        fi
-    fi
-}
 
 # --- メイン処理 ---
 
 echo "=== Bot起動スクリプト ==="
 echo "プロジェクトルート: $PROJECT_ROOT"
 
-# 既存プロセスの確認・停止
-if [ -f "$PID_FILE" ]; then
-    OLD_PID=$(cat "$PID_FILE" 2>/dev/null || echo "")
-
-    # PIDが有効な数値か確認
-    if [[ "$OLD_PID" =~ ^[0-9]+$ ]]; then
-        if is_process_alive "$OLD_PID"; then
-            echo "既存プロセス (PID=$OLD_PID) を停止します..."
-            kill_process_tree "$OLD_PID"
-            echo "既存プロセスを停止しました。"
-        else
-            echo "PIDファイルのプロセス (PID=$OLD_PID) は既に終了しています。"
-        fi
-    else
-        echo "PIDファイルに不正な値が含まれています: '$OLD_PID'"
-    fi
-
-    rm -f "$PID_FILE"
-fi
+# 既存プロセスの停止（bot_stop.sh に委譲）
+bash "$SCRIPT_DIR/bot_stop.sh"
 
 # Bot起動
 echo "Botを起動します..."

--- a/scripts/bot_stop.sh
+++ b/scripts/bot_stop.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# Bot停止スクリプト（プロセス検証付き）
+# 仕様: docs/specs/bot-process-guard.md
+#
+# 使い方:
+#   bash scripts/bot_stop.sh
+#
+# PIDファイル（bot.pid）からプロセスを特定し、
+# Botプロセスであることを検証してから停止する。
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+PID_FILE="$PROJECT_ROOT/bot.pid"
+
+# Bot識別キーワード
+BOT_KEYWORD="src.main"
+
+# --- ヘルパー関数 ---
+
+detect_os() {
+    case "$(uname -s)" in
+        MINGW*|MSYS*|CYGWIN*)
+            echo "windows"
+            ;;
+        Darwin*)
+            echo "macos"
+            ;;
+        *)
+            echo "linux"
+            ;;
+    esac
+}
+
+is_process_alive() {
+    local pid=$1
+    local os_type
+    os_type=$(detect_os)
+
+    if [ "$os_type" = "windows" ]; then
+        tasklist //FI "PID eq $pid" 2>/dev/null | grep -wq "$pid"
+    else
+        kill -0 "$pid" 2>/dev/null
+    fi
+}
+
+is_bot_process() {
+    local pid=$1
+    local os_type
+    os_type=$(detect_os)
+
+    if [ "$os_type" = "windows" ]; then
+        # Windows: wmic でコマンドラインを取得
+        local cmdline
+        cmdline=$(wmic process where "ProcessId=$pid" get CommandLine 2>/dev/null || echo "")
+        if echo "$cmdline" | grep -q "$BOT_KEYWORD"; then
+            return 0
+        fi
+    else
+        # Unix: ps でコマンドラインを取得
+        local cmdline
+        cmdline=$(ps -p "$pid" -o args= 2>/dev/null || echo "")
+        if echo "$cmdline" | grep -q "$BOT_KEYWORD"; then
+            return 0
+        fi
+    fi
+
+    return 1
+}
+
+kill_process_tree() {
+    local pid=$1
+    local os_type
+    os_type=$(detect_os)
+
+    if [ "$os_type" = "windows" ]; then
+        taskkill //F //T //PID "$pid" > /dev/null 2>&1 || true
+    else
+        # まず子プロセスを停止
+        pkill -P "$pid" 2>/dev/null || true
+        # 親プロセスに SIGTERM で graceful に停止
+        kill "$pid" 2>/dev/null || true
+        sleep 1
+        # まだ生きていれば SIGKILL
+        if is_process_alive "$pid"; then
+            pkill -9 -P "$pid" 2>/dev/null || true
+            kill -9 "$pid" 2>/dev/null || true
+        fi
+    fi
+}
+
+# --- メイン処理 ---
+
+echo "=== Bot停止スクリプト ==="
+
+# 1. PIDファイルの存在確認
+if [ ! -f "$PID_FILE" ]; then
+    echo "Botは起動していません（PIDファイルなし）。"
+    exit 0
+fi
+
+# 2. PID読み取り
+OLD_PID=$(cat "$PID_FILE" 2>/dev/null || echo "")
+
+if ! [[ "$OLD_PID" =~ ^[0-9]+$ ]]; then
+    echo "PIDファイルに不正な値が含まれています: '$OLD_PID'"
+    rm -f "$PID_FILE"
+    exit 1
+fi
+
+echo "PIDファイルのプロセス: PID=$OLD_PID"
+
+# 3. プロセス生存確認
+if ! is_process_alive "$OLD_PID"; then
+    echo "プロセス (PID=$OLD_PID) は既に終了しています。PIDファイルを削除します。"
+    rm -f "$PID_FILE"
+    exit 0
+fi
+
+# 4. プロセス検証（Bot以外をkillしない）
+if ! is_bot_process "$OLD_PID"; then
+    echo "警告: PID=$OLD_PID はBotプロセスではありません（PID再利用検出）。killをスキップします。"
+    rm -f "$PID_FILE"
+    exit 0
+fi
+
+# 5. プロセスツリーごと停止
+echo "Botプロセス (PID=$OLD_PID) を停止します..."
+kill_process_tree "$OLD_PID"
+
+# 6. PIDファイル削除・完了報告
+rm -f "$PID_FILE"
+echo "Botを停止しました。"


### PR DESCRIPTION
## Summary

- `scripts/bot_stop.sh` を新規作成: PIDファイルベースのBot停止スクリプト（プロセス検証付き）
- `bot_start.sh` をリファクタリング: ヘルパー関数を `bot_stop.sh` に移設、停止処理を委譲
- `src/process_guard.py` に `is_bot_process()` を追加: コマンドライン文字列から `src.main` を検索し、PID再利用時の誤kill防止
- `kill_existing_process()` にプロセス検証を組み込み: Bot以外のプロセスはkillせずPIDファイルのみ削除
- テスト追加: `TestIsBotProcess`（AC11）、`TestKillExistingProcessWithBotCheck`（AC11）
- 仕様書に AC10-AC12 を追加、CLAUDE.md に停止方法の記載を追加

## Test plan

- [x] pytest 282件全通過
- [x] ruff lint 違反なし
- [x] mypy strict 型エラーなし
- [ ] 手動テスト: Bot起動 → `bot_stop.sh` で停止 → PIDファイル削除確認
- [ ] 手動テスト: PIDファイルに無関係PIDを書き込み → `bot_stop.sh` → killされないこと確認

Closes #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)