### PR TITLE
docs: README.md のエージェントチーム仕様書リンク切れ修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ uv run mypy src
 
 - [Claude Code Hooks](docs/specs/claude-code-hooks.md)
 - [Claude Code Actions](docs/specs/claude-code-actions.md)
-- [エージェントチーム](docs/specs/agent-teams.md)
+- エージェントチーム: [共通仕様](docs/specs/agent-teams/common.md) / [fixed-theme](docs/specs/agent-teams/fixed-theme.md) / [mixed-genius](docs/specs/agent-teams/mixed-genius.md)
 - [Planner サブエージェント](docs/specs/planner-agent.md)
 - [Doc Reviewer サブエージェント](docs/specs/doc-review-agent.md)
 - [Test Runner サブエージェント](docs/specs/test-runner-agent.md)


### PR DESCRIPTION
## Change type

- [x] docs: ドキュメントのみの変更

## Summary

- README.md L175 の `docs/specs/agent-teams.md` へのリンクが存在しないファイルを参照していたため修正
- 実際のファイル構成（`docs/specs/agent-teams/` 配下の3ファイル）に合わせて個別リンクに変更:
  - `docs/specs/agent-teams/common.md`（共通仕様）
  - `docs/specs/agent-teams/fixed-theme.md`（fixed-theme パターン）
  - `docs/specs/agent-teams/mixed-genius.md`（mixed-genius パターン）

## Test plan

- [x] markdownlint 通過確認
- [ ] リンク先ファイルの存在確認

## Related issues

Closes #424