### PR TITLE
refactor: LM Studio ベースURL のハードコード重複を解消 (#426)

### DIFF
--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -12,6 +12,9 @@ import yaml
 from pydantic import Field, model_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+# LM Studio のデフォルトベースURL（Single Source of Truth）
+DEFAULT_LMSTUDIO_BASE_URL = "http://localhost:1234/v1"
+
 
 class Settings(BaseSettings):
     """環境変数から読み込むアプリケーション設定."""
@@ -53,7 +56,7 @@ class Settings(BaseSettings):
     anthropic_model: str = "claude-3-5-sonnet-20241022"
 
     # LM Studio (ローカルLLM)
-    lmstudio_base_url: str = "http://localhost:1234/v1"
+    lmstudio_base_url: str = DEFAULT_LMSTUDIO_BASE_URL
     lmstudio_model: str = "local-model"
 
     # Scheduler

--- a/src/embedding/lmstudio_embedding.py
+++ b/src/embedding/lmstudio_embedding.py
@@ -8,6 +8,7 @@ import logging
 
 from openai import AsyncOpenAI
 
+from src.config.settings import DEFAULT_LMSTUDIO_BASE_URL
 from src.embedding.base import EmbeddingProvider
 
 logger = logging.getLogger(__name__)
@@ -21,7 +22,7 @@ class LMStudioEmbedding(EmbeddingProvider):
 
     def __init__(
         self,
-        base_url: str = "http://localhost:1234/v1",
+        base_url: str = DEFAULT_LMSTUDIO_BASE_URL,
         model: str = "nomic-embed-text",
     ) -> None:
         self._client = AsyncOpenAI(base_url=base_url, api_key="lm-studio")

--- a/src/llm/lmstudio_provider.py
+++ b/src/llm/lmstudio_provider.py
@@ -23,6 +23,7 @@ from openai.types.chat.chat_completion_message_tool_call_param import (
     Function,
 )
 
+from src.config.settings import DEFAULT_LMSTUDIO_BASE_URL
 from src.llm.base import LLMProvider, LLMResponse, Message, ToolCall, ToolDefinition
 
 logger = logging.getLogger(__name__)
@@ -73,7 +74,7 @@ def _tool_def_to_openai(td: ToolDefinition) -> ChatCompletionToolParam:
 class LMStudioProvider(LLMProvider):
     """LM Studio (OpenAI互換API) を使用するローカルLLMプロバイダー."""
 
-    def __init__(self, base_url: str = "http://localhost:1234/v1", model: str = "local-model") -> None:
+    def __init__(self, base_url: str = DEFAULT_LMSTUDIO_BASE_URL, model: str = "local-model") -> None:
         self._client = AsyncOpenAI(base_url=base_url, api_key="lm-studio")
         self._model = model
 

--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -9,7 +9,7 @@ from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from src.config.settings import Settings
+from src.config.settings import DEFAULT_LMSTUDIO_BASE_URL, Settings
 from src.embedding.base import EmbeddingProvider
 from src.embedding.factory import get_embedding_provider
 from src.embedding.lmstudio_embedding import LMStudioEmbedding
@@ -40,7 +40,7 @@ def test_ac1_openai_is_subclass() -> None:
 async def test_ac2_lmstudio_embedding_converts_text() -> None:
     """AC2: LMStudioEmbedding が LM Studio 経由でテキストをベクトルに変換できること."""
     provider = LMStudioEmbedding(
-        base_url="http://localhost:1234/v1",
+        base_url=DEFAULT_LMSTUDIO_BASE_URL,
         model="nomic-embed-text",
     )
 

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import pytest
 
-from src.config.settings import Settings
+from src.config.settings import DEFAULT_LMSTUDIO_BASE_URL, Settings
 from src.llm.base import LLMProvider
 from src.llm.factory import create_local_provider, create_online_provider, get_provider_for_service
 from src.llm.lmstudio_provider import LMStudioProvider
@@ -32,7 +32,7 @@ def test_ac2_three_providers_exist() -> None:
 
 def test_ac3_lmstudio_uses_openai_sdk() -> None:
     """AC3: LM StudioはOpenAI SDKでbase_url変更で対応."""
-    provider = LMStudioProvider(base_url="http://localhost:1234/v1")
+    provider = LMStudioProvider(base_url=DEFAULT_LMSTUDIO_BASE_URL)
     assert provider._client.base_url.host == "localhost"
 
 
@@ -239,7 +239,7 @@ async def test_ac11_lmstudio_complete_with_tools() -> None:
     from src.llm.base import Message, ToolDefinition
     from src.llm.lmstudio_provider import LMStudioProvider
 
-    provider = LMStudioProvider(base_url="http://localhost:1234/v1")
+    provider = LMStudioProvider(base_url=DEFAULT_LMSTUDIO_BASE_URL)
 
     # OpenAI互換APIのモックレスポンス（ツール呼び出しあり）
     mock_tool_call = MagicMock()
@@ -285,7 +285,7 @@ async def test_ac11_lmstudio_complete_with_tools_no_tool_call() -> None:
     from src.llm.base import Message, ToolDefinition
     from src.llm.lmstudio_provider import LMStudioProvider
 
-    provider = LMStudioProvider(base_url="http://localhost:1234/v1")
+    provider = LMStudioProvider(base_url=DEFAULT_LMSTUDIO_BASE_URL)
 
     # ツール呼び出しなしのモックレスポンス
     mock_choice = MagicMock()


### PR DESCRIPTION
## Change type

- [x] refactor: リファクタリング

## Summary

- `settings.py` に `DEFAULT_LMSTUDIO_BASE_URL` 定数を定義（Single Source of Truth）
- `lmstudio_provider.py` のコンストラクタデフォルト値を定数に置換
- `lmstudio_embedding.py` のコンストラクタデフォルト値を定数に置換
- テストファイルのハードコード文字列も定数に統一

## Test plan

- [x] pytest 584 passed
- [x] ruff check passed
- [x] mypy strict passed
- [x] markdownlint passed

## Related issues

Closes #426