### PR TITLE
fix: copilot-auto-fix に checks:read 権限を追加

### DIFF
--- a/.github/workflows/copilot-auto-fix.yml
+++ b/.github/workflows/copilot-auto-fix.yml
@@ -23,6 +23,7 @@ permissions:
   contents: write
   pull-requests: write
   issues: write
+  checks: read
   id-token: write
 
 on:


### PR DESCRIPTION
## Change type

- [x] fix: バグ修正

## Summary

- `copilot-auto-fix.yml` の `permissions` に `checks: read` を追加
- private リポジトリでは `GITHUB_TOKEN` のデフォルト権限で `statusCheckRollup` にアクセスできないため、明示的な宣言が必要
- CI 待機ポーリング（`gh pr checks`）と マージ判定（`merge-check.sh` の `statusCheckRollup`）の両方に影響

## Test plan

- [x] YAML 構文チェック通過
- [ ] 次回の auto-implement E2E テストで CI 待機 + マージ判定が正常動作することを確認

## Related issues

Closes #398