### PR TITLE
feat(f9): rank-bm25 → bm25s 移行 (#329)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,9 +31,7 @@ ANTHROPIC_MODEL=claude-3-5-sonnet-20241022
 LMSTUDIO_BASE_URL=http://localhost:1234/v1
 LMSTUDIO_MODEL=local-model
 
-# Scheduler
-DAILY_FEED_HOUR=7
-DAILY_FEED_MINUTE=0
+# Timezone
 TIMEZONE=Asia/Tokyo
 
 # Feed Articles Per Feed (max articles to deliver per feed, default: 10)

--- a/docs/specs/f9-rag.md
+++ b/docs/specs/f9-rag.md
@@ -190,7 +190,7 @@ bot: エラー: ページの取り込みに失敗しました。
 dependencies = [
     "chromadb>=0.5,<1",
     "beautifulsoup4>=4.12,<5",
-    "rank-bm25>=0.2,<1",
+    "bm25s>=0.3,<1",
     "fugashi>=1.3,<2",
     "unidic-lite>=1.0,<2",
 ]
@@ -1127,6 +1127,7 @@ class Settings(BaseSettings):
 
 | 日付 | 内容 |
 |------|------|
+| 2026-02-18 | BM25ライブラリを rank-bm25 から bm25s に差し替え（#329） |
 | 2026-02-17 | robots.txt 解析・遵守機能を追加（#160） |
 | 2026-02-12 | 4つの仕様書を統合・整理（旧: f9-rag-knowledge.md, f9-rag-evaluation.md, f9-rag-chunking-hybrid.md, f9-rag-auto-evaluation.md） |
 | 2026-02-11 | クロール進捗フィードバック機能を追加（#158） |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "chromadb>=0.5,<1",
     "beautifulsoup4>=4.12,<5",
     "charset-normalizer>=3.0,<4",
-    "rank-bm25>=0.2,<1",
+    "bm25s>=0.3,<1",
     "fugashi>=1.3,<2",
     "unidic-lite>=1.0,<2",
     "tzdata>=2024.1",
@@ -56,10 +56,10 @@ line-length = 100
 [tool.mypy]
 python_version = "3.11"
 strict = true
-untyped_calls_exclude = ["fugashi", "rank_bm25"]
+untyped_calls_exclude = ["fugashi", "bm25s"]
 
 [[tool.mypy.overrides]]
-module = ["fugashi", "fugashi.*", "rank_bm25", "rank_bm25.*"]
+module = ["fugashi", "fugashi.*", "bm25s", "bm25s.*"]
 ignore_missing_imports = true
 follow_imports = "skip"
 

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -59,9 +59,7 @@ class Settings(BaseSettings):
     lmstudio_base_url: str = DEFAULT_LMSTUDIO_BASE_URL
     lmstudio_model: str = "local-model"
 
-    # Scheduler
-    daily_feed_hour: int = Field(default=7, ge=0, le=23)
-    daily_feed_minute: int = Field(default=0, ge=0, le=59)
+    # Timezone
     timezone: str = "Asia/Tokyo"
 
     # Feed delivery

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -38,8 +38,8 @@ def test_ac2_all_config_sections_present() -> None:
     assert {"lmstudio_base_url", "lmstudio_model"} <= fields
     # DB
     assert "database_url" in fields
-    # Scheduler
-    assert {"daily_feed_hour", "daily_feed_minute", "timezone"} <= fields
+    # Timezone
+    assert "timezone" in fields
 
 
 def test_ac3_assistant_yaml_loaded() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -15,6 +15,7 @@ dependencies = [
     { name = "aiosqlite" },
     { name = "anthropic" },
     { name = "beautifulsoup4" },
+    { name = "bm25s" },
     { name = "certifi" },
     { name = "charset-normalizer" },
     { name = "chromadb" },
@@ -26,7 +27,6 @@ dependencies = [
     { name = "pydantic-settings" },
     { name = "python-dotenv" },
     { name = "pyyaml" },
-    { name = "rank-bm25" },
     { name = "slack-bolt" },
     { name = "sqlalchemy" },
     { name = "tzdata" },
@@ -59,6 +59,7 @@ requires-dist = [
     { name = "aiosqlite", specifier = ">=0.20,<1" },
     { name = "anthropic", specifier = ">=0.18,<1" },
     { name = "beautifulsoup4", specifier = ">=4.12,<5" },
+    { name = "bm25s", specifier = ">=0.3,<1" },
     { name = "certifi", specifier = ">=2026.1.4" },
     { name = "charset-normalizer", specifier = ">=3.0,<4" },
     { name = "chromadb", specifier = ">=0.5,<1" },
@@ -74,7 +75,6 @@ requires-dist = [
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0,<6" },
     { name = "python-dotenv", specifier = ">=1.0,<2" },
     { name = "pyyaml", specifier = ">=6.0,<7" },
-    { name = "rank-bm25", specifier = ">=0.2,<1" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.2" },
     { name = "shellcheck-py", marker = "extra == 'dev'", specifier = ">=0.10" },
     { name = "slack-bolt", specifier = ">=1.18,<2" },
@@ -385,6 +385,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c3/b0/1c6a16426d389813b48d95e26898aff79abbde42ad353958ad95cc8c9b21/beautifulsoup4-4.14.3.tar.gz", hash = "sha256:6292b1c5186d356bba669ef9f7f051757099565ad9ada5dd630bd9de5fa7fb86", size = 627737, upload-time = "2025-11-30T15:08:26.084Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/1a/39/47f9197bdd44df24d67ac8893641e16f386c984a0619ef2ee4c51fbbc019/beautifulsoup4-4.14.3-py3-none-any.whl", hash = "sha256:0918bfe44902e6ad8d57732ba310582e98da931428d231a5ecb9e7c703a735bb", size = 107721, upload-time = "2025-11-30T15:08:24.087Z" },
+]
+
+[[package]]
+name = "bm25s"
+version = "0.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/30/0a3f0772101750613ad4662ceb599fee007d2027e52ac917b7eedec6649b/bm25s-0.3.0.tar.gz", hash = "sha256:591aa454d03763bdbc89961823f03fde0016467ceb5a1438363ef1ec3f0a09c9", size = 73998, upload-time = "2026-02-17T19:38:57.214Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0e/90/bc786debc06d7dce2f8385fbe7f8da8c52ca9b7a1f72516a11888c1af150/bm25s-0.3.0-py3-none-any.whl", hash = "sha256:ef515019afafdc5bc181af71097dab78928b76601a1f2745b5761c9bccb6e6dd", size = 69068, upload-time = "2026-02-17T19:38:55.902Z" },
 ]
 
 [[package]]
@@ -2630,18 +2642,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/da/92/1446574745d74df0c92e6aa4a7b0b3130706a4142b2d1a5869f2eaa423c6/pyyaml-6.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:16249ee61e95f858e83976573de0f5b2893b3677ba71c9dd36b9cf8be9ac6d65", size = 829923, upload-time = "2025-09-25T21:32:54.537Z" },
     { url = "https://files.pythonhosted.org/packages/f0/7a/1c7270340330e575b92f397352af856a8c06f230aa3e76f86b39d01b416a/pyyaml-6.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4ad1906908f2f5ae4e5a8ddfce73c320c2a1429ec52eafd27138b7f1cbe341c9", size = 174062, upload-time = "2025-09-25T21:32:55.767Z" },
     { url = "https://files.pythonhosted.org/packages/f1/12/de94a39c2ef588c7e6455cfbe7343d3b2dc9d6b6b2f40c4c6565744c873d/pyyaml-6.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:ebc55a14a21cb14062aa4162f906cd962b28e2e9ea38f9b4391244cd8de4ae0b", size = 149341, upload-time = "2025-09-25T21:32:56.828Z" },
-]
-
-[[package]]
-name = "rank-bm25"
-version = "0.2.2"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "numpy" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/fc/0a/f9579384aa017d8b4c15613f86954b92a95a93d641cc849182467cf0bb3b/rank_bm25-0.2.2.tar.gz", hash = "sha256:096ccef76f8188563419aaf384a02f0ea459503fdf77901378d4fd9d87e5e51d", size = 8347, upload-time = "2022-02-16T12:10:52.196Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/21/f691fb2613100a62b3fa91e9988c991e9ca5b89ea31c0d3152a3210344f9/rank_bm25-0.2.2-py3-none-any.whl", hash = "sha256:7bd4a95571adadfc271746fa146a4bcfd89c0cf731e49c3d1ad863290adbe8ae", size = 8584, upload-time = "2022-02-16T12:10:50.626Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Change type

- [x] feat: 新機能実装
- [x] refactor: リファクタリング

## Summary

- BM25キーワード検索ライブラリを rank-bm25（数年間メンテ停滞）から bm25s（活発にメンテ中）に差し替え
- `src/rag/bm25_index.py` の内部実装のみ変更、公開APIは不変
- bm25s の `show_progress=False` を設定し、Bot内でのtqdmプログレスバー出力を抑制
- apscheduler 廃止後に残っていた未使用のスケジューラ設定（`DAILY_FEED_HOUR`, `DAILY_FEED_MINUTE`）を削除

### 設計決定（Issue #492 チーム議論の結論）

| トピック | 決定 | 根拠 |
|---------|------|------|
| 抽象化レイヤー | 不要 | BM25Indexが十分薄いアダプタ、消費者2つのみ |
| ライブラリ | bm25s本体 + 既存fugashi | bm25s-jは不採用（メンテ停滞、辞書差異リスク） |
| 影響範囲 | ~50行、公開API不変 | bm25_index.py内部のみ変更 |
| 永続化(save/load/mmap) | 別Issue (#497) | 移行PRをコンパクトに保つ |

## Test plan

- [x] pytest 603 passed, 4 skipped
- [x] ruff check 違反なし
- [x] mypy strict 全ファイルパス
- [x] BM25テスト全10件パス（公開API不変のため既存テストそのまま通過）
- [x] 設定テストのスケジューラ設定削除反映確認

## Related issues

Closes #329
Related: #492, #497