### PR TITLE
docs: マージ方式ルールの統一・明文化（通常マージ + main向けsquash）

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -99,6 +99,7 @@
 - コミット: `feat(f{N}): 説明 (#{Issue番号})`
 - PR作成時に `Closes #{Issue番号}` で紐付け
 - **PRのbaseブランチ**: 通常は `develop`、hotfix は `main`
+- **マージ方式**: feature/bugfix → develop は通常マージ（`--merge`）、develop → main は squash マージ（`--squash`）。詳細は `docs/specs/git-flow.md` の「マージ方式」セクション参照
 - GitHub Milestones で Step 単位の進捗管理
 - `gh` コマンドで Issue/PR を操作
 

--- a/docs/specs/auto-progress.md
+++ b/docs/specs/auto-progress.md
@@ -48,7 +48,7 @@ IssueからPRマージまでの全工程を自動化するパイプライン。�
 | Require a pull request before merging | YES | 直 push 禁止 |
 | Require status checks to pass | YES | CI 必須（pytest, mypy, ruff, markdownlint） |
 | Require approvals | NO | 自動マージを許可するため |
-| Require linear history | YES | squash merge で履歴を綺麗に |
+| Require linear history | NO | 通常マージ（開発履歴を保持） |
 | Include administrators | NO | 管理者は緊急時にバイパス可能 |
 | Allow auto-merge | YES | 自動マージを許可 |
 
@@ -59,9 +59,11 @@ IssueからPRマージまでの全工程を自動化するパイプライン。�
 | Require a pull request before merging | YES | 直 push 禁止 |
 | Require status checks to pass | YES | CI 必須 |
 | Require approvals | YES (1名) | 管理者の承認必須 |
-| Require linear history | YES | squash merge で履歴を綺麗に |
+| Require linear history | NO | squash マージはリリースPR作成時に指定（ブランチ保護で強制しない） |
 | Include administrators | YES | 管理者も保護対象 |
 | Allow auto-merge | NO | 手動マージのみ |
+
+> **マージ方式の詳細**: `docs/specs/git-flow.md` の「マージ方式」セクションを参照。
 
 ### リリースフロー（develop → main）
 
@@ -596,7 +598,7 @@ flowchart TD
 | コンフリクトなし | `gh pr view --json mergeable` が `MERGEABLE` |
 | `auto:failed` なし | PRのラベルに `auto:failed` が含まれない |
 
-マージ方式: `gh pr merge --merge`（通常マージ）
+マージ方式: `gh pr merge --merge`（通常マージ。マージ方式の統一ルールは `docs/specs/git-flow.md` の「マージ方式」セクション参照）
 マージ先: `develop` ブランチ（main への直接マージは禁止）
 
 ## 失敗時の振る舞い

--- a/docs/specs/git-flow.md
+++ b/docs/specs/git-flow.md
@@ -102,7 +102,7 @@ sequenceDiagram
 ```
 
 - リリース日は設けず、ある程度機能がまとまったタイミングで `develop` → `main` にPR作成
-- マージ方法: **Create a merge commit**（履歴を保持）
+- マージ方法: **Squash and merge**（リリース単位で1コミットにまとめる。詳細は「マージ方式」セクション参照）
 - マージ判断は開発者が行う
 
 ### hotfix（緊急修正）
@@ -156,6 +156,22 @@ sequenceDiagram
 - PRタイトル例: `Hotfix: 修正内容 (#Issue番号)`
 - `main` をbaseとする
 - マージ後に `develop` への反映を忘れないこと
+
+## マージ方式
+
+本プロジェクトのマージ方式は以下のルールで統一する。
+
+| マージ先 | 方式 | コマンド | 理由 |
+|---------|------|---------|------|
+| feature/bugfix → develop | 通常マージ | `gh pr merge --merge` | 開発履歴を保持 |
+| develop → main（リリース） | squash マージ | `gh pr merge --squash` | リリース単位で1コミットにまとめ、main の履歴をきれいに保つ |
+| hotfix → main | 通常マージ | `gh pr merge --merge` | 緊急修正は個別コミットとして記録 |
+
+### 設計判断
+
+- **develop への通常マージ**: feature ブランチの開発履歴（コミット単位の変更経緯）を保持することで、後からの調査・bisect が容易になる
+- **main への squash マージ**: リリース単位で1コミットにまとめることで、main の履歴が「リリース一覧」として機能する。develop に詳細履歴が残っているため情報は失われない
+- **hotfix の通常マージ**: 緊急修正は個別の修正として main に記録し、トレーサビリティを確保する
 
 ## GitHub Actions への影響
 


### PR DESCRIPTION
## 概要

マージ方式のルールがドキュメント間でバラバラになっている問題を解消し、`git-flow.md` に一元化して統一ルールを明文化する。

## 変更内容

### `docs/specs/git-flow.md`
- **マージ方式セクションを新設**: 統一ルールを一元管理
  - feature/bugfix → develop: 通常マージ（`--merge`、開発履歴保持）
  - develop → main: squash マージ（`--squash`、リリース単位で1コミット）
  - hotfix → main: 通常マージ（`--merge`、トレーサビリティ確保）
- 設計判断の理由を明記
- 「main への反映」セクションのマージ方法を「Create a merge commit」→「Squash and merge」に修正

### `docs/specs/auto-progress.md`
- ブランチ保護ルールの `Require linear history` を `NO` に変更（実態に合わせて修正）
  - develop: 通常マージのため linear history 不要
  - main: squash はマージ時に指定（ブランチ保護で強制しない）
- マージ方式の記述に `git-flow.md` への参照を追加

### `CLAUDE.md`
- Git運用セクションにマージ方式ルールへの参照を1行追加

## 手動作業（未対応）

- **GitHub Settings**: squash merge の有効化が必要（リポジトリ設定 > Merge button > Allow squash merging にチェック）

Closes #321

Generated with [Claude Code](https://claude.ai/code)