### PR TITLE
fix(f5): MCP テストの AsyncMock RuntimeWarning 修正 (#330)

### DIFF
--- a/tests/test_chat_with_tools.py
+++ b/tests/test_chat_with_tools.py
@@ -5,7 +5,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
@@ -91,6 +91,10 @@ def _make_mock_mcp_manager(
 
     mock_manager.get_available_tools = AsyncMock(return_value=tools)
     mock_manager.call_tool = AsyncMock(return_value=call_result)
+    # get_response_instruction は同期メソッドなので MagicMock を使用する
+    # AsyncMock のままだと呼び出し時にコルーチンが生成されるが await されず
+    # RuntimeWarning: coroutine was never awaited が発生する
+    mock_manager.get_response_instruction = MagicMock(return_value="")
     return mock_manager
 
 


### PR DESCRIPTION
## Change type

- [x] fix: バグ修正

## Summary

- `test_chat_with_tools.py` の `_make_mock_mcp_manager` で `get_response_instruction`（同期メソッド）が `AsyncMock` として扱われ、呼び出し時にコルーチンが生成されるが `await` されず `RuntimeWarning: coroutine was never awaited` が13件発生していた問題を修正
- `MagicMock(return_value="")` に明示的に設定し、同期メソッドとして正しくモック化

## Test plan

- [x] `uv run pytest tests/test_chat_with_tools.py -W error::RuntimeWarning` で全10テスト通過（0 warnings）
- [x] `uv run pytest` で全578テスト通過
- [x] `uv run ruff check src/ tests/` 通過
- [x] `uv run mypy src/` 通過
- [x] `npx markdownlint-cli2@0.20.0` 通過

## Related issues

Closes #330