### PR TITLE
feat(ci): auto-fix.yml に labeled トリガー追加

### DIFF
--- a/.github/scripts/auto-fix/_common.sh
+++ b/.github/scripts/auto-fix/_common.sh
@@ -98,6 +98,19 @@ output() {
   echo "$key=$value" >> "$GITHUB_OUTPUT"
 }
 
+# validate_pr_number: PR番号が正の整数かどうかを検証
+# 用途: PR番号の入力バリデーション（0や負数を拒否）
+# 使用例: if ! validate_pr_number "$PR_NUMBER" "PR_NUMBER_FROM_EVENT"; then exit 1; fi
+# 引数: $1 = 値, $2 = 変数名（ログ用、省略可）
+validate_pr_number() {
+  local value="$1"
+  local name="${2:-PR number}"
+  if ! [[ "$value" =~ ^[1-9][0-9]*$ ]]; then
+    echo "::error::Invalid $name: '$value'" >&2
+    return 1
+  fi
+}
+
 # validate_numeric: 値が数値かどうかを検証
 # 用途: API応答の数値バリデーション
 # 使用例: if ! validate_numeric "$COUNT" "loop count"; then COUNT=0; fi

--- a/.github/scripts/auto-fix/get-pr-number.sh
+++ b/.github/scripts/auto-fix/get-pr-number.sh
@@ -15,8 +15,7 @@ require_env GITHUB_OUTPUT
 
 # pull_request(labeled) トリガー: イベントから直接PR番号を取得
 if [ -n "${PR_NUMBER_FROM_EVENT:-}" ]; then
-  if ! [[ "$PR_NUMBER_FROM_EVENT" =~ ^[1-9][0-9]*$ ]]; then
-    echo "::error::Invalid PR_NUMBER_FROM_EVENT: '$PR_NUMBER_FROM_EVENT'"
+  if ! validate_pr_number "$PR_NUMBER_FROM_EVENT" "PR_NUMBER_FROM_EVENT"; then
     exit 1
   fi
   output "number" "$PR_NUMBER_FROM_EVENT"
@@ -51,8 +50,7 @@ if [ -z "$PR_NUMBER" ]; then
 fi
 
 # 数値バリデーション
-if ! [[ "$PR_NUMBER" =~ ^[1-9][0-9]*$ ]]; then
-  echo "::error::Invalid PR number: '$PR_NUMBER'"
+if ! validate_pr_number "$PR_NUMBER"; then
   exit 1
 fi
 

--- a/.github/workflows/auto-fix.yml
+++ b/.github/workflows/auto-fix.yml
@@ -33,7 +33,8 @@ jobs:
     # pull_request(labeled): auto-implement ラベルが付与された場合のみ実行
     if: >-
       (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success') ||
-      (github.event_name == 'pull_request' && github.event.label.name == 'auto-implement')
+      (github.event_name == 'pull_request' && github.event.label.name == 'auto-implement'
+       && github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: ubuntu-latest
     steps:
       # --- スクリプト・promptテンプレートの取得（全ステップで利用するため最初にcheckout） ---
@@ -52,8 +53,13 @@ jobs:
         run: |
           set -euo pipefail
           PR_NUMBER="${{ github.event.pull_request.number }}"
-          if ! gh pr edit "$PR_NUMBER" --remove-label "auto-implement" 2>/dev/null; then
-            echo "::notice::auto-implement label already removed or not found"
+          if ! ERROR_OUTPUT=$(gh pr edit "$PR_NUMBER" --remove-label "auto-implement" 2>&1); then
+            if echo "$ERROR_OUTPUT" | grep -qiE "(not found|no labels)"; then
+              echo "::notice::auto-implement label already removed or not found (PR #$PR_NUMBER)"
+            else
+              echo "::error::Failed to remove auto-implement label (PR #$PR_NUMBER): $ERROR_OUTPUT"
+              exit 1
+            fi
           fi
         env:
           GH_TOKEN: ${{ github.token }}

--- a/docs/specs/auto-fix-structure.md
+++ b/docs/specs/auto-fix-structure.md
@@ -35,11 +35,11 @@ on:
 | PR番号取得 | `workflow_run.pull_requests` or ブランチ名検索 | `github.event.pull_request.number` を直接使用 |
 | checkout ref | `workflow_run.head_branch` | `pull_request.head.ref` |
 | concurrency group | `auto-fix-{branch_name}` | `auto-fix-pr-{pr_number}` |
-| ラベル除去 | リンクIssueから除去（既存ステップ） | PR自体から即座に除去（ループ防止） |
+| ラベル除去 | リンクIssueから除去（既存ステップ） | PRから即座に除去（ループ防止） + リンクIssueからも除去（既存ステップ） |
 
 ### ラベル除去（ループ防止）
 
-labeled トリガー時は起動直後に `auto-implement` ラベルをPRから除去する。これにより、ワークフロー内の処理（コミット等）が再度 `labeled` イベントを発火させることを防ぐ。
+labeled トリガー時は起動直後に `auto-implement` ラベルをPRから除去する。これにより、ラベルが付いたままの状態で後続のレビューや手動操作によって同じラベルが再度付与された場合に、意図せずワークフローが繰り返し実行されることを防ぐ。また、既存の remove-label.sh ステップにより、リンクIssueからも `auto-implement` ラベルが除去される。
 
 ### get-pr-number.sh の拡張
 


### PR DESCRIPTION
## 概要

PRに `auto-implement` ラベルを付与すると auto-fix が起動する仕組みを追加。
`/review` とは独立した操作で、ユーザーが明示的に auto-fix を手動トリガーできる。

## 背景

- Issue #303: PRの指摘処理を手動トリガーで auto-fix できるようにしたい
- `/review` → pr-review → workflow_run → auto-fix のチェーンは `issue_comment` 起源で PR 番号が伝搬しない（GitHub Actions の既知制限: actions/runner#3438）
- `/review` は純粋な「再レビュー」として残し、auto-fix トリガーは別操作に分離

## 変更内容

- `auto-fix.yml` に `pull_request: types: [labeled]` トリガー追加
- `get-pr-number.sh` に `PR_NUMBER_FROM_EVENT` 環境変数対応追加
- ラベル除去ステップ追加（ループ防止）
- concurrency / checkout ref を pull_request イベント対応に拡張
- scope-check は labeled トリガー時スキップ（ラベル付与自体がスコープ制御）
- `auto-fix-structure.md` に labeled トリガーの仕様追記

## テスト結果

- pytest: 573 passed, 4 skipped
- ruff / mypy / markdownlint: 全クリア
- code-review: Critical 0, Warning 0
- doc-review: Critical 0, Warning 0

Closes #303