### PR TITLE
docs: リントツール具体コマンドをCLAUDE.mdから削除しtest-runner経由に集約 (#589)

### DIFF
--- a/.claude/agents/prt-code-simplifier.md
+++ b/.claude/agents/prt-code-simplifier.md
@@ -18,7 +18,7 @@ permissionMode: default
 
 CLAUDE.md に記載されたコーディング規約に従う:
 
-- ruff でリント、mypy (strict) で型チェック
+- コード品質チェック（ruff, mypy, markdownlint, shellcheck）は test-runner エージェント経由で実行
 - 適切なインポートソートと拡張子
 - 適切なエラーハンドリングパターン
 - 一貫した命名規則

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,10 +26,8 @@
 
 - 各サービスクラスのdocstringに仕様書パスを記載: `仕様: docs/specs/f2-feed-collection.md`
 - テスト名は仕様書の受け入れ条件(AC)番号と対応: `test_ac1_rss_feed_is_fetched_and_parsed()`
-- ruff でリント、mypy (strict) で型チェック
-- markdownlint（`npx markdownlint-cli2@0.20.0`）でMarkdownチェック
-- shellcheck（`uv run shellcheck`）でシェルスクリプトチェック（`.github/scripts/` 配下）
-  - suppress コメントはディレクティブ行と説明行を分ける:
+- コード品質チェック（ruff, mypy, markdownlint, shellcheck）は test-runner エージェント経由で実行する
+- shellcheck の suppress コメントはディレクティブ行と説明行を分ける:
 
     ```bash
     # Reason for suppression

--- a/docs/specs/test-runner-agent.md
+++ b/docs/specs/test-runner-agent.md
@@ -6,7 +6,7 @@ pytest によるテスト実行およびコード品質チェック（lint・型
 
 ## 背景
 
-AI Assistantプロジェクトは仕様駆動開発を採用しており、各機能の受け入れ条件（AC）に対応するテストが `tests/` ディレクトリに配置されている。また、コーディング規約として `ruff` によるlintと `mypy` による型チェックの使用が `CLAUDE.md` で規定されている。
+AI Assistantプロジェクトは仕様駆動開発を採用しており、各機能の受け入れ条件（AC）に対応するテストが `tests/` ディレクトリに配置されている。コード品質チェック（ruff, mypy, markdownlint, shellcheck）は本エージェント経由で実行することが `CLAUDE.md` で規定されている。
 
 テスト実行およびコード品質チェックは開発フローの重要な部分だが、以下の課題がある:
 
@@ -400,7 +400,7 @@ test-runnerサブエージェントでカバレッジを測定してください
 | `docs/**/*.md`, `*.md`, `.claude/**/*.md` | Markdownチェック対象のファイル |
 | `.markdownlint-cli2.jsonc` | markdownlint設定ファイル |
 | `pyproject.toml` | pytest設定（asyncio_mode等）、ruff・mypy設定 |
-| `CLAUDE.md` | テスト実行コマンド、コーディング規約、ruff・mypy・markdownlint使用規定 |
+| `CLAUDE.md` | コーディング規約（test-runner エージェント経由での品質チェック実行を規定） |
 
 ## テスト方針
 


### PR DESCRIPTION
## Change type

- [x] docs: ドキュメント更新

## Summary

- CLAUDE.md のコーディング規約から ruff/mypy/markdownlint/shellcheck の具体コマンドを削除し、「test-runner エージェント経由で実行する」に集約
- docs/specs/test-runner-agent.md の背景セクション・関連ファイル欄を CLAUDE.md の変更に追従
- .claude/agents/prt-code-simplifier.md の旧表現（CLAUDE.md コピー）を更新

## Test plan

- [x] test-runner エージェントで品質チェック通過済み（ruff, mypy, markdownlint, shellcheck）
- [x] doc-reviewer エージェントで差分レビュー通過済み
- [x] pytest 失敗12件は #582 起因の既存バグ（Issue #590 で別途対応）

## Related issues

Closes #589