### PR TITLE
fix: 未使用の type: ignore コメントを除去 (#246)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,10 @@ module = ["fugashi", "fugashi.*", "rank_bm25", "rank_bm25.*"]
 ignore_missing_imports = true
 follow_imports = "skip"
 
+[[tool.mypy.overrides]]
+module = ["feedparser", "feedparser.*", "apscheduler", "apscheduler.*"]
+ignore_missing_imports = true
+
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 

--- a/src/scheduler/jobs.py
+++ b/src/scheduler/jobs.py
@@ -10,7 +10,7 @@ from datetime import datetime
 from typing import Any, Literal
 from zoneinfo import ZoneInfo
 
-from apscheduler.schedulers.asyncio import AsyncIOScheduler  # type: ignore[import-untyped]
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 

--- a/src/services/feed_collector.py
+++ b/src/services/feed_collector.py
@@ -12,7 +12,7 @@ from datetime import datetime, timedelta, timezone
 from html import unescape
 from time import mktime
 
-import feedparser  # type: ignore[import-untyped]
+import feedparser
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 


### PR DESCRIPTION
feedparser / apscheduler の import-untyped 抑制をインラインコメントから pyproject.toml の mypy overrides に移行。

Closes #246

Generated with [Claude Code](https://claude.ai/code)