### PR TITLE
fix: エージェントチームのSendMessage配信問題の回避策を追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -256,7 +256,7 @@ Task(
     subagent_type="general-purpose",
     name="member-name",
     team_name="team-name",
-    mode="bypassPermissions",  # ← 必須: これがないと SendMessage が届かない
+    mode="bypassPermissions",  # ← 必須: これがないと content が配信されない
     prompt="..."
 )
 ```

--- a/docs/retro/agent-team-development.md
+++ b/docs/retro/agent-team-development.md
@@ -314,7 +314,7 @@ Task(
 
 1. `docs/specs/agent-teams.md` にメンバースポーン時の必須設定を追加
 2. `CLAUDE.md` にチーム構築時のルールを追加
-3. `MEMORY.md` に学びを記録
+3. Claude Code の auto memory（`~/.claude/projects/*/memory/MEMORY.md`）にも学びを記録（git管理外）
 
 ### 次に活かすこと
 

--- a/docs/specs/agent-teams.md
+++ b/docs/specs/agent-teams.md
@@ -196,7 +196,11 @@ Task(
 )
 ```
 
+> **Note**: Task ツールの `mode` パラメータは、エージェント定義ファイル（`.claude/agents/*.md`）の `permissionMode` とは別物です。Task ツールでスポーンする際は `mode` を使用してください。
+
 **理由**: `mode` を設定しないと、メンバーからの SendMessage の content がリーダーに配信されない問題がある（Issue #224）。
+
+**セキュリティ上の注意**: `bypassPermissions` は全ての許可チェックをスキップするモードです。信頼できるリポジトリ・ローカル環境でのみ使用し、Claude Code 側で問題が修正された場合は設定を見直してください。
 
 ## 注意事項
 


### PR DESCRIPTION
## Summary

- エージェントチームでメンバーからリーダーへの SendMessage の content が届かない問題（Issue #224）の調査結果と回避策をドキュメント化

## 調査結果

| mode パラメータ | SendMessage content |
|----------------|---------------------|
| 未設定 | ❌ 届かない（idle_notification の summary のみ） |
| `bypassPermissions` | ✅ 正常に届く |

## 変更内容

- `docs/specs/agent-teams.md`: メンバースポーン時の必須設定を追加
- `CLAUDE.md`: チーム構築時の必須手順にルールを追加
- `docs/retro/agent-team-development.md`: 調査プロセスと学びを追記

## Test plan

- [x] `mode: "bypassPermissions"` 未設定でスポーン → content 届かないことを確認
- [x] `mode: "bypassPermissions"` 設定でスポーン → content 正常に届くことを確認

Closes #224

🤖 Generated with [Claude Code](https://claude.com/claude-code)