### PR TITLE
fix: 禁止パターンから CLAUDE.md と settings.json を削除

### DIFF
--- a/.github/scripts/auto-fix/check-forbidden.sh
+++ b/.github/scripts/auto-fix/check-forbidden.sh
@@ -51,7 +51,7 @@ while IFS= read -r file; do
     continue
   fi
 
-  # .github/workflows/* は develop 向き緩和で対象外
+  # .github/workflows/* はチェック対象外（パイプラインが develop 向け PR のみ処理するため）
 
 done <<< "$CHANGED_FILES"
 

--- a/docs/specs/auto-progress.md
+++ b/docs/specs/auto-progress.md
@@ -467,15 +467,12 @@ Copilot レビュー指摘検出 → claude-code-action が /check-pr で修正 
 
 以下のファイルが変更に含まれるPRは `auto:failed` ラベルを付与し、自動マージしない:
 
-| パターン | 理由 | develop 向き緩和 |
-|---------|------|-----------------|
-| `.github/workflows/*` | CI/CD設定の変更 | 可（develop へのマージは許可） |
-| `.env*` | 環境変数・シークレット | 不可（常に禁止） |
-| `pyproject.toml` の dependencies | 依存パッケージ変更 | 不可（常に禁止） |
+| パターン | 理由 |
+|---------|------|
+| `.env*` | 環境変数・シークレット |
+| `pyproject.toml` の dependencies | 依存パッケージ変更 |
 
-**develop 向き緩和の理由**: `.github/workflows/*` の変更は develop にマージしても即座にプロダクションに影響しない。リリースPR（develop → main）時に管理者が確認できるため、develop への自動マージは許可する。ただし main への直接自動マージは引き続き禁止。
-
-**注記**: リリースPR（develop → main）は管理者が手動で作成・マージするため、copilot-auto-fix.yml / auto-fix.yml の処理対象外。ワークフロー変更を含む場合でも、リリースPRでの人間レビューが安全弁として機能する。
+**注記**: `.github/workflows/*` は禁止パターンに含まない。自動マージパイプライン（`copilot-auto-fix.yml`）は `auto/` ブランチの develop 向け PR のみを処理するため、ワークフロー変更が main に直接自動マージされることはない。main への反映はリリースPR（develop → main）で管理者が手動レビュー・マージする。
 
 **第3層: `auto:failed` ラベル（緊急停止ボタン兼用）**
 


### PR DESCRIPTION
## Change type

- [x] fix: バグ修正

## Summary

- auto-implement パイプラインの禁止パターンから `CLAUDE.md` と `.claude/settings.json` を削除
- CLAUDE.md を含む変更でも自動パイプライン（Copilot レビュー → auto-fix → auto-merge）が完走可能に
- `.env*` と `pyproject.toml` (dependencies) は引き続き禁止

### 背景

- CLAUDE.md はスキル追加・ルール変更など多くの作業で更新が必要だが、禁止パターンにより auto-implement の大半が途中停止していた（PR #392 の例）
- リポジトリ private 化（2026-02-15）によりセキュリティリスクが低減
- `.claude/settings.json` は GA 環境では使われず、変更される場面も想定しにくい

## Test plan

- [x] shellcheck 通過
- [x] markdownlint 通過
- [x] code-reviewer: Critical/Warning 0件
- [x] doc-reviewer: Critical/Warning 0件
- [ ] 次回の auto-implement E2E テストで CLAUDE.md 含む PR が完走することを確認

## Related issues

Closes #394