### PR TITLE
docs: マージ方式ルールの統一・明文化 (#321)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,6 +110,7 @@
 - コミット: `feat(f{N}): 説明 (#{Issue番号})`
 - PR作成時に `Closes #{Issue番号}` で紐付け
 - **PRのbaseブランチ**: 通常は `develop`、hotfix は `main`
+- **マージ方式**: feature/bugfix → develop は通常マージ（`--merge`）、develop → main は squash マージ（`--squash`）。詳細は `docs/specs/git-flow.md` の「マージ方式」セクション参照
 - GitHub Milestones で Step 単位の進捗管理
 - `gh` コマンドで Issue/PR を操作
 

--- a/docs/specs/auto-progress.md
+++ b/docs/specs/auto-progress.md
@@ -48,7 +48,7 @@ IssueからPRマージまでの全工程を自動化するパイプライン。�
 | Require a pull request before merging | YES | 直 push 禁止 |
 | Require status checks to pass | YES | CI 必須（pytest, mypy, ruff, markdownlint） |
 | Require approvals | NO | 自動マージを許可するため |
-| Require linear history | YES | squash merge で履歴を綺麗に |
+| Require linear history | NO | 通常マージで開発履歴を保持（マージ方式は `git-flow.md` の「マージ方式」セクション参照） |
 | Include administrators | NO | 管理者は緊急時にバイパス可能 |
 | Allow auto-merge | YES | 自動マージを許可 |
 
@@ -59,7 +59,7 @@ IssueからPRマージまでの全工程を自動化するパイプライン。�
 | Require a pull request before merging | YES | 直 push 禁止 |
 | Require status checks to pass | YES | CI 必須 |
 | Require approvals | YES (1名) | 管理者の承認必須 |
-| Require linear history | YES | squash merge で履歴を綺麗に |
+| Require linear history | NO | squash マージで履歴はリリース単位にまとまる（マージ方式は `git-flow.md` の「マージ方式」セクション参照） |
 | Include administrators | YES | 管理者も保護対象 |
 | Allow auto-merge | NO | 手動マージのみ |
 
@@ -612,7 +612,7 @@ flowchart TD
 | コンフリクトなし | `gh pr view --json mergeable` が `MERGEABLE` |
 | `auto:failed` なし | PRのラベルに `auto:failed` が含まれない |
 
-マージ方式: `gh pr merge --merge`（通常マージ）
+マージ方式: `gh pr merge --merge`（通常マージ）。マージ方式の統一ルールは `docs/specs/git-flow.md` の「マージ方式」セクションを参照。
 マージ先: `develop` ブランチ（main への直接マージは禁止）
 
 ## 失敗時の振る舞い

--- a/docs/specs/git-flow.md
+++ b/docs/specs/git-flow.md
@@ -102,7 +102,7 @@ sequenceDiagram
 ```
 
 - リリース日は設けず、ある程度機能がまとまったタイミングで `develop` → `main` にPR作成
-- マージ方法: **Create a merge commit**（履歴を保持）
+- マージ方法: **Squash and merge**（リリース単位で1コミットにまとめる。詳細は「マージ方式」セクション参照）
 - マージ判断は開発者が行う
 
 ### hotfix（緊急修正）
@@ -125,6 +125,16 @@ sequenceDiagram
 2. 修正・コミット
 3. `main` に向けてPR作成・マージ
 4. `main` の変更を `develop` にもマージ（`git merge main` または PR）
+
+## マージ方式
+
+| マージ先 | 方式 | コマンド | 理由 |
+|---------|------|---------|------|
+| feature/bugfix → develop | 通常マージ | `gh pr merge --merge` | 開発履歴を保持 |
+| develop → main（リリース） | squash マージ | `gh pr merge --squash` | リリース単位で1コミットにまとめ、main の履歴をきれいに保つ |
+| hotfix → main | 通常マージ | `gh pr merge --merge` | 緊急修正の履歴を保持 |
+
+**注意**: GitHub リポジトリ設定で squash merge を有効化する必要がある（Settings > General > Pull Requests > Allow squash merging）。
 
 ## コミットメッセージ規約
 


### PR DESCRIPTION
## Change type

- [x] docs: ドキュメント変更

## Summary

- `docs/specs/git-flow.md` にマージ方式ルールのセクションを追加（feature/bugfix→develop: 通常マージ、develop→main: squash マージ、hotfix→main: 通常マージ）
- `docs/specs/auto-progress.md` のブランチ保護ルール記述を実態に合わせて修正（`Require linear history: YES → NO`。squash merge がリポジトリ設定で無効であるため）
- `docs/specs/auto-progress.md` のマージ方式記述を `git-flow.md` への参照に統一
- `CLAUDE.md` の Git 運用セクションにマージ方式ルールへの参照を追加
- **注意**: GitHub Settings で squash merge を有効化する手動作業が別途必要

## Test plan

- [x] markdownlint 通過
- [ ] ドキュメント間のマージ方式記述が一貫していることを確認

## Related issues

Closes #321

Generated with [Claude Code](https://claude.ai/code)