### PR TITLE
refactor(f2): APSchedulerによる定期配信を廃止 (#28)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ dependencies = [
     "sqlalchemy>=2.0,<3",
     "aiosqlite>=0.20,<1",
     "feedparser>=6.0,<7",
-    "apscheduler>=3.10,<4",
     "aiohttp>=3.9,<4",
     "pyyaml>=6.0,<7",
     "mcp>=1.0,<2",
@@ -64,7 +63,7 @@ ignore_missing_imports = true
 follow_imports = "skip"
 
 [[tool.mypy.overrides]]
-module = ["feedparser", "feedparser.*", "apscheduler", "apscheduler.*"]
+module = ["feedparser", "feedparser.*"]
 ignore_missing_imports = true
 
 [tool.pytest.ini_options]

--- a/src/scheduler/jobs.py
+++ b/src/scheduler/jobs.py
@@ -1,4 +1,4 @@
-"""APScheduler 毎朝の収集・配信ジョブ
+"""配信ジョブ・フォーマット
 仕様: docs/specs/f2-feed-collection.md
 """
 
@@ -10,7 +10,6 @@ from datetime import datetime
 from typing import Any, Literal
 from zoneinfo import ZoneInfo
 
-from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
@@ -452,34 +451,3 @@ async def feed_test_deliver(
 
     # delivered フラグは更新しない（テストなので副作用なし）
     logger.info("Test delivery completed for %d feeds", feeds_delivered)
-
-
-def setup_scheduler(
-    collector: FeedCollector,
-    session_factory: async_sessionmaker[AsyncSession],
-    slack_client: object,
-    channel_id: str,
-    hour: int = 7,
-    minute: int = 0,
-    tz: str = "Asia/Tokyo",
-    max_articles_per_feed: int = 10,
-    layout: Literal["vertical", "horizontal"] = "horizontal",
-) -> AsyncIOScheduler:
-    """スケジューラを設定して返す."""
-    scheduler = AsyncIOScheduler(timezone=tz)
-    scheduler.add_job(
-        daily_collect_and_deliver,
-        "cron",
-        hour=hour,
-        minute=minute,
-        kwargs={
-            "collector": collector,
-            "session_factory": session_factory,
-            "slack_client": slack_client,
-            "channel_id": channel_id,
-            "max_articles_per_feed": max_articles_per_feed,
-            "layout": layout,
-        },
-        id="daily_feed_job",
-    )
-    return scheduler

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,9 +1,9 @@
-"""スケジューラ・配信フォーマットのテスト (Issue #8, #123)."""
+"""配信フォーマットのテスト (Issue #8, #123)."""
 
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock
 
 import pytest
 from sqlalchemy import select
@@ -17,7 +17,6 @@ from src.scheduler.jobs import (
     daily_collect_and_deliver,
     feed_test_deliver,
     format_daily_digest,
-    setup_scheduler,
 )
 from src.services.feed_collector import NO_SUMMARY_TEXT
 
@@ -148,32 +147,6 @@ def test_ac14_format_digest_limits_articles_per_feed() -> None:
     result = format_daily_digest(articles, feeds, max_articles_per_feed=5)
     _, article_blocks_list = result[1]
     assert len(article_blocks_list) == 5
-
-
-def test_ac4_scheduler_registers_cron_job() -> None:
-    """AC4: 毎朝指定時刻にスケジューラが収集・配信ジョブを実行する."""
-    collector = MagicMock()
-    session_factory = MagicMock()
-    slack_client = MagicMock()
-
-    scheduler = setup_scheduler(
-        collector=collector,
-        session_factory=session_factory,
-        slack_client=slack_client,
-        channel_id="C123",
-        hour=7,
-        minute=30,
-        tz="Asia/Tokyo",
-    )
-
-    jobs = scheduler.get_jobs()
-    assert len(jobs) == 1
-    assert jobs[0].id == "daily_feed_job"
-    trigger = jobs[0].trigger
-    hour_field = next(f for f in trigger.fields if getattr(f, "name", None) == "hour")
-    minute_field = next(f for f in trigger.fields if getattr(f, "name", None) == "minute")
-    assert str(hour_field) == "7"
-    assert str(minute_field) == "30"
 
 
 @pytest.fixture

--- a/uv.lock
+++ b/uv.lock
@@ -14,7 +14,6 @@ dependencies = [
     { name = "aiohttp" },
     { name = "aiosqlite" },
     { name = "anthropic" },
-    { name = "apscheduler" },
     { name = "beautifulsoup4" },
     { name = "certifi" },
     { name = "charset-normalizer" },
@@ -54,7 +53,6 @@ requires-dist = [
     { name = "aiohttp", specifier = ">=3.9,<4" },
     { name = "aiosqlite", specifier = ">=0.20,<1" },
     { name = "anthropic", specifier = ">=0.18,<1" },
-    { name = "apscheduler", specifier = ">=3.10,<4" },
     { name = "beautifulsoup4", specifier = ">=4.12,<5" },
     { name = "certifi", specifier = ">=2026.1.4" },
     { name = "charset-normalizer", specifier = ">=3.0,<4" },
@@ -265,18 +263,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/96/f0/5eb65b2bb0d09ac6776f2eb54adee6abe8228ea05b20a5ad0e4945de8aac/anyio-4.12.1.tar.gz", hash = "sha256:41cfcc3a4c85d3f05c932da7c26d0201ac36f72abd4435ba90d0464a3ffed703", size = 228685, upload-time = "2026-01-06T11:45:21.246Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/38/0e/27be9fdef66e72d64c0cdc3cc2823101b80585f8119b5c112c2e8f5f7dab/anyio-4.12.1-py3-none-any.whl", hash = "sha256:d405828884fc140aa80a3c667b8beed277f1dfedec42ba031bd6ac3db606ab6c", size = 113592, upload-time = "2026-01-06T11:45:19.497Z" },
-]
-
-[[package]]
-name = "apscheduler"
-version = "3.11.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "tzlocal" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/07/12/3e4389e5920b4c1763390c6d371162f3784f86f85cd6d6c1bfe68eef14e2/apscheduler-3.11.2.tar.gz", hash = "sha256:2a9966b052ec805f020c8c4c3ae6e6a06e24b1bf19f2e11d91d8cca0473eef41", size = 108683, upload-time = "2025-12-22T00:39:34.884Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/9f/64/2e54428beba8d9992aa478bb8f6de9e4ecaa5f8f513bcfd567ed7fb0262d/apscheduler-3.11.2-py3-none-any.whl", hash = "sha256:ce005177f741409db4e4dd40a7431b76feb856b9dd69d57e0da49d6715bfd26d", size = 64439, upload-time = "2025-12-22T00:39:33.303Z" },
 ]
 
 [[package]]
@@ -3154,27 +3140,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
-]
-
-[[package]]
-name = "tzdata"
-version = "2025.3"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5e/a7/c202b344c5ca7daf398f3b8a477eeb205cf3b6f32e7ec3a6bac0629ca975/tzdata-2025.3.tar.gz", hash = "sha256:de39c2ca5dc7b0344f2eba86f49d614019d29f060fc4ebc8a417896a620b56a7", size = 196772, upload-time = "2025-12-13T17:45:35.667Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c7/b0/003792df09decd6849a5e39c28b513c06e84436a54440380862b5aeff25d/tzdata-2025.3-py2.py3-none-any.whl", hash = "sha256:06a47e5700f3081aab02b2e513160914ff0694bce9947d6b76ebd6bf57cfc5d1", size = 348521, upload-time = "2025-12-13T17:45:33.889Z" },
-]
-
-[[package]]
-name = "tzlocal"
-version = "5.3.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "tzdata", marker = "sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/8b/2e/c14812d3d4d9cd1773c6be938f89e5735a1f11a9f184ac3639b93cef35d5/tzlocal-5.3.1.tar.gz", hash = "sha256:cceffc7edecefea1f595541dbd6e990cb1ea3d19bf01b2809f362a03dd7921fd", size = 30761, upload-time = "2025-03-05T21:17:41.549Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/c2/14/e2a54fabd4f08cd7af1c07030603c3356b74da07f7cc056e600436edfa17/tzlocal-5.3.1-py3-none-any.whl", hash = "sha256:eb1a66c3ef5847adf7a834f1be0800581b683b5608e74f86ecbcef8ab91bb85d", size = 18026, upload-time = "2025-03-05T21:17:39.857Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Change type

- [x] refactor: リファクタリング

## Summary

- `src/scheduler/jobs.py` から `setup_scheduler` 関数と APScheduler import を削除
- `pyproject.toml` から `apscheduler>=3.10,<4` 依存を除去
- mypy overrides から `apscheduler` 設定を除去
- `tests/test_scheduler.py` から `test_ac4_scheduler_registers_cron_job` テストと未使用 import（`setup_scheduler`, `MagicMock`）を整理
- `uv.lock` 更新（apscheduler, tzdata, tzlocal が除去）
- `daily_collect_and_deliver`, `format_daily_digest`, `feed_test_deliver` 等のハンドラ利用関数は維持

## Test plan

- [x] pytest: 583 passed, 4 skipped
- [x] ruff: All checks passed
- [x] mypy: Success, no issues found
- [x] markdownlint: 0 errors
- [x] shellcheck: info-level warnings only (pre-existing SC1091)

## Related issues

Closes #28