### PR TITLE
fix: CI待機ステップの削除と仕様書修正 (#407)

### DIFF
--- a/.github/workflows/copilot-auto-fix.yml
+++ b/.github/workflows/copilot-auto-fix.yml
@@ -357,88 +357,15 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           GH_REPO: ${{ github.repository }}
 
-      # --- CI 完了待機（全パスで実行）---
-      # PR 作成直後にワークフローが起動するため、CI がまだ実行中の可能性がある
-
-      - name: Wait for CI
-        if: |
-          steps.preconditions.outputs.skip != 'true'
-          && steps.copilot-wait.outputs.copilot_reviewed == 'true'
-          && steps.forbidden-check.outputs.forbidden != 'true'
-          && (
-            steps.review-result.outputs.has_issues != 'true'
-            || (steps.review-result.outputs.has_issues == 'true' && steps.recount.outputs.has_issues != 'true')
-          )
-        id: ci-wait
-        run: |
-          set -euo pipefail
-          PR_NUMBER="${{ steps.pr-info.outputs.number }}"
-          TIMEOUT=600  # 10 minutes
-          INTERVAL=30
-          ELAPSED=0
-
-          echo "Waiting for CI checks to complete (timeout: ${TIMEOUT}s)..."
-
-          # CI が新しい push を認識するまでの初期待機（タイムアウトには含めない）
-          sleep 15
-
-          while [ "$ELAPSED" -lt "$TIMEOUT" ]; do
-            # 自分自身（copilot-auto-fix）以外の pending チェックをカウント
-            if PENDING=$(gh pr checks "$PR_NUMBER" --json name,bucket --jq '
-              [.[] |
-               select((.name | contains("copilot-auto-fix")) | not) |
-               select(.bucket == "pending")
-              ] | length
-            ' 2>&1); then
-              if [ "$PENDING" -eq 0 ]; then
-                echo "All CI checks completed."
-                echo "timeout=false" >> "$GITHUB_OUTPUT"
-                exit 0
-              fi
-              echo "CI checks still running ($PENDING pending). Waiting ${INTERVAL}s... (${ELAPSED}s/${TIMEOUT}s)"
-            else
-              echo "::warning::Failed to get PR checks: $PENDING. Retrying..."
-            fi
-
-            sleep "$INTERVAL"
-            ELAPSED=$((ELAPSED + INTERVAL))
-          done
-
-          echo "::warning::CI wait timed out after ${TIMEOUT}s"
-          echo "timeout=true" >> "$GITHUB_OUTPUT"
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GH_REPO: ${{ github.repository }}
-
-      - name: Handle CI timeout
-        if: steps.ci-wait.outputs.timeout == 'true'
-        run: |
-          source "$GITHUB_WORKSPACE/.github/scripts/auto-fix/_common.sh"
-          PR_NUMBER="${{ steps.pr-info.outputs.number }}"
-
-          gh_safe gh issue edit "$PR_NUMBER" --add-label "auto:failed"
-          gh_comment "$PR_NUMBER" "## copilot-auto-fix: CI タイムアウト
-
-          CI チェックが10分以内に完了しませんでした。
-          \`auto:failed\` ラベルを付与して自動処理を停止します。
-
-          **次のアクション**: CI の状態を確認し、問題を解消してください。
-          対応完了後、\`auto:failed\` を除去し、Actions タブから「Copilot Auto Fix」の Run workflow で PR 番号を指定して再実行してください。
-
-          [Actions ログ](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
-        env:
-          GH_TOKEN: ${{ github.token }}
-          GH_REPO: ${{ github.repository }}
-
       # --- マージ判定 ---
-      # 条件: (Copilot検知済み) AND (禁止パターンなし) AND (CI通過) AND (指摘なし OR 修正完了)
+      # 条件: (Copilot検知済み) AND (禁止パターンなし) AND (指摘なし OR 修正完了)
+      # 品質チェック（pytest/ruff/mypy/markdownlint）はエージェント内テストで担保済み（外部CIワークフロー不使用）
 
       - name: Merge check
         if: |
           steps.preconditions.outputs.skip != 'true'
           && steps.copilot-wait.outputs.copilot_reviewed == 'true'
           && steps.forbidden-check.outputs.forbidden != 'true'
-          && steps.ci-wait.outputs.timeout != 'true'
           && (
             steps.review-result.outputs.has_issues != 'true'
             || steps.recount.outputs.has_issues != 'true'


### PR DESCRIPTION
## Change type

- [x] fix: バグ修正

## Summary

- copilot-auto-fix.yml の CI wait ステップ（`gh pr checks` ポーリング）と Handle CI timeout ステップを削除
- copilot-auto-fix.md: CI完了待機セクション（旧§6）削除、分岐処理のフロー順序を「修正→テスト→commit→resolve→マージ判定」に修正、AC番号リナンバリング
- auto-progress.md: ブランチ保護ルール・マージ前5条件・概要フロー・Resolve タイミング・受け入れ条件（AC8, AC10.1, AC11, AC17）から外部CI依存を削除
- 品質チェック（pytest/ruff/mypy/markdownlint）はエージェント内テストで担保する設計に統一

### 背景

本プロジェクトでは外部CIワークフロー（pytest/ruff/mypy を実行する GitHub Actions ワークフロー）を使用していない。品質チェックは claude-code-action 内のエージェントが実行する。CI wait ステップが存在しない外部CIを `gh pr checks` で待ち続け、「no checks reported」で永久リトライ→タイムアウト→`auto:failed` になる問題が発生していた。

### 修正不要の確認

- `merge-check.sh`: `statusCheckRollup` を使用し、チェック未設定時は `no_checks` → 自動PASS する設計のため修正不要
- `git-flow.md`: 手段を特定しない一般ルール（「CIチェック必須」）のため修正不要

## Test plan

- [ ] markdownlint 通過確認済み
- [ ] auto-implement の E2E テストで CI wait でスタックしないことを確認

## Related issues

Closes #407