### PR TITLE
fix: claude-code-actionを最新バージョンv1.0.46に更新

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: anthropics/claude-code-action@v1.0.46
+      - uses: anthropics/claude-code-action@3e2f3e0c3b9f90c71f6b16e0ef5c975c3ac3e072 # v1.0.46
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- claude-code-action を `@v1`（2025年8月）から `@v1.0.46`（2026年2月7日）に更新
- コメント投稿が行われない問題の解決を期待

## 問題

PR #180 の修正後、AskUserQuestion の問題は解決したが、**Claudeの処理結果がGitHubコメントとして投稿されない**問題が残っていた。

**ログ分析結果**:
- `permission_denials: []` - ツール拒否は発生していない
- `"subtype": "success"` - Claude の処理自体は成功
- しかし、Issue #179 にコメントが投稿されていない

## 原因

`@v1` は 2025年8月のバージョンで、コメント投稿機能にバグがある可能性。

関連Issue: https://github.com/anthropics/claude-code-action/issues/548

## 変更内容

```diff
- uses: anthropics/claude-code-action@v1
+ uses: anthropics/claude-code-action@v1.0.46
```

## Test plan

- [ ] @claude メンションでタスクを依頼し、結果がGitHubコメントとして投稿されることを確認

Closes #153

---
🤖 Generated with [Claude Code](https://claude.com/claude-code) by SOS団