### PR TITLE
feat(f9): BM25 k1/b パラメータスイープ (Phase 4) 追加

### DIFF
--- a/scripts/parameter_sweep.py
+++ b/scripts/parameter_sweep.py
@@ -675,15 +675,31 @@ def main() -> None:
         required=True,
         help="チャンクオーバーラップ",
     )
+    def _validate_bm25_k1(value: str) -> float:
+        f = float(value)
+        if f < 0.0:
+            raise argparse.ArgumentTypeError(
+                f"--bm25-k1 must be >= 0.0 (got {f})"
+            )
+        return f
+
+    def _validate_bm25_b(value: str) -> float:
+        f = float(value)
+        if not 0.0 <= f <= 1.0:
+            raise argparse.ArgumentTypeError(
+                f"--bm25-b must be between 0.0 and 1.0 (got {f})"
+            )
+        return f
+
     parser.add_argument(
         "--bm25-k1",
-        type=float,
+        type=_validate_bm25_k1,
         default=1.5,
         help="BM25 k1パラメータ（デフォルト: 1.5）",
     )
     parser.add_argument(
         "--bm25-b",
-        type=float,
+        type=_validate_bm25_b,
         default=0.75,
         help="BM25 bパラメータ（デフォルト: 0.75）",
     )

--- a/src/rag/cli.py
+++ b/src/rag/cli.py
@@ -32,6 +32,8 @@ class EvaluationParams(TypedDict):
     threshold: float | None
     vector_weight: float | None
     n_results: int
+    k1: float
+    b: float
 
 
 class RegressionInfo(TypedDict):
@@ -128,15 +130,31 @@ def main() -> None:
         required=True,
         help="チャンクオーバーラップ",
     )
+    def _validate_bm25_k1(value: str) -> float:
+        f = float(value)
+        if f < 0.0:
+            raise argparse.ArgumentTypeError(
+                f"--bm25-k1 must be >= 0.0 (got {f})"
+            )
+        return f
+
+    def _validate_bm25_b(value: str) -> float:
+        f = float(value)
+        if not 0.0 <= f <= 1.0:
+            raise argparse.ArgumentTypeError(
+                f"--bm25-b must be between 0.0 and 1.0 (got {f})"
+            )
+        return f
+
     eval_parser.add_argument(
         "--bm25-k1",
-        type=float,
+        type=_validate_bm25_k1,
         default=1.5,
         help="BM25 k1パラメータ（デフォルト: 1.5）",
     )
     eval_parser.add_argument(
         "--bm25-b",
-        type=float,
+        type=_validate_bm25_b,
         default=0.75,
         help="BM25 bパラメータ（デフォルト: 0.75）",
     )
@@ -353,6 +371,8 @@ async def run_evaluation(args: argparse.Namespace) -> None:
         threshold=args.threshold,
         vector_weight=args.vector_weight,
         n_results=args.n_results,
+        k1=bm25_k1,
+        b=bm25_b,
     )
 
     # レポート出力
