### PR TITLE
docs: リリース後のタグ付け・Release作成・sync経由の差分反映手順を追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,7 +58,7 @@
 - コミット: `feat(f{N}): 説明 (#{Issue番号})`
 - PR作成時に `Closes #{Issue番号}` で紐付け
 - **PRのbaseブランチ**: 通常は `develop`、リリース/hotfix は `main`、リリース中の bugfix は `release/*`
-- **マージ方式**: feature/bugfix → develop は通常マージ、bugfix → release は通常マージ、release → main は squash マージ
+- **マージ方式**: feature/bugfix → develop は通常マージ、bugfix → release は通常マージ、release → main は squash マージ、sync → develop は通常マージ
 - **サブIssue作成**: `gh` CLI は未サポートのため GraphQL API を使用（`gh api graphql` の `addSubIssue` mutation）。親・子の Node ID は `gh issue view <番号> --json id --jq '.id'` で取得し、直接埋め込む
 
 ### 実装完了時の必須手順

--- a/docs/specs/overview.md
+++ b/docs/specs/overview.md
@@ -128,7 +128,8 @@ git-flow ベースのブランチ戦略を採用。詳細は [git-flow.md](git-f
   - `bugfix/{修正内容}-#{Issue番号}` — バグ修正（`develop` → `develop` / `release/*` → `release/*`）
   - `release/v{X.Y.Z}` — リリース準備（`develop` → `main` squash マージ）
   - `hotfix/{修正内容}-#{Issue番号}` — 緊急修正（`main` → `main` + `develop`）
+  - `sync/main-to-develop-v{X.Y.Z}` — リリース後の main → develop 同期（`develop` → `develop`）
 - コミット: `feat(f{N}): 説明 (#{Issue番号})`
 - PR作成時に `Closes #{Issue番号}` でIssueを紐付け（feature/bugfix: base `develop`, release/hotfix: base `main`）
-- リリース後は `main` → `develop` に差分反映（履歴の整合性維持）
+- リリース後は sync ブランチ経由で `main` → `develop` に差分反映（詳細は git-flow.md 参照）
 - マイルストーンでStep単位の進捗管理


### PR DESCRIPTION
## Summary

v0.0.1 リリースの実体験に基づき、git-flow 仕様に不足していたリリース後手順を追加。

## Change type

- docs

## Changes

- タグ付け・GitHub Release 作成手順を新設
- main → develop 差分反映を sync ブランチ経由に変更（直接PRではコンフリクトが発生するため）
- シーケンス図にタグ・Release・sync フローを追加
- 作業ブランチ表に `sync/` プレフィックスを追加
- マージ方式表を `sync → develop` に更新

## Test plan

- [ ] markdownlint 通過確認済み
- [ ] 仕様書内の整合性確認（シーケンス図・手順・ブランチ表・マージ方式表が一貫している）