### PR TITLE
fix(ci): post-merge.yml を自動マージのみに限定 + レビューIssueタイトルに日付追加 (#317)

### DIFF
--- a/.github/scripts/post-merge/update-review-issue.sh
+++ b/.github/scripts/post-merge/update-review-issue.sh
@@ -138,7 +138,7 @@ ${NEW_SECTION}"
 
   NEW_ISSUE_URL=""
   if ! NEW_ISSUE_URL=$(gh issue create \
-    --title "自動マージレビュー" \
+    --title "自動マージレビュー (created:${DATE})" \
     --body "$ISSUE_BODY" \
     --label "auto:review-batch" 2>&1); then
     echo "::warning::Failed to create review-batch issue: $NEW_ISSUE_URL"

--- a/.github/workflows/post-merge.yml
+++ b/.github/workflows/post-merge.yml
@@ -28,8 +28,11 @@ on:
 
 jobs:
   post-merge:
-    # マージされた場合のみ実行（クローズのみは除外）
-    if: github.event.pull_request.merged == true
+    # 自動マージされたPRのみ実行（手動マージは除外）
+    # auto-fix.yml がマージ前に auto-merged ラベルを付与する想定
+    if: >-
+      github.event.pull_request.merged == true &&
+      contains(github.event.pull_request.labels.*.name, 'auto-merged')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout scripts


### PR DESCRIPTION
## Summary

- `post-merge.yml` が全PRマージで発火していたバグを修正
- レビューIssueのタイトルに作成日を追加し識別性を向上

## 変更内容

### 1. post-merge.yml に `auto-merged` ラベルフィルター追加

```yaml
if: >-
  github.event.pull_request.merged == true &&
  contains(github.event.pull_request.labels.*.name, 'auto-merged')
```

手動マージでは `auto-merged` ラベルがないため発火しない。
auto-fix.yml（Phase 1）がマージ前にラベルを付与する想定。

### 2. レビューIssueタイトルに日付追加

```
Before: 自動マージレビュー
After:  自動マージレビュー (created:YYYY-MM-DD)
```

### 3. 仕様書更新（auto-progress.md）

- ラベル一覧に `auto-merged` を追加
- 状態遷移図に `auto-merged` 付与を明記
- Issueタイトルフォーマット（UTC基準）を管理ルールに追加
- ステップ7に Phase 1 実装時の注記を追加

### 4. `auto-merged` ラベル作成済み

GitHub上に `auto-merged` ラベル（青 `#1D76DB`）を作成済み。

Closes #317