### PR TITLE
sync: main → develop (release/v0.0.1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,8 +57,8 @@
 - **作業ブランチ**: `feature/f{N}-{機能名}-#{Issue番号}` / `bugfix/{修正内容}-#{Issue番号}` / `release/v{X.Y.Z}` / `hotfix/{修正内容}-#{Issue番号}`
 - コミット: `feat(f{N}): 説明 (#{Issue番号})`
 - PR作成時に `Closes #{Issue番号}` で紐付け
-- **PRのbaseブランチ**: 通常は `develop`、リリース/hotfix は `main`
-- **マージ方式**: feature/bugfix → develop は通常マージ、release → main は squash マージ
+- **PRのbaseブランチ**: 通常は `develop`、リリース/hotfix は `main`、リリース中の bugfix は `release/*`
+- **マージ方式**: feature/bugfix → develop は通常マージ、bugfix → release は通常マージ、release → main は squash マージ
 - **サブIssue作成**: `gh` CLI は未サポートのため GraphQL API を使用（`gh api graphql` の `addSubIssue` mutation）。親・子の Node ID は `gh issue view <番号> --json id --jq '.id'` で取得し、直接埋め込む
 
 ### 実装完了時の必須手順

--- a/docs/specs/git-flow.md
+++ b/docs/specs/git-flow.md
@@ -59,7 +59,7 @@ gitGraph
 | プレフィックス | 用途 | ベース | マージ先 | 命名規則 |
 |--------------|------|--------|---------|---------|
 | `feature/` | 新機能開発 | `develop` | `develop` | `feature/f{N}-{機能名}-#{Issue番号}` |
-| `bugfix/` | バグ修正 | `develop` | `develop` | `bugfix/{修正内容}-#{Issue番号}` |
+| `bugfix/` | バグ修正 | `develop` または対象 `release/*` | ベースと同一ブランチ | `bugfix/{修正内容}-#{Issue番号}` |
 | `release/` | リリース準備 | `develop` | `main`（squash） | `release/v{X.Y.Z}` |
 | `hotfix/` | 本番緊急修正 | `main` | `main` + `develop` | `hotfix/{修正内容}-#{Issue番号}` |
 | `claude/` | Claude Code自動生成 | `develop`(*) | `develop` | `claude/issue-{N}-{date}-{id}`（自動命名） |
@@ -96,23 +96,47 @@ sequenceDiagram
     participant Dev as 開発者
     participant Develop as develop
     participant Release as release/vX.Y.Z
+    participant Bugfix as bugfix/*
     participant Main as main
 
     Dev->>Develop: 機能がまとまった状態を確認
     Dev->>Release: develop から release/vX.Y.Z を作成
-    Note over Release: リリース準備（必要に応じて修正）
     Dev->>Main: PR作成（release/vX.Y.Z → main）
+    Note over Release: リリース準備中に修正が必要な場合
+    Dev->>Bugfix: release/vX.Y.Z から分岐
+    Dev->>Bugfix: 修正コミット
+    Dev->>Release: PR作成（bugfix → release）・マージ
     Note over Main: CI実行
     Main->>Main: Squash and merge
     Dev->>Develop: main → develop に差分反映
 ```
 
 1. ある程度機能がまとまったタイミングで `develop` から `release/v{X.Y.Z}` ブランチを作成
-2. リリース準備（必要に応じてバージョン番号の更新、軽微な修正等）
-3. `release/v{X.Y.Z}` → `main` に向けてPR作成
+2. `release/v{X.Y.Z}` → `main` に向けてPR作成（リリースPR）
+3. リリース準備中に修正が必要な場合は、bugfix ブランチを `release/*` から作成し、PRで `release/*` にマージする（詳細は下記「release ブランチ上の修正」参照）
 4. マージ方法: **Squash and merge**（リリース単位で1コミットにまとめる。詳細は「マージ方式」セクション参照）
 5. マージ判断は開発者が行う
 6. **main マージ後、`main` → `develop` に差分を反映する**（履歴の整合性を保つため）
+
+#### release ブランチ上の修正
+
+リリース準備中に修正が必要な場合、release ブランチに直接コミットせず、bugfix ブランチを経由してPRでマージする。
+
+- **理由**: release PRに修正を直接混ぜると、どの時点で何が修正されたか追跡しづらくなる。PR単位で修正履歴を残すことでトレーサビリティを確保する
+- **ブランチ命名**: `bugfix/{修正内容}-#{Issue番号}` （release ブランチからの分岐。Issue がない軽微な修正は番号省略可）
+- **マージ先**: `release/v{X.Y.Z}`
+- **マージ方式**: 通常マージ
+
+```bash
+# release ブランチから bugfix ブランチを作成
+git checkout -b bugfix/fix-something release/v0.0.1
+
+# 修正して push
+git push -u origin bugfix/fix-something
+
+# release ブランチに向けてPR作成
+gh pr create --base release/v0.0.1 --head bugfix/fix-something
+```
 
 #### main → develop の差分反映
 
@@ -159,6 +183,7 @@ sequenceDiagram
 | マージ先 | 方式 | コマンド | 理由 |
 |---------|------|---------|------|
 | feature/bugfix → develop | 通常マージ | `gh pr merge --merge` | 開発履歴を保持 |
+| bugfix → release（リリース準備中の修正） | 通常マージ | `gh pr merge --merge` | 修正履歴を保持し、トレーサビリティを確保 |
 | release → main（リリース） | squash マージ | `gh pr merge --squash` | リリース単位で1コミットにまとめ、main の履歴をきれいに保つ |
 | main → develop（リリース後同期） | 通常マージ | `git merge main` or `gh pr merge --merge` | main の squash コミットを develop に取り込み、差分を解消する |
 | hotfix → main | 通常マージ | `gh pr merge --merge` | 緊急修正の履歴を保持 |
@@ -183,6 +208,13 @@ sequenceDiagram
 - `Closes #{Issue番号}` で紐付け
 - CIチェック（pytest / mypy / ruff / markdownlint）必須
 - **base ブランチ**: `develop`
+
+### bugfix → release（リリース準備中の修正）
+
+- PRタイトル例: `fix: 修正内容`
+- `release/v{X.Y.Z}` をbaseとする
+- CIチェック必須
+- リリースPRに直接コミットせず、必ずPR経由でマージする
 
 ### release → main
 
@@ -255,7 +287,7 @@ sequenceDiagram
 - [x] AC3: `CLAUDE.md` のGit運用セクションが git-flow に対応している
 - [x] AC4: `docs/specs/overview.md` のGit運用セクションが更新されている
 - [x] AC5: `README.md` の開発フロー概要が更新されている
-- [x] AC6: feature/bugfix ブランチは `develop` からの分岐・マージで運用される
+- [x] AC6: feature/bugfix ブランチは `develop` からの分岐・マージで運用される（bugfix は `release/*` からの分岐・マージも可）
 - [x] AC7: GitHub Actions（claude.yml, pr-review.yml）が `develop` ベースで正しく動作する
 - [ ] AC8: `main` への反映は `release/v{X.Y.Z}` ブランチを経由して行われる
 - [ ] AC9: `release/v{X.Y.Z}` → `main` は squash マージで行われる

--- a/docs/specs/overview.md
+++ b/docs/specs/overview.md
@@ -125,7 +125,7 @@ git-flow ベースのブランチ戦略を採用。詳細は [git-flow.md](git-f
 - **常設ブランチ**: `main`（安定版）/ `develop`（開発統合）
 - **作業ブランチ**:
   - `feature/f{N}-{機能名}-#{Issue番号}` — 新機能（`develop` → `develop`）
-  - `bugfix/{修正内容}-#{Issue番号}` — バグ修正（`develop` → `develop`）
+  - `bugfix/{修正内容}-#{Issue番号}` — バグ修正（`develop` → `develop` / `release/*` → `release/*`）
   - `release/v{X.Y.Z}` — リリース準備（`develop` → `main` squash マージ）
   - `hotfix/{修正内容}-#{Issue番号}` — 緊急修正（`main` → `main` + `develop`）
 - コミット: `feat(f{N}): 説明 (#{Issue番号})`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,17 +27,6 @@ dependencies = [
     "tzdata>=2024.1",
 ]
 
-[project.optional-dependencies]
-dev = [
-    "pytest>=8.0,<9",
-    "pytest-asyncio>=0.23,<1",
-    "pytest-cov>=5.0,<6",
-    "ruff>=0.2",
-    "mypy>=1.8",
-    "types-PyYAML>=6.0",
-    "shellcheck-py>=0.10",
-]
-
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"
@@ -75,6 +64,8 @@ dev = [
     "mypy>=1.19.1",
     "pytest>=8.4.2",
     "pytest-asyncio>=0.26.0",
+    "pytest-cov>=5.0",
     "ruff>=0.14.14",
+    "shellcheck-py>=0.10",
     "types-pyyaml>=6.0.12.20250915",
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -33,7 +33,7 @@ dependencies = [
     { name = "unidic-lite" },
 ]
 
-[package.optional-dependencies]
+[package.dev-dependencies]
 dev = [
     { name = "mypy" },
     { name = "pytest" },
@@ -41,15 +41,6 @@ dev = [
     { name = "pytest-cov" },
     { name = "ruff" },
     { name = "shellcheck-py" },
-    { name = "types-pyyaml" },
-]
-
-[package.dev-dependencies]
-dev = [
-    { name = "mypy" },
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
-    { name = "ruff" },
     { name = "types-pyyaml" },
 ]
 
@@ -66,31 +57,25 @@ requires-dist = [
     { name = "feedparser", specifier = ">=6.0,<7" },
     { name = "fugashi", specifier = ">=1.3,<2" },
     { name = "mcp", specifier = ">=1.0,<2" },
-    { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.8" },
     { name = "openai", specifier = ">=1.12,<2" },
     { name = "pydantic", specifier = ">=2.6,<3" },
     { name = "pydantic-settings", specifier = ">=2.1,<3" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0,<9" },
-    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.23,<1" },
-    { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0,<6" },
     { name = "python-dotenv", specifier = ">=1.0,<2" },
     { name = "pyyaml", specifier = ">=6.0,<7" },
-    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.2" },
-    { name = "shellcheck-py", marker = "extra == 'dev'", specifier = ">=0.10" },
     { name = "slack-bolt", specifier = ">=1.18,<2" },
     { name = "sqlalchemy", specifier = ">=2.0,<3" },
-    { name = "types-pyyaml", marker = "extra == 'dev'", specifier = ">=6.0" },
     { name = "tzdata", specifier = ">=2024.1" },
     { name = "unidic-lite", specifier = ">=1.0,<2" },
 ]
-provides-extras = ["dev"]
 
 [package.metadata.requires-dev]
 dev = [
     { name = "mypy", specifier = ">=1.19.1" },
     { name = "pytest", specifier = ">=8.4.2" },
     { name = "pytest-asyncio", specifier = ">=0.26.0" },
+    { name = "pytest-cov", specifier = ">=5.0" },
     { name = "ruff", specifier = ">=0.14.14" },
+    { name = "shellcheck-py", specifier = ">=0.10" },
     { name = "types-pyyaml", specifier = ">=6.0.12.20250915" },
 ]
 


### PR DESCRIPTION
## Summary

リリース v0.0.1 の squash マージ後、main → develop の差分反映。
コンフリクトはローカルで解消済み（main 側の内容を採用）。

### main にのみ含まれる変更

- pyproject.toml: dev依存を dependency-groups に統一（optional-dependencies dev 廃止）
- CLAUDE.md: bugfix → release のマージ方式・baseブランチ追記
- docs/specs/git-flow.md: release ブランチ上の修正をbugfix PR経由にするルール追加
- docs/specs/overview.md: bugfix の release 分岐を追記
- uv.lock: 依存変更の反映

### マージ方式

**通常マージ**（git-flow 仕様に準拠）

### 確認事項

- `git diff HEAD main --stat` で差分ゼロを確認済み