### PR TITLE
fix: test_rag_cli.py の Namespace に不足属性を追加 (#590)

### DIFF
--- a/tests/test_rag_cli.py
+++ b/tests/test_rag_cli.py
@@ -322,6 +322,10 @@ class TestCLIEvaluate:
             save_baseline=False,
             chunk_size=200,
             chunk_overlap=30,
+            fixture="tests/fixtures/rag_test_documents.json",
+            bm25_k1=1.5,
+            bm25_b=0.75,
+            min_combined_score=None,
         )
 
         with patch("mcp_servers.rag.cli._build_bm25_index_from_fixture", return_value=MagicMock()):
@@ -374,6 +378,10 @@ class TestCLIEvaluate:
             save_baseline=False,
             chunk_size=200,
             chunk_overlap=30,
+            fixture="tests/fixtures/rag_test_documents.json",
+            bm25_k1=1.5,
+            bm25_b=0.75,
+            min_combined_score=None,
         )
 
         mock_eval = AsyncMock(return_value=mock_report)
@@ -426,6 +434,10 @@ class TestCLIEvaluate:
             save_baseline=False,
             chunk_size=200,
             chunk_overlap=30,
+            fixture="tests/fixtures/rag_test_documents.json",
+            bm25_k1=1.5,
+            bm25_b=0.75,
+            min_combined_score=None,
         )
 
         with patch("mcp_servers.rag.cli._build_bm25_index_from_fixture", return_value=MagicMock()):
@@ -485,6 +497,10 @@ class TestCLIEvaluate:
             save_baseline=False,
             chunk_size=200,
             chunk_overlap=30,
+            fixture="tests/fixtures/rag_test_documents.json",
+            bm25_k1=1.5,
+            bm25_b=0.75,
+            min_combined_score=None,
         )
 
         with patch("mcp_servers.rag.cli._build_bm25_index_from_fixture", return_value=MagicMock()):
@@ -537,6 +553,10 @@ class TestCLIEvaluate:
             save_baseline=False,
             chunk_size=200,
             chunk_overlap=30,
+            fixture="tests/fixtures/rag_test_documents.json",
+            bm25_k1=1.5,
+            bm25_b=0.75,
+            min_combined_score=None,
         )
 
         mock_eval = AsyncMock(return_value=mock_report)
@@ -590,6 +610,10 @@ class TestCLIEvaluate:
             save_baseline=False,
             chunk_size=200,
             chunk_overlap=30,
+            fixture="tests/fixtures/rag_test_documents.json",
+            bm25_k1=1.5,
+            bm25_b=0.75,
+            min_combined_score=None,
         )
 
         mock_eval = AsyncMock(return_value=mock_report)
@@ -642,6 +666,10 @@ class TestCLIEvaluate:
             save_baseline=False,
             chunk_size=200,
             chunk_overlap=30,
+            fixture="tests/fixtures/rag_test_documents.json",
+            bm25_k1=1.5,
+            bm25_b=0.75,
+            min_combined_score=None,
         )
 
         mock_eval = AsyncMock(return_value=mock_report)
@@ -691,6 +719,10 @@ class TestCLIEvaluate:
             save_baseline=False,
             chunk_size=300,
             chunk_overlap=50,
+            fixture="tests/fixtures/rag_test_documents.json",
+            bm25_k1=1.5,
+            bm25_b=0.75,
+            min_combined_score=None,
         )
 
         mock_eval = AsyncMock(return_value=mock_report)
@@ -751,6 +783,8 @@ class TestCLIEvaluate:
             chunk_overlap=30,
             bm25_k1=2.0,
             bm25_b=0.5,
+            fixture="tests/fixtures/rag_test_documents.json",
+            min_combined_score=None,
         )
 
         mock_eval = AsyncMock(return_value=mock_report)
@@ -805,6 +839,8 @@ class TestCLIEvaluate:
             chunk_overlap=30,
             bm25_k1=2.0,
             bm25_b=0.5,
+            fixture="tests/fixtures/rag_test_documents.json",
+            min_combined_score=None,
         )
 
         mock_eval = AsyncMock(return_value=mock_report)
@@ -865,6 +901,10 @@ class TestCLIEvaluate:
             save_baseline=False,
             chunk_size=200,
             chunk_overlap=30,
+            fixture="tests/fixtures/rag_test_documents.json",
+            bm25_k1=1.5,
+            bm25_b=0.75,
+            min_combined_score=None,
         )
 
         mock_eval = AsyncMock(return_value=mock_report)
@@ -916,6 +956,9 @@ class TestCLIEvaluate:
             save_baseline=False,
             chunk_size=200,
             chunk_overlap=30,
+            fixture="tests/fixtures/rag_test_documents.json",
+            bm25_k1=1.5,
+            bm25_b=0.75,
             min_combined_score=0.65,
         )
 


### PR DESCRIPTION
## Change type

- [x] fix: バグ修正

## Summary

- `tests/test_rag_cli.py` の `TestCLIEvaluate` クラス全12テストで `Namespace` に不足していた属性（`fixture`, `bm25_k1`, `bm25_b`, `min_combined_score`）を追加
- PR #582 で `cli.py` の `getattr` フォールバックを直接アクセスに変更した際のテスト側更新漏れを修正

## Test plan

- [x] 修正対象の12テストが全てパス（`uv run pytest tests/test_rag_cli.py::TestCLIEvaluate -v`）
- [x] test-runner エージェントで品質チェック通過済み（ruff, mypy, markdownlint, shellcheck）

## Related issues

Closes #590