### PR TITLE
feat: shellcheck 前の CRLF → LF 自動変換 (#384)

### DIFF
--- a/.claude/skills/test-run/SKILL.md
+++ b/.claude/skills/test-run/SKILL.md
@@ -111,7 +111,7 @@ diff モードでは変更された Markdown ファイルのみを対象にす�
 # CRLF → LF 自動変換（shellcheck SC1017 防止）
 for f in .github/scripts/auto-fix/*.sh .github/scripts/post-merge/*.sh; do
   [ -f "$f" ] || continue
-  if grep -Plq '\r\n' "$f" 2>/dev/null; then
+  if grep -q $'\r' "$f" 2>/dev/null; then
     tmp=$(mktemp) && tr -d '\r' < "$f" > "$tmp" && mv "$tmp" "$f"
     echo "[fix] CRLF→LF: $f"
   fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -258,7 +258,7 @@ GitHub Actions 環境では Skill ツールを使用しない。以下の4ステ
 
 ```bash
 # CRLF → LF 自動変換（Windows 環境の shellcheck SC1017 防止）
-for f in .github/scripts/auto-fix/*.sh .github/scripts/post-merge/*.sh; do [ -f "$f" ] || continue; if grep -Plq '\r\n' "$f" 2>/dev/null; then tmp=$(mktemp) && tr -d '\r' < "$f" > "$tmp" && mv "$tmp" "$f" && echo "[fix] CRLF→LF: $f"; fi; done
+for f in .github/scripts/auto-fix/*.sh .github/scripts/post-merge/*.sh; do [ -f "$f" ] || continue; if grep -q $'\r' "$f" 2>/dev/null; then tmp=$(mktemp) && tr -d '\r' < "$f" > "$tmp" && mv "$tmp" "$f" && echo "[fix] CRLF→LF: $f"; fi; done
 
 uv run pytest && uv run ruff check src/ tests/ && uv run mypy src/ && npx markdownlint-cli2@0.20.0 "CLAUDE.md" "docs/**/*.md" "*.md" ".claude/**/*.md" && uv run shellcheck .github/scripts/auto-fix/*.sh .github/scripts/post-merge/*.sh
 ```


### PR DESCRIPTION
## Change type

- [x] feat: 新機能実装
- [x] docs: ドキュメント更新

## Summary

- test-run スキルの shellcheck ステップ（ステップ7）に、CRLF → LF 自動変換を追加
  - `grep -Plq '\r\n'` で CRLF を検出し、`tr -d '\r'` で変換
  - 変換時は `[fix] CRLF→LF: ファイル名` をログ出力（暗黙的な変更を防止）
- CLAUDE.md の GA環境テスト実行ステップにも同様の自動変換を追加
- CLAUDE.md の Windows 注意点セクションに自動変換の説明を追記

### 背景

Windows 環境で Write ツールが `.sh` ファイルを CRLF で書き出し、shellcheck SC1017 エラーになる問題が繰り返し発生していた（直近: PR #382）。`.gitattributes` で `*.sh text eol=lf` は設定済みだが、`git add` 前の作業ツリーには効かない。

### 設計判断

暗黙的な PostToolUse hook 方式ではなく、shellcheck 実行直前の明示的な自動変換を採用。テスト実行の一環として見える場所で実行されるため、存在を忘れた場合のデバッグ困難を回避。

## Test plan

- [x] markdownlint: CLAUDE.md, SKILL.md エラーなし
- [x] pytest: 578 passed, 4 skipped
- [x] ruff / mypy: エラーなし
- [x] shellcheck: エラーなし（SC1091 info のみ）

## Related issues

Closes #384