### PR TITLE
docs: release ブランチ上の修正をbugfix PR経由にするルールを追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,8 +57,8 @@
 - **作業ブランチ**: `feature/f{N}-{機能名}-#{Issue番号}` / `bugfix/{修正内容}-#{Issue番号}` / `release/v{X.Y.Z}` / `hotfix/{修正内容}-#{Issue番号}`
 - コミット: `feat(f{N}): 説明 (#{Issue番号})`
 - PR作成時に `Closes #{Issue番号}` で紐付け
-- **PRのbaseブランチ**: 通常は `develop`、リリース/hotfix は `main`
-- **マージ方式**: feature/bugfix → develop は通常マージ、release → main は squash マージ
+- **PRのbaseブランチ**: 通常は `develop`、リリース/hotfix は `main`、リリース中の bugfix は `release/*`
+- **マージ方式**: feature/bugfix → develop は通常マージ、bugfix → release は通常マージ、release → main は squash マージ
 - **サブIssue作成**: `gh` CLI は未サポートのため GraphQL API を使用（`gh api graphql` の `addSubIssue` mutation）。親・子の Node ID は `gh issue view <番号> --json id --jq '.id'` で取得し、直接埋め込む
 
 ### 実装完了時の必須手順

--- a/docs/specs/git-flow.md
+++ b/docs/specs/git-flow.md
@@ -59,7 +59,7 @@ gitGraph
 | プレフィックス | 用途 | ベース | マージ先 | 命名規則 |
 |--------------|------|--------|---------|---------|
 | `feature/` | 新機能開発 | `develop` | `develop` | `feature/f{N}-{機能名}-#{Issue番号}` |
-| `bugfix/` | バグ修正 | `develop` or `release/*` | `develop` or `release/*` | `bugfix/{修正内容}-#{Issue番号}` |
+| `bugfix/` | バグ修正 | `develop` または対象 `release/*` | ベースと同一ブランチ | `bugfix/{修正内容}-#{Issue番号}` |
 | `release/` | リリース準備 | `develop` | `main`（squash） | `release/v{X.Y.Z}` |
 | `hotfix/` | 本番緊急修正 | `main` | `main` + `develop` | `hotfix/{修正内容}-#{Issue番号}` |
 | `claude/` | Claude Code自動生成 | `develop`(*) | `develop` | `claude/issue-{N}-{date}-{id}`（自動命名） |
@@ -123,7 +123,7 @@ sequenceDiagram
 リリース準備中に修正が必要な場合、release ブランチに直接コミットせず、bugfix ブランチを経由してPRでマージする。
 
 - **理由**: release PRに修正を直接混ぜると、どの時点で何が修正されたか追跡しづらくなる。PR単位で修正履歴を残すことでトレーサビリティを確保する
-- **ブランチ命名**: `bugfix/{修正内容}` （release ブランチからの分岐）
+- **ブランチ命名**: `bugfix/{修正内容}-#{Issue番号}` （release ブランチからの分岐。Issue がない軽微な修正は番号省略可）
 - **マージ先**: `release/v{X.Y.Z}`
 - **マージ方式**: 通常マージ
 
@@ -131,7 +131,7 @@ sequenceDiagram
 # release ブランチから bugfix ブランチを作成
 git checkout -b bugfix/fix-something release/v0.0.1
 
-# 修正・コミット
+# 修正して push
 git push -u origin bugfix/fix-something
 
 # release ブランチに向けてPR作成
@@ -213,6 +213,7 @@ sequenceDiagram
 
 - PRタイトル例: `fix: 修正内容`
 - `release/v{X.Y.Z}` をbaseとする
+- CIチェック必須
 - リリースPRに直接コミットせず、必ずPR経由でマージする
 
 ### release → main
@@ -286,7 +287,7 @@ sequenceDiagram
 - [x] AC3: `CLAUDE.md` のGit運用セクションが git-flow に対応している
 - [x] AC4: `docs/specs/overview.md` のGit運用セクションが更新されている
 - [x] AC5: `README.md` の開発フロー概要が更新されている
-- [x] AC6: feature/bugfix ブランチは `develop` からの分岐・マージで運用される
+- [x] AC6: feature/bugfix ブランチは `develop` からの分岐・マージで運用される（bugfix は `release/*` からの分岐・マージも可）
 - [x] AC7: GitHub Actions（claude.yml, pr-review.yml）が `develop` ベースで正しく動作する
 - [ ] AC8: `main` への反映は `release/v{X.Y.Z}` ブランチを経由して行われる
 - [ ] AC9: `release/v{X.Y.Z}` → `main` は squash マージで行われる

--- a/docs/specs/overview.md
+++ b/docs/specs/overview.md
@@ -125,7 +125,7 @@ git-flow ベースのブランチ戦略を採用。詳細は [git-flow.md](git-f
 - **常設ブランチ**: `main`（安定版）/ `develop`（開発統合）
 - **作業ブランチ**:
   - `feature/f{N}-{機能名}-#{Issue番号}` — 新機能（`develop` → `develop`）
-  - `bugfix/{修正内容}-#{Issue番号}` — バグ修正（`develop` → `develop`）
+  - `bugfix/{修正内容}-#{Issue番号}` — バグ修正（`develop` → `develop` / `release/*` → `release/*`）
   - `release/v{X.Y.Z}` — リリース準備（`develop` → `main` squash マージ）
   - `hotfix/{修正内容}-#{Issue番号}` — 緊急修正（`main` → `main` + `develop`）
 - コミット: `feat(f{N}): 説明 (#{Issue番号})`


### PR DESCRIPTION
## Summary

- release ブランチ上の修正を直接コミットせず、bugfix PR 経由でマージする運用ルールを git-flow 仕様に追加
- 作業ブランチ表・リリースフロー・マージ方式表・PR運用セクションを更新

## 変更内容

- `bugfix/` のベースに `release/*` を追加
- リリースフローの手順にbugfix PR経由の修正フローを追記
- mermaid シーケンス図にbugfixフローを反映
- 「release ブランチ上の修正」詳細セクションを新設
- マージ方式表に `bugfix → release` 行を追加
- PR運用セクションに `bugfix → release` を追加

## Test plan

- [ ] markdownlint 通過確認済み
- [ ] 仕様書の整合性確認（作業ブランチ表・フロー・マージ方式表・PR運用が一貫している）