### PR TITLE
fix(f2): OgpExtractorのHTTPリクエストにSSRF対策を追加

### DIFF
--- a/src/services/ogp_extractor.py
+++ b/src/services/ogp_extractor.py
@@ -102,7 +102,14 @@ class OgpExtractor:
     async def _fetch_og_image(self, url: str) -> str | None:
         """記事URLにアクセスしてog:imageメタタグを抽出する."""
         async with aiohttp.ClientSession(timeout=self._timeout) as session:
-            async with session.get(url) as resp:
+            async with session.get(url, allow_redirects=False) as resp:
+                if resp.status in (301, 302, 303, 307, 308):
+                    logger.warning(
+                        "Redirect detected (SSRF protection): %s -> %s",
+                        url,
+                        resp.headers.get("Location", "unknown"),
+                    )
+                    return None
                 if resp.status != 200:
                     return None
                 html = await resp.text(errors="replace")


### PR DESCRIPTION
## Change type

- [x] fix: バグ修正

## Summary

- `OgpExtractor._fetch_og_image` メソッドに `allow_redirects=False` を設定し、リダイレクト追従を無効化
- リダイレクト応答（301/302/303/307/308）検出時に warning ログを出して `None` を返すよう変更
- `web_crawler.py` の `crawl_page` メソッドと同じ SSRF 対策パターンを踏襲
- 全5種のリダイレクトステータスコードに対するテスト、ログ出力テスト、`allow_redirects=False` 引数テストを追加

## Test plan

- [x] 全リダイレクトステータスコード（301/302/303/307/308）で `None` が返ることを確認
- [x] リダイレクト検出時に warning ログが出力されることを確認
- [x] `session.get()` に `allow_redirects=False` が渡されることを確認
- [x] 既存テスト（15件全て）がパスすることを確認
- [x] 全テスト（580件）がパスすることを確認
- [x] ruff / mypy チェック通過

## Related issues

Closes #286

Generated with [Claude Code](https://claude.ai/code)