### PR TITLE
fix: claude.yml のauto-implementジョブを分離 (#256)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -17,15 +17,14 @@ on:
     types: [submitted]
 
 jobs:
+  # 既存: @claude メンションによる手動トリガー
   claude:
-    # ガード: becky3ユーザーが@claudeメンションした場合のみ実行
     if: |
       github.actor == 'becky3' && (
         (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
         (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
         (github.event_name == 'issues' && github.event.action != 'labeled' && contains(github.event.issue.body, '@claude')) ||
-        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-        (github.event_name == 'issues' && github.event.action == 'labeled' && github.event.label != null && github.event.label.name == 'auto-implement' && !contains(github.event.issue.labels.*.name, 'auto:failed'))
+        (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude'))
       )
     runs-on: ubuntu-latest
     steps:
@@ -38,3 +37,25 @@ jobs:
           bot_id: "209825114"
           claude_args: "--model claude-opus-4-6 --max-turns 100 --dangerously-skip-permissions"
           show_full_output: true
+
+  # auto-implement ラベルによる自動実装トリガー
+  claude-auto-implement:
+    if: |
+      github.actor == 'becky3' &&
+      github.event_name == 'issues' &&
+      github.event.action == 'labeled' &&
+      github.event.label != null &&
+      github.event.label.name == 'auto-implement' &&
+      !contains(github.event.issue.labels.*.name, 'auto:failed')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: anthropics/claude-code-action@5994afaaa7f44611addc97a696a135acff5fd218 # v1.0.46
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          bot_name: "claude[bot]"
+          bot_id: "209825114"
+          claude_args: "--model claude-opus-4-6 --max-turns 100 --dangerously-skip-permissions"
+          show_full_output: true
+          label_trigger: "auto-implement"


### PR DESCRIPTION
## 概要

`claude-code-action` の内部トリガー判定（`label_trigger`）との整合性を取るため、claude.yml のジョブを2つに分離する。

## 背景

`claude-code-action` は内部で独自のトリガー判定を持っており、`label_trigger` パラメータが設定されていない場合、`auto-implement` ラベルではアクションが何もせず終了してしまう問題があった。

## 変更内容

- `claude` ジョブ: 既存の `@claude` メンション条件のみ（auto-implement 条件を除去）
- `claude-auto-implement` ジョブ: `auto-implement` ラベル専用。`label_trigger: "auto-implement"` を設定

両ジョブとも `github.actor == 'becky3'` のガードを維持。

Closes #256