### PR TITLE
fix(ci): auto-fix.yml の max-turns を 50→100 に修正

### DIFF
--- a/.github/workflows/auto-fix.yml
+++ b/.github/workflows/auto-fix.yml
@@ -266,7 +266,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           bot_name: "claude[bot]"
           bot_id: "209825114"
-          claude_args: "--model claude-sonnet-4-5-20250929 --max-turns 50 --dangerously-skip-permissions"
+          claude_args: "--model claude-sonnet-4-5-20250929 --max-turns 100 --dangerously-skip-permissions"
           show_full_output: true
           prompt: |
             ${{ steps.load-prompt.outputs.prompt }}


### PR DESCRIPTION
## 概要

auto-fix.yml の `--max-turns` が 50 のままだったため、レビュー指摘修正+テスト+commit/push の全工程が完了せず `error_max_turns` で失敗していた。

100 に修正。

## 経緯

PR #304 の auto-fix 実行時に 50 ターンで打ち切られ、ステップ 4/8（テスト実行）まで到達したが commit/push に至らなかった。