@@ -493,7 +513,12 @@ def write_markdown_report(
     if params is not None:
         threshold_str = str(params["threshold"]) if params["threshold"] is not None else "None (設定値)"
         vw_str = str(params["vector_weight"]) if params["vector_weight"] is not None else "None (設定値)"
-        lines.append(f"**パラメータ**: threshold={threshold_str}, vector_weight={vw_str}, n_results={params['n_results']}")
+        k1_str = str(params.get("k1", 1.5))
+        b_str = str(params.get("b", 0.75))
+        lines.append(
+            f"**パラメータ**: threshold={threshold_str}, vector_weight={vw_str}, "
+            f"n_results={params['n_results']}, k1={k1_str}, b={b_str}",
+        )
     lines.append("")
     lines.extend([
         "## サマリー",

--- a/tests/test_rag_cli.py
+++ b/tests/test_rag_cli.py
@@ -716,6 +716,60 @@ class TestCLIEvaluate:
                     assert call_kwargs[1]["chunk_overlap"] == 50
 
     @pytest.mark.asyncio
+    async def test_ac10_bm25_params_propagation(self, tmp_path: Path) -> None:
+        """AC10: --bm25-k1/--bm25-b が_build_bm25_index_from_fixtureに正しく伝播すること."""
+        from src.rag.cli import run_evaluation
+        from argparse import Namespace
+
+        mock_report = EvaluationReport(
+            queries_evaluated=1,
+            average_precision=0.8,
+            average_recall=0.9,
+            average_f1=0.85,
+            average_ndcg=0.9,
+            average_mrr=1.0,
+            negative_source_violations=[],
+            query_results=[],
+        )
+
+        dataset = tmp_path / "dataset.json"
+        dataset.write_text(json.dumps({"queries": []}), encoding="utf-8")
+        output_dir = tmp_path / "output"
+
+        args = Namespace(
+            dataset=str(dataset),
+            output_dir=str(output_dir),
+            baseline_file=None,
+            n_results=5,
+            threshold=None,
+            vector_weight=0.6,
+            persist_dir=None,
+            fail_on_regression=False,
+            regression_threshold=0.1,
+            save_baseline=False,
+            chunk_size=200,
+            chunk_overlap=30,
+            bm25_k1=2.0,
+            bm25_b=0.5,
+        )
+
+        mock_eval = AsyncMock(return_value=mock_report)
+        mock_bm25_builder = MagicMock(return_value=MagicMock())
+        with patch("src.rag.cli._build_bm25_index_from_fixture", mock_bm25_builder):
+            with patch("src.rag.cli.create_rag_service") as mock_create_service:
+                with patch("src.rag.cli.evaluate_retrieval", new=mock_eval):
+                    mock_service = AsyncMock()
+                    mock_create_service.return_value = mock_service
+
+                    await run_evaluation(args)
+
+                    # BM25構築にk1/bパラメータが渡されたか確認
+                    mock_bm25_builder.assert_called_once()
+                    bm25_kwargs = mock_bm25_builder.call_args
+                    assert bm25_kwargs[1]["k1"] == 2.0
+                    assert bm25_kwargs[1]["b"] == 0.5
+
+    @pytest.mark.asyncio
     async def test_ac13_params_in_json_report(self, tmp_path: Path) -> None:
         """AC13: レポートに評価パラメータが含まれること."""
         from src.rag.cli import run_evaluation
@@ -749,6 +803,8 @@ class TestCLIEvaluate:
             save_baseline=False,
             chunk_size=200,
             chunk_overlap=30,
+            bm25_k1=2.0,
+            bm25_b=0.5,
         )
 
         mock_eval = AsyncMock(return_value=mock_report)
@@ -769,6 +825,8 @@ class TestCLIEvaluate:
         assert data["params"]["threshold"] == 0.6
         assert data["params"]["vector_weight"] == 0.7
         assert data["params"]["n_results"] == 5
+        assert data["params"]["k1"] == 2.0
+        assert data["params"]["b"] == 0.5
 
     @pytest.mark.asyncio
     async def test_ac6_persist_dir_option(self, tmp_path: Path) -> None:


### PR DESCRIPTION
## Change type

- [x] feat: 新機能実装 ★

## Summary

- `parameter_sweep.py` に Phase 4 (BM25 k1/b グリッドサーチ) を追加
  - k1=[0.5, 1.0, 1.5, 2.0, 2.5] × b=[0.0, 0.25, 0.5, 0.75, 1.0] の 25 組み合わせ
  - `--phase 4` で単独実行、`--phase 0` でチェーン実行 (Phase 1→2→3→4)
- `SweepResult` に k1/b フィールド追加、JSON出力・テーブル表示対応
- `_build_bm25_index_from_fixture()` に k1/b 引数追加（デフォルト値で後方互換維持）
- `run_single_evaluation()` に k1/b 引数追加
- evaluate サブコマンドに `--bm25-k1` / `--bm25-b` CLI引数追加 (AC2)
- `--best-n-results` CLI引数追加 (Phase 4 単独実行時に必要)

## Test plan

- [x] ruff lint: All checks passed
- [x] mypy: no issues found
- [x] pytest: 57 passed (既存テストへの影響なし)
- [ ] Phase 4 単独実行で k1/b グリッドサーチが動作すること
- [ ] Phase 0 チェーン実行で Phase 1→2→3→4 が連続実行されること

## Related issues

Closes #534