### PR TITLE
fix: CLAUDE.md の markdownlint MD031 違反を修正

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,7 @@
     # Bad: ディレクティブ行にインラインコメント（パースエラー）
     # shellcheck disable=SC2016 -- reason here
     ```
+
 - ドキュメント内の図表（フローチャート、シーケンス図、ER図等）はmermaid形式を使用する
   - ASCII図表は使用しない
   - 参考: <https://mermaid.js.org/>


### PR DESCRIPTION
CLAUDE.md のコードブロック前後に空行を追加し、MD031 (blanks-around-fences) を解消。

Closes #319

Generated with [Claude Code](https://claude.ai/code)