### PR TITLE
fix(f2): OgpExtractorのHTTPリクエストにSSRF対策を追加

### DIFF
--- a/src/services/ogp_extractor.py
+++ b/src/services/ogp_extractor.py
@@ -102,7 +102,14 @@ class OgpExtractor:
     async def _fetch_og_image(self, url: str) -> str | None:
         """記事URLにアクセスしてog:imageメタタグを抽出する."""
         async with aiohttp.ClientSession(timeout=self._timeout) as session:
-            async with session.get(url) as resp:
+            async with session.get(url, allow_redirects=False) as resp:
+                if resp.status in (301, 302, 303, 307, 308):
+                    logger.warning(
+                        "Redirect detected (SSRF protection): %s -> %s",
+                        url,
+                        resp.headers.get("Location", "unknown"),
+                    )
+                    return None
                 if resp.status != 200:
                     return None
                 html = await resp.text(errors="replace")


### PR DESCRIPTION
## Change type

- [x] fix: バグ修正

## Summary

- `OgpExtractor._fetch_og_image` メソッドに `allow_redirects=False` を設定し、リダイレクト追従を無効化
- リダイレクト応答（301, 302, 303, 307, 308）検出時は warning ログを出力して `None` を返す
- `web_crawler.py` の `crawl_page` メソッドと同じSSRF対策パターンを踏襲
- リダイレクト検出テストを `@pytest.mark.parametrize` で全5ステータスコードをカバー

## Test plan

- [x] pytest: 578 passed, 4 skipped
- [x] ruff: All checks passed
- [x] mypy: Success, no issues found
- [x] 新規テスト `test_ac10_returns_none_on_redirect` が全パラメータで PASSED

## Related issues

Closes #286