### PR TITLE
feat(f9): ハイブリッド検索に combined_score 下限閾値を追加 (#538)

### DIFF
--- a/src/services/rag_knowledge.py
+++ b/src/services/rag_knowledge.py
@@ -99,6 +99,7 @@ class RAGKnowledgeService:
         bm25_index: BM25Index | None = None,
         hybrid_search_enabled: bool = False,
         vector_weight: float = 1.0,
+        min_combined_score: float | None = None,
         debug_log_enabled: bool = False,
     ) -> None:
         """RAGKnowledgeServiceを初期化する.
@@ -113,6 +114,7 @@ class RAGKnowledgeService:
             bm25_index: BM25インデックス（オプション、ハイブリッド検索用）
             hybrid_search_enabled: ハイブリッド検索の有効/無効
             vector_weight: ベクトル検索の重み（ハイブリッド検索用）
+            min_combined_score: combined_scoreの下限閾値（None=フィルタなし）
             debug_log_enabled: RAGデバッグログの有効/無効
         """
         self._vector_store = vector_store
@@ -123,6 +125,7 @@ class RAGKnowledgeService:
         self._safe_browsing_client = safe_browsing_client
         self._bm25_index = bm25_index
         self._hybrid_search_enabled = hybrid_search_enabled
+        self._min_combined_score = min_combined_score
         self._debug_log_enabled = debug_log_enabled
         self._hybrid_search_engine: HybridSearchEngine | None = None
 
@@ -452,6 +455,7 @@ class RAGKnowledgeService:
             query,
             n_results=n_results,
             similarity_threshold=self._similarity_threshold,
+            min_combined_score=self._min_combined_score,
         )
 
         if not results:


### PR DESCRIPTION
## Change type

- [x] feat: 新機能実装 ★
- [x] test: テスト追加・修正

## Summary

- `HybridSearchEngine.search()` に `min_combined_score` パラメータを追加し、combined_score が閾値未満の結果をフィルタリング
- `RAGKnowledgeService` / `create_rag_service()` / `EvaluationParams` に `min_combined_score` を伝播
- `evaluate` CLI サブコマンドに `--min-combined-score` 引数を追加
- `parameter_sweep.py` に Phase 5（min_combined_score スイープ）を追加
  - スイープ値: `[None, 0.50, 0.55, 0.60, 0.65, 0.70, 0.75, 0.80, 0.85]`
  - CLI引数 `--best-k1` / `--best-b` / `--min-combined-score` を追加
  - `SweepResult` / `_sweep_result_to_dict` / `_build_json_output` / FINAL SUMMARY に Phase 5 対応
- テスト3件追加（min_combined_score フィルタリング、None 時の全結果返却、CLI 伝播）

## Test plan

- [x] `test_min_combined_score_filters_low_results`: 低スコア結果がフィルタリングされること
- [x] `test_min_combined_score_none_returns_all`: None 時は全結果を返すこと
- [x] `test_ac11_min_combined_score_propagation`: CLI から create_rag_service へ伝播すること
- [x] 既存テスト 653 passed（後方互換: min_combined_score=None がデフォルト）
- [x] ruff / mypy 全チェック通過
- [ ] Phase 5 スイープ実行で最適値を確認（PR作成後に実施）

## Related issues

Closes #538