### PR TITLE
fix: echo -e を printf に置換（ポータビリティ改善）

### DIFF
--- a/.github/scripts/auto-fix/check-forbidden.sh
+++ b/.github/scripts/auto-fix/check-forbidden.sh
@@ -57,7 +57,7 @@ done <<< "$CHANGED_FILES"
 
 if [ -n "$FORBIDDEN_FOUND" ]; then
   echo "forbidden=true" >> "$GITHUB_OUTPUT"
-  FORBIDDEN_LIST=$(echo -e "$FORBIDDEN_FOUND" | head -c 1000)
+  FORBIDDEN_LIST=$(printf '%b' "$FORBIDDEN_FOUND" | head -c 1000)
   {
     echo "forbidden_files<<EOF"
     echo "$FORBIDDEN_LIST"

--- a/.github/scripts/auto-fix/merge-check.sh
+++ b/.github/scripts/auto-fix/merge-check.sh
@@ -109,7 +109,7 @@ else
   echo "Merge conditions not met"
   {
     echo "reasons<<EOF"
-    echo -e "$REASONS"
+    printf '%b\n' "$REASONS"
     echo "EOF"
   } >> "$GITHUB_OUTPUT"
 fi


### PR DESCRIPTION
## Change type

- [x] fix: バグ修正

## Summary

- `echo -e` は POSIX 非準拠で dash 等のシェルでは `-e` がそのまま出力されるため、`printf '%b'` に置換
- `check-forbidden.sh`: `echo -e "$FORBIDDEN_FOUND"` → `printf '%b' "$FORBIDDEN_FOUND"`
- `merge-check.sh`: `echo -e "$REASONS"` → `printf '%b\n' "$REASONS"`

## Test plan

- [ ] shellcheck でエラーがないことを確認（SC1091 info のみ）
- [ ] CI が通過すること

## Related issues

Closes #428