### PR TITLE
fix: RAG評価レポートの出力先を .tmp 配下に変更

### DIFF
--- a/src/rag/cli.py
+++ b/src/rag/cli.py
@@ -62,7 +62,7 @@ def main() -> None:
     )
     eval_parser.add_argument(
         "--output-dir",
-        default="reports/rag-evaluation",
+        default=".tmp/rag-evaluation",
         help="レポート出力ディレクトリ",
     )
     eval_parser.add_argument(


### PR DESCRIPTION
## Change type

- [x] fix: バグ修正

## Summary

- 評価CLI (`src/rag/cli.py`) の `--output-dir` デフォルト値を `reports/rag-evaluation` → `.tmp/rag-evaluation` に変更
- `reports/` は `.gitignore` 対象外のため、評価実行後に `git status` に出てしまう問題を修正
- `.tmp/` は既に `.gitignore` に含まれている

## Test plan

- [x] `--output-dir` のデフォルト値が `.tmp/rag-evaluation` であることを確認