### PR TITLE
chore: .tmp/ を .gitignore に追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,5 +47,8 @@ bot.pid
 htmlcov/
 .coverage
 
+# Temporary files
+.tmp/
+
 # Zenn drafts (personal, not for repository)
 docs/zenn-drafts/


### PR DESCRIPTION
## Change type

- [x] chore: ビルド・設定の変更

## Summary

- `.tmp/` ディレクトリを `.gitignore` に追加
- Bluesky API 実証実験（#441）の一時データ保存先として使用

## Test plan

- [x] `.tmp/` 配下のファイルが `git status` に表示されないことを確認

## Related issues

Ref becky3/rag-knowledge#48