### PR TITLE
fix: prompt削除・Slack通知追加でコメント投稿問題を解決 (#153)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -37,21 +37,15 @@ jobs:
           bot_id: "209825114"
           claude_args: "--model claude-opus-4-5 --max-turns 100 --dangerously-skip-permissions"
           show_full_output: true
-          prompt: |
-            【ユーザーからの指示】
-            ${{ github.event.comment.body || github.event.issue.body || github.event.review.body }}
 
-            【追加ルール】
-            CLAUDE.md のルールに従って作業を進めてください。
-
-            【GitHub Actions環境の制約】
-            この環境では対話ができない。AskUserQuestionツールは使用不可。
-            不明点があっても質問せずに、以下の原則で自分で判断して進めること:
-            - 情報不足で判断できない場合は、最も妥当な選択を行い、その判断理由をコメントに明記する
-            - 曖昧な指示は、CLAUDE.md のルールに基づいて解釈する
-            - 完璧を求めず、まず動くものを作ることを優先する
-
-            【重要】タスク完了時の必須アクション:
-            PRを作成したら、必ず対応したIssueに「新規コメント」として完了報告を投稿すること。
-            - 既存コメントの編集ではなく、新しいコメントを追加する（編集では通知が飛ばないため）
-            - コマンド: `gh issue comment <Issue番号> --body "対応が完了しました。PR #<PR番号> をご確認ください。"`
+      # Slack通知（ワークフロー完了時）
+      - name: Slack notification
+        if: always()
+        uses: 8398a7/action-slack@v3
+        with:
+          status: ${{ job.status }}
+          fields: repo,message,commit,author,action,eventName,ref,workflow
+          mention: here
+          if_mention: failure
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -209,3 +209,24 @@ PRに対するレビュー指摘（Copilot、人間問わず）への対応は `
 | 複数視点でのバグ調査 | **エージェントチーム** | 仮説の議論が必要 |
 
 **詳細仕様・プロンプトテンプレート**: `docs/specs/agent-teams.md`
+
+### GitHub Actions 環境（claude-code-action）
+
+GitHub Actions で `anthropics/claude-code-action` を使用する場合の制約事項。
+
+**対話不可の制約**:
+
+- `AskUserQuestion` ツールは使用不可（`permission_denials` で拒否される）
+- 不明点があっても質問せずに、以下の原則で自分で判断して進めること:
+  - 情報不足で判断できない場合は、最も妥当な選択を行い、その判断理由をコメントに明記する
+  - 曖昧な指示は、CLAUDE.md のルールに基づいて解釈する
+  - 完璧を求めず、まず動くものを作ることを優先する
+
+**タスク完了時の必須アクション**:
+
+- PRを作成したら、必ず対応したIssueに「新規コメント」として完了報告を投稿すること
+- 既存コメントの編集ではなく、新しいコメントを追加する（編集では通知が飛ばないため）
+- コマンド: `gh issue comment <Issue番号> --body "対応が完了しました。PR #<PR番号> をご確認ください。"`
+
+**設定ファイル**: `.github/workflows/claude.yml`
+**レトロスペクティブ**: `docs/retro/claude-code-action.md`


### PR DESCRIPTION
## Summary

- `prompt` パラメータを削除してTag Modeに戻す
  - **根本原因**: Agent Mode (prompt有り) はコメント投稿機能が設計上無効
- Slack通知ステップを追加（ワークフロー完了時の通知用）
- `CLAUDE.md` にGitHub Actions環境の制約を追加
- レトロスペクティブに根本原因と解決策を追記

## 背景

`prompt` パラメータを追加した結果、claude-code-actionが「Agent Mode」に切り替わり、コメント投稿機能が無効化されていた。これはバグではなく仕様。

## 変更内容

1. **`.github/workflows/claude.yml`**
   - `prompt` パラメータを削除（Tag Modeに戻す）
   - Slack通知ステップを追加

2. **`CLAUDE.md`**
   - GitHub Actions環境の制約セクションを追加
   - AskUserQuestion不可、自己判断の原則を記載

3. **`docs/retro/claude-code-action.md`**
   - 根本原因（Agent Modeはコメント投稿しない）を追記
   - 解決策とlearningsを更新

## 必要な設定

Slack通知を有効にするには、以下のSecretを設定してください:
- `SLACK_WEBHOOK_URL`: Slack Incoming Webhook URL

## Test plan

- [ ] `@claude` メンションでワークフローをトリガー
- [ ] Claudeがコメントを投稿することを確認
- [ ] Slack通知が届くことを確認

Closes #153

🤖 Generated with [Claude Code](https://claude.com/claude-code)