### PR TITLE
fix(ci): 禁止パターン検出時もauto-fixを続行しマージのみブロック (#439)

### DIFF
--- a/.github/scripts/auto-fix/merge-check.sh
+++ b/.github/scripts/auto-fix/merge-check.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Merge check — マージ条件5項目（PR状態・レビュー・CI・コンフリクト・ラベル）のチェック
+# Merge check — マージ条件6項目（PR状態・レビュー・CI・コンフリクト・ラベル・禁止パターン）のチェック
 #
 # 入力（環境変数）:
 #   PR_NUMBER       — 対象PR番号
@@ -7,6 +7,7 @@
 #   GH_TOKEN        — GitHub トークン（env経由で gh CLI が自動参照）
 #   GH_REPO         — 対象リポジトリ（owner/repo）
 #   EXCLUDE_CHECK   — （任意）CI チェック除外名。自ワークフローの自己参照防止用
+#   FORBIDDEN_DETECTED — （任意）禁止パターン検出結果。"true" の場合マージ拒否
 #
 # 出力（$GITHUB_OUTPUT）:
 #   merge_ready     — "true" / "false"
@@ -99,6 +100,15 @@ elif echo "$LABELS" | grep -q "^auto:failed$"; then
   echo "❌ Condition 5: auto:failed label found"
 else
   echo "✅ Condition 5: No auto:failed label"
+fi
+
+# 条件6: 禁止パターンなし（auto-fix は続行させるが、マージのみブロック）
+if [ "${FORBIDDEN_DETECTED:-}" = "true" ]; then
+  MERGE_READY=false
+  REASONS="${REASONS}\n- ❌ Forbidden patterns detected (manual merge required)"
+  echo "❌ Condition 6: Forbidden patterns detected"
+else
+  echo "✅ Condition 6: No forbidden patterns"
 fi
 
 echo "merge_ready=$MERGE_READY" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/copilot-auto-fix.yml
+++ b/.github/workflows/copilot-auto-fix.yml
@@ -14,7 +14,7 @@
 # エラーハンドリング方針:
 #   認証/権限エラー        → exit 1（即停止）
 #   一時的API障害          → warning で続行 or 安全側に倒す
-#   セキュリティ必須処理の失敗 → exit 1（禁止パターンチェック等）
+#   セキュリティ必須処理の失敗 → exit 1（禁止パターンチェックのスクリプト実行不能時等）
 #   エラーハンドラ内の失敗  → ベストエフォート（ログのみ）
 
 name: Copilot Auto Fix
@@ -210,18 +210,15 @@ jobs:
           source "$GITHUB_WORKSPACE/.github/scripts/auto-fix/_common.sh"
           PR_NUMBER="${{ steps.pr-info.outputs.number }}"
 
-          gh_safe gh issue edit "$PR_NUMBER" --add-label "auto:failed"
-          gh_comment "$PR_NUMBER" "## copilot-auto-fix: 禁止パターン検出
+          gh_comment "$PR_NUMBER" "## copilot-auto-fix: 禁止パターン検出（自動修正は続行）
 
-          以下のファイルが変更に含まれているため、自動マージを停止します:
+          以下のファイルが変更に含まれているため、**自動マージは行いません**:
 
           \`\`\`
           ${{ steps.forbidden-check.outputs.forbidden_files }}
           \`\`\`
 
-          これらのファイルは自動マージの対象外です（セキュリティ・安定性のため）。
-
-          **次のアクション**: 管理者が手動でレビュー・マージしてください。
+          レビュー指摘の自動修正は続行します。修正完了後、管理者が手動でレビュー・マージしてください。
 
           [Actions ログ](${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})"
         env:
@@ -230,7 +227,7 @@ jobs:
 
       # --- unresolved threads カウント ---
       - name: Check review result
-        if: steps.preconditions.outputs.skip != 'true' && steps.copilot-wait.outputs.copilot_reviewed == 'true' && steps.forbidden-check.outputs.forbidden != 'true'
+        if: steps.preconditions.outputs.skip != 'true' && steps.copilot-wait.outputs.copilot_reviewed == 'true'
         id: review-result
         run: bash "$GITHUB_WORKSPACE/.github/scripts/auto-fix/check-review-result.sh"
         env:
@@ -242,7 +239,7 @@ jobs:
       # --- 自動修正パス（unresolved > 0）---
 
       - name: Post fix notification
-        if: steps.preconditions.outputs.skip != 'true' && steps.copilot-wait.outputs.copilot_reviewed == 'true' && steps.forbidden-check.outputs.forbidden != 'true' && steps.review-result.outputs.has_issues == 'true'
+        if: steps.preconditions.outputs.skip != 'true' && steps.copilot-wait.outputs.copilot_reviewed == 'true' && steps.review-result.outputs.has_issues == 'true'
         run: |
           source "$GITHUB_WORKSPACE/.github/scripts/auto-fix/_common.sh"
           PR_NUMBER="${{ steps.pr-info.outputs.number }}"
@@ -257,7 +254,7 @@ jobs:
           GH_REPO: ${{ github.repository }}
 
       - name: Get PR head ref for checkout
-        if: steps.preconditions.outputs.skip != 'true' && steps.copilot-wait.outputs.copilot_reviewed == 'true' && steps.forbidden-check.outputs.forbidden != 'true' && steps.review-result.outputs.has_issues == 'true'
+        if: steps.preconditions.outputs.skip != 'true' && steps.copilot-wait.outputs.copilot_reviewed == 'true' && steps.review-result.outputs.has_issues == 'true'
         id: pr-head-ref
         run: |
           set -euo pipefail
@@ -273,14 +270,14 @@ jobs:
           GH_REPO: ${{ github.repository }}
 
       - name: Checkout for auto-fix
-        if: steps.preconditions.outputs.skip != 'true' && steps.copilot-wait.outputs.copilot_reviewed == 'true' && steps.forbidden-check.outputs.forbidden != 'true' && steps.review-result.outputs.has_issues == 'true'
+        if: steps.preconditions.outputs.skip != 'true' && steps.copilot-wait.outputs.copilot_reviewed == 'true' && steps.review-result.outputs.has_issues == 'true'
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: ${{ steps.pr-head-ref.outputs.ref }}
 
       - name: Load prompt template
-        if: steps.preconditions.outputs.skip != 'true' && steps.copilot-wait.outputs.copilot_reviewed == 'true' && steps.forbidden-check.outputs.forbidden != 'true' && steps.review-result.outputs.has_issues == 'true'
+        if: steps.preconditions.outputs.skip != 'true' && steps.copilot-wait.outputs.copilot_reviewed == 'true' && steps.review-result.outputs.has_issues == 'true'
         id: load-prompt
         run: |
           set -euo pipefail
@@ -300,7 +297,7 @@ jobs:
           PR_NUMBER: ${{ steps.pr-info.outputs.number }}
 
       - name: Validate REPO_OWNER_PAT
-        if: steps.preconditions.outputs.skip != 'true' && steps.copilot-wait.outputs.copilot_reviewed == 'true' && steps.forbidden-check.outputs.forbidden != 'true' && steps.review-result.outputs.has_issues == 'true'
+        if: steps.preconditions.outputs.skip != 'true' && steps.copilot-wait.outputs.copilot_reviewed == 'true' && steps.review-result.outputs.has_issues == 'true'
         run: |
           set -euo pipefail
           if [ -z "$TOKEN" ]; then
@@ -311,7 +308,7 @@ jobs:
           TOKEN: ${{ secrets.REPO_OWNER_PAT }}
 
       - name: Auto-fix with Claude
-        if: steps.preconditions.outputs.skip != 'true' && steps.copilot-wait.outputs.copilot_reviewed == 'true' && steps.forbidden-check.outputs.forbidden != 'true' && steps.review-result.outputs.has_issues == 'true'
+        if: steps.preconditions.outputs.skip != 'true' && steps.copilot-wait.outputs.copilot_reviewed == 'true' && steps.review-result.outputs.has_issues == 'true'
         id: auto-fix
         uses: anthropics/claude-code-action@5994afaaa7f44611addc97a696a135acff5fd218 # v1.0.46
         with:
@@ -328,7 +325,7 @@ jobs:
       # --- 修正後の検証 ---
 
       - name: Recount unresolved threads
-        if: steps.preconditions.outputs.skip != 'true' && steps.copilot-wait.outputs.copilot_reviewed == 'true' && steps.forbidden-check.outputs.forbidden != 'true' && steps.review-result.outputs.has_issues == 'true'
+        if: steps.preconditions.outputs.skip != 'true' && steps.copilot-wait.outputs.copilot_reviewed == 'true' && steps.review-result.outputs.has_issues == 'true'
         id: recount
         run: bash "$GITHUB_WORKSPACE/.github/scripts/auto-fix/check-review-result.sh"
         env:
@@ -338,7 +335,7 @@ jobs:
           GITHUB_REPOSITORY: ${{ github.repository }}
 
       - name: Handle remaining issues
-        if: steps.preconditions.outputs.skip != 'true' && steps.copilot-wait.outputs.copilot_reviewed == 'true' && steps.forbidden-check.outputs.forbidden != 'true' && steps.review-result.outputs.has_issues == 'true' && steps.recount.outputs.has_issues == 'true'
+        if: steps.preconditions.outputs.skip != 'true' && steps.copilot-wait.outputs.copilot_reviewed == 'true' && steps.review-result.outputs.has_issues == 'true' && steps.recount.outputs.has_issues == 'true'
         run: |
           source "$GITHUB_WORKSPACE/.github/scripts/auto-fix/_common.sh"
           PR_NUMBER="${{ steps.pr-info.outputs.number }}"
@@ -358,14 +355,14 @@ jobs:
           GH_REPO: ${{ github.repository }}
 
       # --- マージ判定 ---
-      # 条件: (Copilot検知済み) AND (禁止パターンなし) AND (指摘なし OR 修正完了)
+      # 条件: (Copilot検知済み) AND (指摘なし OR 修正完了)
+      # 禁止パターンは merge-check.sh 内で条件6としてチェック（auto-fix は続行させるため）
       # 品質チェック（pytest/ruff/mypy/markdownlint）はエージェント内テストで担保済み（外部CIワークフロー不使用）
 
       - name: Merge check
         if: |
           steps.preconditions.outputs.skip != 'true'
           && steps.copilot-wait.outputs.copilot_reviewed == 'true'
-          && steps.forbidden-check.outputs.forbidden != 'true'
           && (
             steps.review-result.outputs.has_issues != 'true'
             || steps.recount.outputs.has_issues != 'true'
@@ -377,6 +374,7 @@ jobs:
           GH_REPO: ${{ github.repository }}
           PR_NUMBER: ${{ steps.pr-info.outputs.number }}
           EXCLUDE_CHECK: "copilot-auto-fix"
+          FORBIDDEN_DETECTED: ${{ steps.forbidden-check.outputs.forbidden }}
 
       - name: Merge or dry-run
         if: steps.merge-check.outputs.merge_ready == 'true'


### PR DESCRIPTION
## Change type

- [x] fix: バグ修正

## Summary

- 禁止パターン検出時に即`auto:failed`付与して全処理停止していたフローを変更
- auto-fix（レビュー指摘の自動修正）は続行し、マージ判定のみでブロックする
- `merge-check.sh`に条件6（`FORBIDDEN_DETECTED`環境変数による禁止パターンチェック）を追加（5条件→6条件）
- 仕様書2つ（copilot-auto-fix.md, auto-progress.md）のフロー図・安全弁設計・AC・スクリプト一覧を更新

## Test plan

- [ ] 禁止パターンを含むPR（.env*, pyproject.toml deps）でauto-fixが続行されることを確認
- [ ] 禁止パターンを含むPRでマージ判定が条件6でブロックされることを確認
- [ ] 禁止パターンを含まないPRで従来通り自動マージされることを確認
- [ ] markdownlint, shellcheck 通過済み

## Related issues

Closes #439