### PR TITLE
docs: README.mdからAPScheduler記述を削除 (#477)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ RSS記事の自動収集・要約配信、チャットでの質問応答、ユ�
 
 ## 技術スタック
 
-Python 3.11+ / uv / slack-bolt / OpenAI SDK / Anthropic SDK / SQLite + SQLAlchemy / APScheduler / feedparser / MCP SDK / ChromaDB / BeautifulSoup4
+Python 3.11+ / uv / slack-bolt / OpenAI SDK / Anthropic SDK / SQLite + SQLAlchemy / feedparser / MCP SDK / ChromaDB / BeautifulSoup4
 
 ## セットアップ
 
@@ -101,7 +101,7 @@ src/
   services/ogp_extractor.py   # OGPメタデータ抽出
   services/safe_browsing.py   # Google Safe Browsing API
   services/thread_history.py  # Slackスレッド履歴取得
-  scheduler/jobs.py  # APScheduler 毎朝の収集・配信ジョブ
+  scheduler/jobs.py  # 配信ジョブ・フォーマット
 mcp-servers/                 # MCPサーバー群（将来リポジトリ分離対象）
   weather/
     server.py          # 天気予報MCPサーバー（気象庁API）


### PR DESCRIPTION
## Change type

- [x] docs: ドキュメント修正

## Summary

- README.md の技術スタック一覧から `APScheduler` を削除
- プロジェクト構造の `scheduler/jobs.py` 説明を「配信ジョブ・フォーマット」に更新
- PR #455 で APScheduler を廃止済みだが、README の記述が古いままだった

## Test plan

- [ ] README.md の表示確認（技術スタック、プロジェクト構造）

## Related issues

Closes #477