### PR TITLE
fix(f2): OgpExtractorのHTTPリクエストにSSRF対策を追加 (#286)

### DIFF
--- a/src/services/ogp_extractor.py
+++ b/src/services/ogp_extractor.py
@@ -102,7 +102,14 @@ class OgpExtractor:
     async def _fetch_og_image(self, url: str) -> str | None:
         """記事URLにアクセスしてog:imageメタタグを抽出する."""
         async with aiohttp.ClientSession(timeout=self._timeout) as session:
-            async with session.get(url) as resp:
+            async with session.get(url, allow_redirects=False) as resp:
+                if resp.status in (301, 302, 303, 307, 308):
+                    logger.warning(
+                        "Redirect detected (SSRF protection): %s -> %s",
+                        url,
+                        resp.headers.get("Location", "unknown"),
+                    )
+                    return None
                 if resp.status != 200:
                     return None
                 html = await resp.text(errors="replace")

--- a/tests/test_ogp_extractor.py
+++ b/tests/test_ogp_extractor.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
+
 from src.services.ogp_extractor import OgpExtractor
 
 
@@ -123,3 +125,83 @@ async def test_ac10_returns_none_on_non_200() -> None:
         result = await extractor.extract_image_url("https://example.com/article")
 
     assert result is None
+
+
+@pytest.mark.parametrize("status_code", [301, 302, 303, 307, 308])
+async def test_ac10_returns_none_on_redirect_ssrf_protection(status_code: int) -> None:
+    """AC10: リダイレクト応答時はSSRF対策としてNoneを返す."""
+    extractor = OgpExtractor()
+
+    mock_resp = AsyncMock()
+    mock_resp.status = status_code
+    mock_resp.headers = {"Location": "http://internal-server/secret"}
+    mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+    mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+    mock_session = AsyncMock()
+    mock_session.get = MagicMock(return_value=mock_resp)
+    mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("src.services.ogp_extractor.aiohttp.ClientSession", return_value=mock_session):
+        result = await extractor.extract_image_url("https://example.com/article")
+
+    assert result is None
+
+
+async def test_ac10_redirect_logs_warning() -> None:
+    """AC10: リダイレクト検出時にwarningログが出力される."""
+    extractor = OgpExtractor()
+
+    mock_resp = AsyncMock()
+    mock_resp.status = 302
+    mock_resp.headers = {"Location": "http://192.168.1.1/admin"}
+    mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+    mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+    mock_session = AsyncMock()
+    mock_session.get = MagicMock(return_value=mock_resp)
+    mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session.__aexit__ = AsyncMock(return_value=False)
+
+    with (
+        patch("src.services.ogp_extractor.aiohttp.ClientSession", return_value=mock_session),
+        patch("src.services.ogp_extractor.logger") as mock_logger,
+    ):
+        result = await extractor.extract_image_url("https://example.com/article")
+
+    assert result is None
+    mock_logger.warning.assert_called_once_with(
+        "Redirect detected (SSRF protection): %s -> %s",
+        "https://example.com/article",
+        "http://192.168.1.1/admin",
+    )
+
+
+async def test_ac10_redirect_without_location_header() -> None:
+    """AC10: Locationヘッダーがないリダイレクト応答でもNoneを返す."""
+    extractor = OgpExtractor()
+
+    mock_resp = AsyncMock()
+    mock_resp.status = 301
+    mock_resp.headers = {}
+    mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+    mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+    mock_session = AsyncMock()
+    mock_session.get = MagicMock(return_value=mock_resp)
+    mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session.__aexit__ = AsyncMock(return_value=False)
+
+    with (
+        patch("src.services.ogp_extractor.aiohttp.ClientSession", return_value=mock_session),
+        patch("src.services.ogp_extractor.logger") as mock_logger,
+    ):
+        result = await extractor.extract_image_url("https://example.com/article")
+
+    assert result is None
+    mock_logger.warning.assert_called_once_with(
+        "Redirect detected (SSRF protection): %s -> %s",
+        "https://example.com/article",
+        "unknown",
+    )


### PR DESCRIPTION
## 概要

`OgpExtractor._fetch_og_image` メソッドにSSRF対策（リダイレクト制限）を追加。
`web_crawler.py` と同じパターンで `allow_redirects=False` を設定し、リダイレクト応答検出時は warning ログを出力して `None` を返すようにした。

## 変更内容

- `src/services/ogp_extractor.py`: `_fetch_og_image` に `allow_redirects=False` 設定、リダイレクト応答(301/302/303/307/308)の検出・ログ出力
- `tests/test_ogp_extractor.py`: リダイレクト検出テスト3件追加（全ステータスコードのパラメータ化テスト、warningログ検証、Locationヘッダーなしケース）

## テスト結果

- pytest: 580 passed, 4 skipped
- ruff: All checks passed
- mypy: Success, no issues found

Closes #286

Generated with [Claude Code](https://claude.ai/code)