### PR TITLE
fix: run_in_background 使用禁止ブロックを解除

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,13 +109,6 @@ PR や Issue にコメントを投稿する際、`@ユーザー名` 形式のメ
 
 サブエージェント定義は `.claude/agents/` 配下を参照。
 
-<!-- CLI-BUG: classifyHandoffIfNeeded (anthropics/claude-code#24181) -->
-> **Task ツールの `run_in_background: true` は使用禁止**
->
-> CLI の既知バグによりバックグラウンドモードの結果が正常に返らない。
-> サブエージェントは常にフォアグラウンドで起動すること。
-> **解除条件**: バグ修正確認後、このブロックを削除する。
-
 ### エージェントチーム
 
 チーム機能の仕様は `docs/specs/agent-teams/` 配下を参照。


### PR DESCRIPTION
## Change type

- [x] fix: バグ修正 ★

## Summary

- CLAUDE.md から `run_in_background: true` 使用禁止ブロック（CLI-BUG: classifyHandoffIfNeeded）を削除
- Claude Code v2.1.47 で以下のバグが修正されたことを確認済み:
  - v2.1.45: Task tool (backgrounded agents) の ReferenceError クラッシュ修正
  - v2.1.47: バックグラウンドエージェント結果が生トランスクリプトを返す問題修正
- [CHANGELOG (v2.1.47)](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md) に記載あり

## Test plan

- [x] `run_in_background: true` でサブエージェント起動 → 正常に結果取得を確認

## Related issues

N/A（upstream: anthropics/claude-code#24181）