### PR TITLE
refactor: slack_client の型ヒントを AsyncWebClient に改善 (#585)

### DIFF
--- a/src/messaging/router.py
+++ b/src/messaging/router.py
@@ -26,6 +26,7 @@ from src.services.topic_recommender import TopicRecommender
 from src.services.user_profiler import UserProfiler
 
 if TYPE_CHECKING:
+    from slack_sdk.web.async_client import AsyncWebClient
     from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
     from src.mcp_bridge.client_manager import MCPClientManager
@@ -496,7 +497,7 @@ class MessageRouter:
         env_name: str = "",
         mcp_manager: MCPClientManager | None = None,
         bot_start_time: datetime | None = None,
-        slack_client: object | None = None,
+        slack_client: AsyncWebClient | None = None,
     ) -> None:
         self._messaging = messaging
         self._chat_service = chat_service

--- a/src/messaging/slack_adapter.py
+++ b/src/messaging/slack_adapter.py
@@ -11,6 +11,8 @@ from src.llm.base import Message
 from src.messaging.port import MessagingPort
 
 if TYPE_CHECKING:
+    from slack_sdk.web.async_client import AsyncWebClient
+
     from src.services.thread_history import ThreadHistoryService
 
 
@@ -22,7 +24,7 @@ class SlackAdapter(MessagingPort):
 
     def __init__(
         self,
-        slack_client: object,
+        slack_client: AsyncWebClient,
         bot_user_id: str,
         thread_history_service: ThreadHistoryService,
         format_instruction: str = "",
@@ -34,7 +36,7 @@ class SlackAdapter(MessagingPort):
 
     async def send_message(self, text: str, thread_id: str, channel: str) -> None:
         """Slack にメッセージを投稿する."""
-        await self._client.chat_postMessage(  # type: ignore[attr-defined]
+        await self._client.chat_postMessage(
             channel=channel, text=text, thread_ts=thread_id,
         )
 
@@ -47,7 +49,7 @@ class SlackAdapter(MessagingPort):
         comment: str,
     ) -> None:
         """Slack にファイルをアップロードする."""
-        await self._client.files_upload_v2(  # type: ignore[attr-defined]
+        await self._client.files_upload_v2(
             channel=channel,
             thread_ts=thread_id,
             content=content,


### PR DESCRIPTION
## Change type

- [x] refactor: リファクタリング

## Summary

- `slack_client` の型ヒントを `object` から `AsyncWebClient` に変更（3ファイル・8箇所）
- `TYPE_CHECKING` ブロックで `slack_sdk.web.async_client.AsyncWebClient` を import
- 不要になった `# type: ignore[attr-defined]` を8箇所除去
- 対象ファイル: `src/scheduler/jobs.py`, `src/messaging/router.py`, `src/messaging/slack_adapter.py`

## Test plan

- [x] pytest 678 passed
- [x] ruff 違反なし
- [x] mypy エラーなし

## Related issues

Closes #585