### PR TITLE
fix: /resume スキルを /restore にリネーム

### DIFF
--- a/.claude/skills/restore/SKILL.md
+++ b/.claude/skills/restore/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: resume
+name: restore
 description: セッション復帰時のジャーナル確認・前回作業の把握
 user-invocable: true
 allowed-tools: Bash, Read, Glob

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -377,7 +377,7 @@ commitが成功していない状態でpushしないこと。
 | `/auto-finalize` | 品質チェック後のcommit/push/PR作成/Issue完了コメント | `/auto-finalize 272` |
 | `/merged` | PRマージ後処理（develop同期・ブランチ削除・ジャーナル・レトロ） | `/merged 482` |
 | `/handoff` | セッション引き継ぎ（MEMORY.md更新・ジャーナル記録） | `/handoff`, `/handoff "次はCopilotフロー"` |
-| `/resume` | セッション復帰（ジャーナル確認・前回作業把握） | `/resume`, `/resume 3` |
+| `/restore` | セッション復帰（ジャーナル確認・前回作業把握） | `/restore`, `/restore 3` |
 | `/check-review-batch` | 自動マージIssueの全PRチェック・レポート | `/check-review-batch`, `/check-review-batch 375` |
 
 **定義ファイル**: `.claude/skills/` 配下
@@ -387,7 +387,7 @@ commitが成功していない状態でpushしないこと。
 - `docs/specs/topic-skill.md`（`/topic` 用）
 - `docs/specs/handoff-skill.md`（`/handoff` 用）
 - `docs/specs/check-review-batch-skill.md`（`/check-review-batch` 用）
-**補足**: `/check-pr`、`/merged`、`/resume` は `.claude/skills/` 配下の SKILL.md の定義のみで、`docs/specs/` 配下に専用の仕様書はありません。
+**補足**: `/check-pr`、`/merged`、`/restore` は `.claude/skills/` 配下の SKILL.md の定義のみで、`docs/specs/` 配下に専用の仕様書はありません。
 
 ### サブエージェント（自動委譲タスク）
 


### PR DESCRIPTION
## Change type

- [x] fix: バグ修正

## Summary

- `/resume` カスタムスキルが Claude Code 公式の `/resume` コマンドと名前が衝突していたため `/restore` にリネーム
- 変更箇所: スキルディレクトリ名、SKILL.md の name フィールド、CLAUDE.md のスキル表・補足（2箇所）
- memory 内の参照（MEMORY.md、journal-guidelines.md）も更新済み（git 管理外）

## Test plan

- [x] `/restore` でスキルが正しく呼び出せることを確認
- [x] `.claude/skills/` 配下・CLAUDE.md・docs/specs/ に `/resume` の残留参照がないことを grep で確認

## Related issues

N/A