### PR TITLE
fix(markdownlint): exclude docs/zenn-drafts/ from lint target (#503)

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -12,6 +12,9 @@
     "MD041": false,
     "MD060": false
   },
+  "ignores": [
+    "docs/zenn-drafts/**"
+  ],
   "globs": [
     "docs/**/*.md",
     "*.md",


### PR DESCRIPTION
## Change type

- [x] fix: バグ修正

## Summary

- `.markdownlint-cli2.jsonc` の `ignores` に `docs/zenn-drafts/**` を追加し、ドラフト記事をリント対象から除外

## Test plan

- [x] `npx markdownlint-cli2@0.20.0` が `!docs/zenn-drafts/**` を除外パターンとして認識すること
- [x] 既存の Markdown ファイルのリントが正常に通ること（0 errors）

## Related issues

Closes #503

Generated with [Claude Code](https://claude.ai/code)