### PR TITLE
docs(claude-code-actions): ワークフロー仕様書を新テンプレートで移行 (#636)

### DIFF
--- a/docs/specs/workflows/github/claude-code-actions.md
+++ b/docs/specs/workflows/github/claude-code-actions.md
@@ -18,19 +18,18 @@ GitHub PR や Issue で `@claude` メンションすることで Claude Code を
 | ガード | 内容 |
 | --- | --- |
 | ユーザー制限 | 許可ユーザーのみ実行可能 |
-| イベントフィルタリング | `@claude` メンションを含むコメントのみ実行 |
+| イベントフィルタリング | 対象イベントのコメントまたは本文に `@claude` メンションを含む場合のみ実行 |
 | トークン保護 | シークレット経由で参照（ハードコードしない） |
 | ターン制限 | 無限ループ防止のためターン数を制限 |
 
 ### 認証方式
 
-OAuth 認証（`CLAUDE_CODE_OAUTH_TOKEN`）を使用する。
+OAuth 認証を使用する。
 
-セットアップ手順:
+前提条件:
 
-1. Claude GitHub App をリポジトリにインストール
-2. OAuth トークンを取得
-3. リポジトリシークレットに `CLAUDE_CODE_OAUTH_TOKEN` を登録
+- GitHub Actions から Claude Code 用の OAuth アクセストークンを参照できること
+- リポジトリシークレット `CLAUDE_CODE_OAUTH_TOKEN`: Claude GitHub App により発行された OAuth トークンを格納する
 
 ## トリガー条件
 
@@ -75,4 +74,5 @@ flowchart TD
 
 ## 関連ドキュメント
 
-- `workflows/github/auto-progress` — 自動進行管理（`auto-implement` ラベルトリガーを含む）
+<!-- auto-progress は未移行。#648 で一括修正予定 -->
+- [auto-progress](auto-progress.md) — 自動進行管理（`auto-implement` ラベルトリガーを含む）


### PR DESCRIPTION
## Change type

- [x] docs(pre-impl)

## Summary

- claude-code-actions.md を workflows/github テンプレートに準拠してリライト
- ACセクション廃止、コードスニペット・設定値除去、過去情報除去
- スコープを明示（メンショントリガーのみ。auto-implement は auto-progress の範囲）
- 出力セクションに成功/失敗時の挙動を追記

## Test plan

- [x] markdownlint 0 エラー
- [x] doc-reviewer によるフルレビュー実施・指摘修正済み

## Related issues

Closes #636