### PR TITLE
docs: サブIssue作成手順をCLAUDE.mdに追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,6 +115,21 @@
 - GitHub Milestones で Step 単位の進捗管理
 - `gh` コマンドで Issue/PR を操作
 
+**サブIssueの作成**:
+
+`gh` CLI にはサブIssue作成のネイティブサポートがないため、GraphQL API を使用する。
+Issue作成時にサブIssue関係の指示がある場合は、Issue作成後にこの手順で紐付けること。
+
+```bash
+# 1. 親・子IssueのNode IDを取得
+gh issue view <親Issue番号> --json id --jq '.id'
+gh issue view <子Issue番号> --json id --jq '.id'
+
+# 2. サブIssue関係を作成（IDは直接埋め込む）
+gh api graphql -H "GraphQL-Features:sub_issues" \
+  -f query='mutation { addSubIssue(input: { issueId: "<親のNode ID>", subIssueId: "<子のNode ID>" }) { issue { title number } subIssue { title number } } }'
+```
+
 **Claudeによる実装完了時の必須手順**:
 
 1. **ファイル作成の確認**: 作成したと報告したファイルが実際に存在するか `ls -la` で確認


### PR DESCRIPTION
## Change type

- [x] docs: ドキュメントのみの変更

## Summary

- `gh` CLIにサブIssue作成のネイティブサポートがないため、GraphQL API (`addSubIssue` mutation) を使用する手順をGit運用セクションに追記
- Node ID取得 → GraphQL mutation の2ステップ手順を記載

## Test plan

- [x] markdownlint 通過確認

## Related issues

N/A（Issue #492 作成時にサブIssue紐付けが漏れた経験から追加）