### PR TITLE
fix(f2): OgpExtractorのHTTPリクエストにSSRF対策を追加

### DIFF
--- a/src/services/ogp_extractor.py
+++ b/src/services/ogp_extractor.py
@@ -102,7 +102,14 @@ class OgpExtractor:
     async def _fetch_og_image(self, url: str) -> str | None:
         """記事URLにアクセスしてog:imageメタタグを抽出する."""
         async with aiohttp.ClientSession(timeout=self._timeout) as session:
-            async with session.get(url) as resp:
+            async with session.get(url, allow_redirects=False) as resp:
+                if resp.status in (301, 302, 303, 307, 308):
+                    logger.warning(
+                        "Redirect detected (SSRF protection): %s -> %s",
+                        url,
+                        resp.headers.get("Location", "unknown"),
+                    )
+                    return None
                 if resp.status != 200:
                     return None
                 html = await resp.text(errors="replace")

--- a/tests/test_ogp_extractor.py
+++ b/tests/test_ogp_extractor.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import logging
 from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
 
 from src.services.ogp_extractor import OgpExtractor
 
@@ -123,3 +126,51 @@ async def test_ac10_returns_none_on_non_200() -> None:
         result = await extractor.extract_image_url("https://example.com/article")
 
     assert result is None
+
+
+@pytest.mark.parametrize("status_code", [301, 302, 303, 307, 308])
+async def test_ac10_returns_none_on_redirect(status_code: int) -> None:
+    """AC10: リダイレクト応答時はSSRF対策としてNoneを返す."""
+    extractor = OgpExtractor()
+
+    mock_resp = AsyncMock()
+    mock_resp.status = status_code
+    mock_resp.headers = {"Location": "http://internal-server/secret"}
+    mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+    mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+    mock_session = AsyncMock()
+    mock_session.get = MagicMock(return_value=mock_resp)
+    mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session.__aexit__ = AsyncMock(return_value=False)
+
+    with patch("src.services.ogp_extractor.aiohttp.ClientSession", return_value=mock_session):
+        result = await extractor.extract_image_url("https://example.com/article")
+
+    assert result is None
+
+
+async def test_ac10_redirect_logs_warning(caplog: pytest.LogCaptureFixture) -> None:
+    """AC10: リダイレクト検出時にwarningログが出力される."""
+    extractor = OgpExtractor()
+
+    mock_resp = AsyncMock()
+    mock_resp.status = 302
+    mock_resp.headers = {"Location": "http://internal-server/secret"}
+    mock_resp.__aenter__ = AsyncMock(return_value=mock_resp)
+    mock_resp.__aexit__ = AsyncMock(return_value=False)
+
+    mock_session = AsyncMock()
+    mock_session.get = MagicMock(return_value=mock_resp)
+    mock_session.__aenter__ = AsyncMock(return_value=mock_session)
+    mock_session.__aexit__ = AsyncMock(return_value=False)
+
+    with (
+        patch("src.services.ogp_extractor.aiohttp.ClientSession", return_value=mock_session),
+        caplog.at_level(logging.WARNING, logger="src.services.ogp_extractor"),
+    ):
+        result = await extractor.extract_image_url("https://example.com/article")
+
+    assert result is None
+    assert "Redirect detected (SSRF protection)" in caplog.text
+    assert "http://internal-server/secret" in caplog.text


### PR DESCRIPTION
## Change type

- [x] fix: バグ修正

## Summary

- `OgpExtractor._fetch_og_image` メソッドに `allow_redirects=False` を設定し、リダイレクト追従を無効化
- リダイレクト応答（301, 302, 303, 307, 308）検出時は warning ログを出力して `None` を返す
- `web_crawler.py` の `crawl_page` メソッドと同じ SSRF 対策パターンを踏襲し、プロジェクト内の一貫性を確保
- 全5種のリダイレクトステータスコードに対するテストとログ出力テストを追加

## Test plan

- [x] 全リダイレクトステータスコード（301/302/303/307/308）で `None` を返すことを確認
- [x] リダイレクト検出時に warning ログが出力されることを確認
- [x] 既存テスト（OGP抽出、非200応答、失敗時のNone返却）が引き続きパスすることを確認
- [x] 全テストスイート 579 passed、ruff / mypy もクリーン

## Related issues

Closes #286