### PR TITLE
feat: RAG MCPサーバーに _reset_rag_service() を追加 (#586)

### DIFF
--- a/mcp_servers/rag/server.py
+++ b/mcp_servers/rag/server.py
@@ -49,6 +49,12 @@ _rag_service = None
 _init_lock = asyncio.Lock()
 
 
+def _reset_rag_service() -> None:
+    """グローバルな RAGKnowledgeService をリセットする（テスト用）."""
+    global _rag_service
+    _rag_service = None
+
+
 async def _get_rag_service() -> RAGKnowledgeService:
     """RAGKnowledgeService を遅延初期化して返す."""
     global _rag_service

--- a/tests/test_rag_mcp_server.py
+++ b/tests/test_rag_mcp_server.py
@@ -17,6 +17,13 @@ from mcp_servers.rag.rag_knowledge import (
     RawSearchResults,
     VectorSearchItem,
 )
+from mcp_servers.rag.server import _reset_rag_service
+
+
+@pytest.fixture(autouse=True)
+def _reset_rag_global_state() -> None:
+    """各テスト前にRAGサービスのグローバル状態をリセットする."""
+    _reset_rag_service()
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Change type

- [x] feat: 新機能実装
- [x] test: テスト追加・修正

## Summary

- `mcp_servers/rag/server.py` に `_reset_rag_service()` 関数を追加し、テスト時にグローバル状態をリセット可能にした
- `tests/test_rag_mcp_server.py` に `autouse=True` の fixture を追加し、各テスト前にグローバル状態をリセットするようにした

## Test plan

- [x] pytest 678 passed
- [x] ruff 違反なし
- [x] mypy エラーなし

## Related issues

Closes #586