### PR TITLE
fix: PR #280/#282 レビュー未対応指摘7件への対応 (#290)

### DIFF
--- a/.github/workflows/auto-fix.yml
+++ b/.github/workflows/auto-fix.yml
@@ -217,12 +217,13 @@ jobs:
               }
             ' -f owner="${REPO_OWNER}" -f name="${REPO_NAME}" -F number="$PR_NUMBER" \
               --jq '
-                if .data.repository.pullRequest == null then
-                  error("PR #\($number) not found")
+                .data.repository.pullRequest as $pr |
+                if $pr == null then
+                  error("PR not found")
                 else
-                  [.data.repository.pullRequest.reviewThreads.nodes[] | select(.isResolved == false)] | length
+                  [$pr.reviewThreads.nodes[] | select(.isResolved == false)] | length
                 end
-              ' --arg number "$PR_NUMBER" 2>&1); then
+              ' 2>&1); then
               # 数値バリデーション（リトライループ内で実行）
               if ! [[ "$UNRESOLVED_COUNT" =~ ^[0-9]+$ ]]; then
                 echo "::warning::Invalid response format (attempt $i/5): '$UNRESOLVED_COUNT'. Retrying..."
@@ -231,10 +232,19 @@ jobs:
                 fi
                 LAST_ERROR="$UNRESOLVED_COUNT"
                 UNRESOLVED_COUNT=""
-                if [ "$i" -lt 5 ]; then sleep 10; fi
-                continue
+                if [ "$i" -lt 5 ]; then
+                  sleep 10
+                  continue
+                else
+                  echo "::error::Failed to get valid response after 5 attempts."
+                  echo "::error::First error: $FIRST_ERROR"
+                  echo "::error::Last error: $LAST_ERROR"
+                  exit 1
+                fi
               fi
-              # 成功
+              # 成功 - エラー記録をクリア
+              FIRST_ERROR=""
+              LAST_ERROR=""
               break
             fi
             echo "::warning::Failed to query review threads (attempt $i/5): $UNRESOLVED_COUNT"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -224,8 +224,8 @@ Critical/Warning レベルの問題があれば修正する。
 3. `git diff --cached --stat` で差分サマリ表示
 4. 変更内容からコミットメッセージ自動生成（優先順位: fix > feat > docs > ci）
 5. `git commit -m "生成したメッセージ"`
-6. `BRANCH=$(git branch --show-current)` && `git push origin "$BRANCH"`
-7. `gh pr create --base develop --title "タイトル" --body "説明\n\nCloses #Issue番号"`
+6. `BRANCH=$(git branch --show-current) && git push origin "$BRANCH"`
+7. `gh pr create --base develop --title "タイトル" --body $'説明\n\nCloses #Issue番号'`
 8. `gh issue comment <Issue番号> --body "対応が完了しました。PR #<PR番号> をご確認ください。"`
 
 エラー時: ステップ1-7は失敗で停止。ステップ8は警告して続行（PRは作成済み）。


### PR DESCRIPTION
## Summary

PR #280 および #282 で受けたレビュー指摘のうち、対応が必要な7件を修正。

### PR #280 関連（4件） — CLAUDE.md
- git pushのブランチ名クォート
- ステップ1/4のbash失敗ハンドリング改善（&& で連結）
- gh pr createに--title/--body明示（GA環境対話モード回避）
- gh issue commentに--body明示

### PR #282 関連（3件） — auto-fix.yml
- PR不存在時のnullチェック追加
- リトライエラーメッセージ上書き問題修正（FIRST_ERROR/LAST_ERROR）
- 数値バリデーション位置修正（リトライループ内移動）

Closes #290