### PR TITLE
fix(ci): 自動実装パイプラインのワークフロー2問題を修正

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -65,9 +65,10 @@ jobs:
       - uses: anthropics/claude-code-action@5994afaaa7f44611addc97a696a135acff5fd218 # v1.0.46
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
-          # REPO_OWNER_PAT を使用: GITHUB_TOKEN で作成されたPRイベントでは
-          # pr-review.yml が再トリガーされないため（GitHub の無限ループ防止仕様）
-          github_token: ${{ secrets.REPO_OWNER_PAT }}
+          # GITHUB_TOKEN を使用: PR作成イベントが pr-review.yml をトリガーしない
+          # （GitHub の無限ループ防止仕様）。auto:pipeline ラベル付与前に
+          # PRKit が走るレースコンディションを根本回避する。
+          github_token: ${{ secrets.GITHUB_TOKEN }}
           bot_name: "claude[bot]"
           bot_id: "209825114"
           claude_args: "--model claude-opus-4-6 --max-turns 100 --dangerously-skip-permissions"

--- a/.github/workflows/copilot-auto-fix.yml
+++ b/.github/workflows/copilot-auto-fix.yml
@@ -195,6 +195,9 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          # Copilot のレビュー完了（pull_request_review[submitted]）でトリガーされるため
+          # github.actor が Copilot になる。デフォルトでは bot はブロックされるため明示許可。
+          allowed_bots: "Copilot"
           bot_name: "claude[bot]"
           bot_id: "209825114"
           claude_args: "--model claude-sonnet-4-5-20250929 --max-turns 100 --dangerously-skip-permissions"


### PR DESCRIPTION
## Change type

- [x] fix: バグ修正

## Summary

- `claude.yml`: `claude-auto-implement` の `github_token` を `REPO_OWNER_PAT` → `GITHUB_TOKEN` に変更。PR作成イベントが `pr-review.yml` をトリガーしなくなり、`auto:pipeline` ラベル付与前に PRKit が走るレースコンディションを根本解消
- `copilot-auto-fix.yml`: `claude-code-action` に `allowed_bots: "Copilot"` を追加。Copilot のレビュー完了でトリガーされた際の「Copilot is not a user」権限チェックエラーを解消

## Test plan

- [ ] 自動実装テスト（`auto-implement` ラベル付与）で PRKit が走らないことを確認
- [ ] Copilot レビュー完了後に `copilot-auto-fix` が正常起動することを確認

## Related issues

Closes #357