### PR TITLE
fix: tzdata を直接依存に追加（Windows ZoneInfo対応） (#479)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ dependencies = [
     "rank-bm25>=0.2,<1",
     "fugashi>=1.3,<2",
     "unidic-lite>=1.0,<2",
+    "tzdata>=2024.1",
 ]
 
 [project.optional-dependencies]

--- a/uv.lock
+++ b/uv.lock
@@ -29,6 +29,7 @@ dependencies = [
     { name = "rank-bm25" },
     { name = "slack-bolt" },
     { name = "sqlalchemy" },
+    { name = "tzdata" },
     { name = "unidic-lite" },
 ]
 
@@ -79,6 +80,7 @@ requires-dist = [
     { name = "slack-bolt", specifier = ">=1.18,<2" },
     { name = "sqlalchemy", specifier = ">=2.0,<3" },
     { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0" },
+    { name = "tzdata", specifier = ">=2024.1" },
     { name = "unidic-lite", specifier = ">=1.0,<2" },
 ]
 provides-extras = ["dev"]
@@ -3150,6 +3152,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2025.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/a7/c202b344c5ca7daf398f3b8a477eeb205cf3b6f32e7ec3a6bac0629ca975/tzdata-2025.3.tar.gz", hash = "sha256:de39c2ca5dc7b0344f2eba86f49d614019d29f060fc4ebc8a417896a620b56a7", size = 196772, upload-time = "2025-12-13T17:45:35.667Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/b0/003792df09decd6849a5e39c28b513c06e84436a54440380862b5aeff25d/tzdata-2025.3-py2.py3-none-any.whl", hash = "sha256:06a47e5700f3081aab02b2e513160914ff0694bce9947d6b76ebd6bf57cfc5d1", size = 348521, upload-time = "2025-12-13T17:45:33.889Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Change type

- [x] fix: バグ修正

## Summary

- `tzdata>=2024.1` を `pyproject.toml` の直接依存に追加
- PR #455 で `apscheduler` を廃止した際、間接依存の `tzdata` も削除された
- Windows では `zoneinfo` モジュールがシステムタイムゾーンDBを持たないため `tzdata` が必要
- `ZoneInfo("Asia/Tokyo")` が `ZoneInfoNotFoundError` でクラッシュしていた

## Test plan

- [ ] Windows で `uv sync` 後に `uv run python -c "from zoneinfo import ZoneInfo; ZoneInfo('Asia/Tokyo')"` が成功すること
- [ ] 全モジュールのインポートがエラーなく完了すること

## Related issues

Closes #479