### PR TITLE
fix(ci): @claude ジョブの github_token を REPO_OWNER_PAT に変更 (#331)

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -32,7 +32,9 @@ jobs:
       - uses: anthropics/claude-code-action@5994afaaa7f44611addc97a696a135acff5fd218 # v1.0.46
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          # REPO_OWNER_PAT を使用: GITHUB_TOKEN で作成されたPRイベントでは
+          # pr-review.yml が再トリガーされないため（GitHub の無限ループ防止仕様）
+          github_token: ${{ secrets.REPO_OWNER_PAT }}
           bot_name: "claude[bot]"
           bot_id: "209825114"
           claude_args: "--model claude-opus-4-6 --max-turns 100 --dangerously-skip-permissions"


### PR DESCRIPTION
## Summary

- `claude.yml` の `claude` ジョブ（`@claude` メンション用）で `GITHUB_TOKEN` → `REPO_OWNER_PAT` に変更
- `GITHUB_TOKEN` で作成された PR イベントは GitHub の無限ループ防止仕様により他ワークフローをトリガーしないため、`@claude` が作成した PR に自動レビュー（pr-review.yml）が走らなかった

## Test plan

- [ ] `@claude` メンション経由で PR を作成し、pr-review.yml が自動トリガーされることを確認
- [ ] PR 作成者が `becky3` になることを確認（`github-actions` ではなく）
- [ ] `auto-progress` ラベルが付かないことを確認（auto-fix は走らない想定）

Closes #331

🤖 Generated with [Claude Code](https://claude.com/claude-code)