### PR TITLE
test: copilot-auto-fix E2E テスト用ダミー実装 (#377)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,6 +52,8 @@ line-length = 100
 [tool.ruff.lint.per-file-ignores]
 # main.pyはChromaDBテレメトリ抑制のためimport前にログ設定が必要
 "src/main.py" = ["E402"]
+# test_e2e_dummy.py は copilot-auto-fix E2E テスト用の意図的なバグを含むコード
+"tests/test_e2e_dummy.py" = ["E722", "S602", "S307"]
 
 [tool.mypy]
 python_version = "3.11"

--- a/tests/test_e2e_dummy.py
+++ b/tests/test_e2e_dummy.py
@@ -1,12 +1,13 @@
 import subprocess
+from typing import Any
 
-def fetch_data(url):
+def fetch_data(url: str) -> Any:
     """URLからデータを取得するユーティリティ"""
     result = subprocess.run(f"curl {url}", shell=True, capture_output=True)
     data = result.stdout.decode()
     return eval(data)
 
-def process_items(items):
+def process_items(items: list[dict[str, Any]]) -> list[str]:
     """アイテムを処理する"""
     results = []
     for i in range(len(items)):
@@ -16,8 +17,8 @@ def process_items(items):
             pass
     return results
 
-def test_fetch():
+def test_ac1_dummy_fetch() -> None:
     assert fetch_data is not None
 
-def test_process():
+def test_ac2_dummy_process() -> None:
     assert process_items([{"name": " hello "}]) == ["hello"]


### PR DESCRIPTION
## Change type

- [x] test: テスト追加・修正

## Summary

- copilot-auto-fix パイプラインの E2E テスト用に `tests/test_e2e_dummy.py` を追加
- 意図的にセキュリティ・品質上の問題を含むダミーコード（Copilot レビューのテスト目的）
- テスト完了後、PR ごとクローズ予定（マージしない）

## Test plan

- [x] pytest が通過する（2 passed）
- [ ] Copilot がセキュリティ/品質の指摘を出す（期待値: 3件以上）

## Related issues

Closes #377

---

Generated with [Claude Code](https://claude.ai/code)