### PR TITLE
docs(f5,f9): MCPServerConfig拡張フィールドとauto_context_tool方式を仕様書に反映

### DIFF
--- a/docs/specs/f9-rag.md
+++ b/docs/specs/f9-rag.md
@@ -1068,7 +1068,7 @@ async def rag_stats() -> str:
 
 ### MCP経由のRAG統合
 
-`ChatService` は RAG サービスを直接参照しない。`config/mcp_servers.json` の `auto_context_tool` 設定により、`ChatService` がユーザーの質問で `rag_search` を自動呼び出しし、結果をシステムプロンプトに注入する。
+`ChatService` は RAG サービスを直接参照しない。`config/mcp_servers.json` の `auto_context_tool` 設定により、`ChatService` がユーザーの質問で `rag_search` を自動的に呼び出し、結果をシステムプロンプトに注入する。
 
 - `ChatService` は `rag_service` 引数を持たない
 - `auto_context_tool: "rag_search"` により、LLM のツール選択に依存せずコード側で確実にRAG検索を実行する


### PR DESCRIPTION
## Change type

- [x] docs: ドキュメント更新 ★

## Summary

- `f5-mcp-integration.md`: `MCPServerConfig` に `system_instruction` / `response_instruction` / `auto_context_tool` フィールドを追加
- `f5-mcp-integration.md`: `MCPClientManager` に `get_system_instructions()` / `get_auto_context_tools()` / `get_response_instruction()` メソッドを追加
- `f5-mcp-integration.md`: `ChatService` の擬似コードを auto_context / response_instruction 処理を含む形に更新
- `f5-mcp-integration.md`: `mcp_servers.json` 設定例に RAG エントリと設定フィールド一覧表を追加
- `f9-rag.md`: チャット応答フロー図を「LLM がツール選択」から「auto_context_tool による自動注入」方式に変更
- `f9-rag.md`: 「MCP経由のRAG統合」セクションをハイブリッド構成（自動注入 + LLM 追加呼び出し可能）に書き換え
- `f9-rag.md`: `mcp_servers.json` の RAG エントリ設定例を実態に合わせて更新

## Test plan

- [x] markdownlint: 違反なし

## Related issues

Closes #564

🤖 Generated with [Claude Code](https://claude.com/claude-code)