### PR TITLE
refactor: auto-fix.yml エラーハンドリング統一 + ガード集約 (#293)

### DIFF
--- a/.github/scripts/auto-fix/_common.sh
+++ b/.github/scripts/auto-fix/_common.sh
@@ -1,8 +1,10 @@
 #!/usr/bin/env bash
 # Auto Fix — 共通エラーハンドリング関数
 #
-# 使い方:
+# 使い方 (ローカル実行時):
 #   source "$(dirname "$0")/_common.sh"
+# 使い方 (GitHub Actions ワークフロー内):
+#   source "$GITHUB_WORKSPACE/.github/scripts/auto-fix/_common.sh"
 #
 # エラーハンドリング方針（auto-fix.yml 冒頭と対応）:
 #   gh_safe          → 失敗時 ::error:: + exit 1（認証/権限/必須データ取得）

--- a/.github/workflows/auto-fix.yml
+++ b/.github/workflows/auto-fix.yml
@@ -873,6 +873,7 @@ jobs:
       - name: Handle errors
         if: failure() && steps.pr-info.outputs.number != '' && steps.scope-check.outputs.in_scope == 'true'
         run: |
+          set -euo pipefail
           # エラーハンドラ: checkout 失敗の可能性があるため source は best-effort
           COMMON_SCRIPT="$GITHUB_WORKSPACE/.github/scripts/auto-fix/_common.sh"
           SOURCED=false


### PR DESCRIPTION
## Summary

auto-fix.yml の構造的技術的負債を解消するリファクタリング。

### エラーハンドリング共通関数
- .github/scripts/auto-fix/_common.sh に5つの共通関数を定義
- gh_safe / gh_safe_warning / gh_safe_noncrit / gh_comment / validate_numeric
- 7ステップで共通関数を適用

### ガード集約
- 6条件の組み合わせを1つのガード集約ステップに統合
- 後続9ステップのif条件を簡素化（60行削減）

### 効果
- エラーハンドリングパターンの統一（4種類→2種類）
- if条件のコピペ排除
- auto-fix.yml 全体で12行純削減

Closes #293