### PR TITLE
fix: copilot-auto-fix に actions:read 権限を追加

### DIFF
--- a/.github/workflows/copilot-auto-fix.yml
+++ b/.github/workflows/copilot-auto-fix.yml
@@ -24,6 +24,7 @@ permissions:
   pull-requests: write
   issues: write
   checks: read
+  actions: read
   id-token: write
 
 on:


### PR DESCRIPTION
## Change type

- [x] fix: バグ修正

## Summary

- `copilot-auto-fix.yml` の `permissions` に `actions: read` を追加
- private リポジトリでは `checkSuite.workflowRun` へのアクセスに `actions: read` が必要
- 前回の `checks: read` 追加（PR #399）で `statusCheckRollup` 自体は読めるようになったが、その中の `workflowRun` フィールドは Actions API の領域

### エラーメッセージ（修正前）

```
Warning: Failed to get PR checks: GraphQL: Resource not accessible by integration
(node.statusCheckRollup.nodes.0.commit.statusCheckRollup.contexts.nodes.0.checkSuite.workflowRun)
```

### 参考

- [gh pr view fails with fine-grained PAT on private repos (cli/cli#12597)](https://github.com/cli/cli/issues/12597)

## Test plan

- [x] YAML 構文確認
- [ ] 次回の auto-implement E2E テストで CI 待機が正常動作することを確認

## Related issues

Closes #398