### PR TITLE
docs: REPO_OWNER_PATの必要権限にIssuesを追加

### DIFF
--- a/docs/specs/auto-progress.md
+++ b/docs/specs/auto-progress.md
@@ -717,7 +717,7 @@ GitHub Actions は `GITHUB_TOKEN` で作成したイベントでは同一リポ�
 
 1. GitHub Settings > Developer settings > Personal access tokens > **Fine-grained tokens**
 2. Repository access: 対象リポジトリのみ（例: `<owner>/<repo>`）。最小権限の原則に従い、必要なリポジトリのみに限定する
-3. Permissions: Contents (Read and write), Pull requests (Read and write), Workflows (Read and write)
+3. Permissions: Contents (Read and write), Issues (Read and write), Pull requests (Read and write), Workflows (Read and write)
 4. Expiration: 最大90日（定期的なローテーションが必要）
 5. Token を作成し、リポジトリの Settings > Secrets and variables > Actions に `REPO_OWNER_PAT` として登録
 


### PR DESCRIPTION
## Summary
- REPO_OWNER_PATの必要権限一覧にIssues (Read and write)を追加
- claude-code-actionがIssueへのコメント投稿・ラベル操作にgithub_tokenを使用するため必要

## 背景
auto-implementテスト時に403エラー(`Resource not accessible by personal access token`)が発生。
PATにIssues権限が未設定だったことが原因。

🤖 Generated with [Claude Code](https://claude.com/claude-code)