### PR TITLE
fix(ci): レビューIssueのファイル一覧をリスト形式に変更

### DIFF
--- a/.github/scripts/post-merge/update-review-issue.sh
+++ b/.github/scripts/post-merge/update-review-issue.sh
@@ -31,26 +31,24 @@ fi
 # 今日の日付（失敗時はフォールバック）
 DATE=$(date -u +"%Y-%m-%d") || DATE="unknown-date"
 
-# ファイル一覧を整形（バッククォート付きカンマ区切り）
+# ファイル一覧を整形（リスト形式）
 FILE_LIST=""
 while IFS= read -r file; do
   if [ -n "$file" ]; then
-    if [ -n "$FILE_LIST" ]; then
-      FILE_LIST="${FILE_LIST}, \`${file}\`"
-    else
-      FILE_LIST="\`${file}\`"
-    fi
+    FILE_LIST="${FILE_LIST}
+- \`${file}\`"
   fi
 done <<< "$CHANGED_FILES"
 
 if [ -z "$FILE_LIST" ]; then
-  FILE_LIST="(取得失敗)"
+  FILE_LIST="
+- (取得失敗)"
 fi
 
 # コメントとして追記するセクション
 COMMENT_BODY="## PR #${PR_NUMBER}: ${PR_TITLE} (${DATE})
 
-- 変更: ${FILE_LIST}"
+### 変更ファイル${FILE_LIST}"
 
 # --- 既存 review-batch Issue を検索 ---
 EXISTING_ISSUE=""

--- a/docs/specs/auto-progress.md
+++ b/docs/specs/auto-progress.md
@@ -569,7 +569,9 @@ auto:review-batch ラベルの Open Issue を検索
 ```markdown
 ## PR #123: フィード追加機能の改善 (2026-02-12)
 
-- 変更: `src/services/feed.py`, `src/utils/parser.py`
+### 変更ファイル
+- `src/services/feed.py`
+- `src/utils/parser.py`
 ```
 
 **Issueの管理ルール:**


### PR DESCRIPTION
## Change type

- [x] fix: バグ修正

## Summary

- 自動マージレビューIssueのファイル一覧表示をカンマ区切りからリスト形式に変更
- `update-review-issue.sh` のファイル一覧フォーマットを修正
- 仕様書 `docs/specs/auto-progress.md` のコメントフォーマット例を更新

### Before

```
- 変更: `CLAUDE.md`, `docs/specs/git-flow.md`, `docs/specs/overview.md`
```

### After

```
### 変更ファイル
- `CLAUDE.md`
- `docs/specs/git-flow.md`
- `docs/specs/overview.md`
```

## Test plan

- [ ] shellcheck 通過確認済み
- [ ] markdownlint 通過確認済み
- [ ] 自動マージ後にレビューIssueへのコメントがリスト形式で投稿されることを確認

## Related issues

Closes #410