### PR TITLE
feat(f9): パラメータスイープ再実行で推奨値更新 (#518)

### DIFF
--- a/docs/specs/f9-rag.md
+++ b/docs/specs/f9-rag.md
@@ -1006,7 +1006,7 @@ class Settings(BaseSettings):
 
     # ハイブリッド検索
     rag_hybrid_search_enabled: bool = False
-    rag_vector_weight: float = 0.5
+    rag_vector_weight: float = 1.0
     rag_bm25_k1: float = 1.5
     rag_bm25_b: float = 0.75
     bm25_persist_dir: str = "./bm25_index"
@@ -1279,6 +1279,7 @@ class Settings(BaseSettings):
 
 | 日付 | 内容 |
 |------|------|
+| 2026-02-19 | パラメータスイープ再実行（拡充データ101件+プレフィックス有効）で `RAG_VECTOR_WEIGHT` 推奨値を 0.5→1.0 に更新（#518） |
 | 2026-02-19 | Embeddingプレフィックス検証: `embed_documents()` / `embed_query()` メソッド追加、`EMBEDDING_PREFIX_ENABLED` 設定追加（#517） |
 | 2026-02-18 | 評価CLIに `--vector-weight` オプション追加、CC自然減衰の対称性を記述（#509） |
 | 2026-02-18 | BM25インデックスの永続化機能を追加（#497） |

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -104,7 +104,7 @@ class Settings(BaseSettings):
 
     # RAGハイブリッド検索 (Phase 2)
     rag_hybrid_search_enabled: bool = False  # ハイブリッド検索の有効/無効
-    rag_vector_weight: float = Field(default=0.5, ge=0.0, le=1.0)  # ベクトル検索の重み
+    rag_vector_weight: float = Field(default=1.0, ge=0.0, le=1.0)  # ベクトル検索の重み
     rag_bm25_k1: float = Field(default=1.5, gt=0.0)  # BM25の用語頻度パラメータ
     rag_bm25_b: float = Field(default=0.75, ge=0.0, le=1.0)  # BM25の文書長正規化パラメータ
     bm25_persist_dir: str = "./bm25_index"


### PR DESCRIPTION
## Change type

- [x] feat: 新機能実装 ★
- [x] docs: ドキュメント更新

## Summary

- 拡充データ（101ドキュメント / 55クエリ）+ Embeddingプレフィックス有効環境でパラメータスイープを再実行
- `rag_vector_weight` デフォルト値を 0.5 → 1.0 に更新（α=1.0 が F1=0.784 で最適）
- `rag_similarity_threshold` は None を維持（全閾値で同一結果）
- 仕様書 `f9-rag.md` のデフォルト値・変更履歴を更新
- スイープ中に Embedding モデルのトークン上限（512）超過の WARNING を発見 → #522 で別途対応

## Test plan

- [x] パラメータスイープ 3 回実行で再現性を確認（全回同一結果）
- [x] pytest 649 passed, 4 skipped
- [x] ruff / mypy / markdownlint 全パス

## Related issues

Closes #518