### PR TITLE
test: test_ac プレフィックスを振る舞いベースのテスト名にリネーム (#673)

### DIFF
--- a/tests/test_bot_manager.py
+++ b/tests/test_bot_manager.py
@@ -1,4 +1,4 @@
-"""Bot管理コマンドのテスト (AC10-AC18, Issue #580).
+"""Bot管理コマンドのテスト (Issue #580).
 
 仕様: docs/specs/bot-process-guard.md
 """
@@ -34,7 +34,7 @@ from src.bot_manager import (
 class TestGetChildPids:
     """子プロセスPID取得のテスト."""
 
-    def test_ac17_get_child_pids_windows_returns_pids(self) -> None:
+    def test_get_child_pids_windows_returns_pids(self) -> None:
         """Windows: wmic出力から子プロセスPIDを取得する."""
         mock_result = MagicMock()
         mock_result.stdout = "ProcessId\n111\n222\n\n"
@@ -42,7 +42,7 @@ class TestGetChildPids:
             pids = _get_child_pids_windows(9999)
         assert pids == [111, 222]
 
-    def test_ac17_get_child_pids_windows_empty(self) -> None:
+    def test_get_child_pids_windows_empty(self) -> None:
         """Windows: 子プロセスがない場合は空リストを返す."""
         mock_result = MagicMock()
         mock_result.stdout = "ProcessId\n\n"
@@ -50,13 +50,13 @@ class TestGetChildPids:
             pids = _get_child_pids_windows(9999)
         assert pids == []
 
-    def test_ac17_get_child_pids_windows_wmic_not_found(self) -> None:
+    def test_get_child_pids_windows_wmic_not_found(self) -> None:
         """Windows: wmicが見つからない場合は空リストを返す."""
         with patch("src.bot_manager.subprocess.run", side_effect=FileNotFoundError()):
             pids = _get_child_pids_windows(9999)
         assert pids == []
 
-    def test_ac17_get_child_pids_unix_returns_pids(self) -> None:
+    def test_get_child_pids_unix_returns_pids(self) -> None:
         """Unix: pgrep出力から子プロセスPIDを取得する."""
         mock_result = MagicMock()
         mock_result.stdout = "111\n222\n"
@@ -64,13 +64,13 @@ class TestGetChildPids:
             pids = _get_child_pids_unix(9999)
         assert pids == [111, 222]
 
-    def test_ac17_get_child_pids_unix_pgrep_not_found(self) -> None:
+    def test_get_child_pids_unix_pgrep_not_found(self) -> None:
         """Unix: pgrepが見つからない場合は空リストを返す."""
         with patch("src.bot_manager.subprocess.run", side_effect=FileNotFoundError()):
             pids = _get_child_pids_unix(9999)
         assert pids == []
 
-    def test_ac17_get_child_pids_windows_wmic_timeout(self) -> None:
+    def test_get_child_pids_windows_wmic_timeout(self) -> None:
         """Windows: wmicがタイムアウトした場合は空リストを返す."""
         with patch(
             "src.bot_manager.subprocess.run",
@@ -79,7 +79,7 @@ class TestGetChildPids:
             pids = _get_child_pids_windows(9999)
         assert pids == []
 
-    def test_ac17_get_child_pids_unix_pgrep_timeout(self) -> None:
+    def test_get_child_pids_unix_pgrep_timeout(self) -> None:
         """Unix: pgrepがタイムアウトした場合は空リストを返す."""
         with patch(
             "src.bot_manager.subprocess.run",
@@ -95,12 +95,12 @@ class TestGetChildPids:
 
 
 class TestKillProcessTree:
-    """AC17: プロセスツリー停止のテスト."""
+    """プロセスツリー停止のテスト."""
 
-    def test_ac17_windows_kills_children_then_parent(
+    def test_windows_kills_children_then_parent(
         self, monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """AC17: Windows で子プロセスが先に停止され、その後に本体が停止される."""
+        """Windows で子プロセスが先に停止され、その後に本体が停止される."""
         monkeypatch.setattr("sys.platform", "win32")
         kill_order: list[int] = []
 
@@ -123,10 +123,10 @@ class TestKillProcessTree:
         # 子プロセス(111, 222)が先、本体(9999)が最後
         assert kill_order == [111, 222, 9999]
 
-    def test_ac17_unix_kills_children_then_parent(
+    def test_unix_kills_children_then_parent(
         self, monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """AC17: Unix で子プロセスが先に停止され、その後に本体が停止される."""
+        """Unix で子プロセスが先に停止され、その後に本体が停止される."""
         monkeypatch.setattr("sys.platform", "linux")
         kill_order: list[int] = []
 
@@ -153,10 +153,10 @@ class TestKillProcessTree:
 class TestStopBot:
     """停止処理のテスト."""
 
-    def test_ac12_stop_running_bot(
+    def test_stop_running_bot(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """AC12: 起動中のBotを停止し、PIDファイルを削除する."""
+        """起動中のBotを停止し、PIDファイルを削除する."""
         pid_file = tmp_path / "bot.pid"
         pid_file.write_text("12345", encoding="utf-8")
         monkeypatch.setattr("src.process_guard.PID_FILE", pid_file)
@@ -172,10 +172,10 @@ class TestStopBot:
         assert result is True
         mock_kill.assert_called_once_with(12345)
 
-    def test_ac13_stop_not_running(
+    def test_stop_not_running(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """AC13: Botが起動していない場合はFalseを返す."""
+        """Botが起動していない場合はFalseを返す."""
         with patch("src.bot_manager.read_pid_file", return_value=None):
             result = _stop_bot()
 
@@ -190,8 +190,8 @@ class TestStopBot:
 class TestCmdStart:
     """--start コマンドのテスト."""
 
-    def test_ac10_start_success(self, capsys: pytest.CaptureFixture[str]) -> None:
-        """AC10: 正常起動時に Running (PID=xxxx) を表示する."""
+    def test_start_success(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """正常起動時に Running (PID=xxxx) を表示する."""
         with (
             patch("src.bot_manager.read_pid_file", return_value=None),
             patch("src.bot_manager._start_bot", return_value=12345),
@@ -201,8 +201,8 @@ class TestCmdStart:
         captured = capsys.readouterr()
         assert "Running (PID=12345)" in captured.out
 
-    def test_ac11_start_already_running(self, capsys: pytest.CaptureFixture[str]) -> None:
-        """AC11: 既にBotが起動中の場合、Already running を表示して exit(1)."""
+    def test_start_already_running(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """既にBotが起動中の場合、Already running を表示して exit(1)."""
         with (
             patch("src.bot_manager.read_pid_file", return_value=12345),
             patch("src.bot_manager.is_process_alive", return_value=True),
@@ -213,8 +213,8 @@ class TestCmdStart:
         captured = capsys.readouterr()
         assert "Already running (PID=12345)" in captured.out
 
-    def test_ac10_start_with_stale_pid(self, capsys: pytest.CaptureFixture[str]) -> None:
-        """AC10: stale PIDファイルがある場合は削除して起動する."""
+    def test_start_with_stale_pid(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """stale PIDファイルがある場合は削除して起動する."""
         with (
             patch("src.bot_manager.read_pid_file", return_value=99999),
             patch("src.bot_manager.is_process_alive", return_value=False),
@@ -236,16 +236,16 @@ class TestCmdStart:
 class TestCmdStop:
     """--stop コマンドのテスト."""
 
-    def test_ac12_stop_success(self, capsys: pytest.CaptureFixture[str]) -> None:
-        """AC12: 正常停止時に Stopped を表示する."""
+    def test_stop_success(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """正常停止時に Stopped を表示する."""
         with patch("src.bot_manager._stop_bot", return_value=True):
             cmd_stop()
 
         captured = capsys.readouterr()
         assert "Stopped" in captured.out
 
-    def test_ac13_stop_not_running(self, capsys: pytest.CaptureFixture[str]) -> None:
-        """AC13: 未起動時に Not running を表示する."""
+    def test_stop_not_running(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """未起動時に Not running を表示する."""
         with patch("src.bot_manager._stop_bot", return_value=False):
             cmd_stop()
 
@@ -261,8 +261,8 @@ class TestCmdStop:
 class TestCmdRestart:
     """--restart コマンドのテスト."""
 
-    def test_ac14_restart_with_existing(self, capsys: pytest.CaptureFixture[str]) -> None:
-        """AC14: 既存プロセスあり→停止→起動."""
+    def test_restart_with_existing(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """既存プロセスあり→停止→起動."""
         with (
             patch("src.bot_manager._stop_bot", return_value=True),
             patch("src.bot_manager._start_bot", return_value=12345),
@@ -273,8 +273,8 @@ class TestCmdRestart:
         assert "Stopped" in captured.out
         assert "Running (PID=12345)" in captured.out
 
-    def test_ac14_restart_without_existing(self, capsys: pytest.CaptureFixture[str]) -> None:
-        """AC14: 既存プロセスなし→起動のみ."""
+    def test_restart_without_existing(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """既存プロセスなし→起動のみ."""
         with (
             patch("src.bot_manager._stop_bot", return_value=False),
             patch("src.bot_manager._start_bot", return_value=12345),
@@ -294,8 +294,8 @@ class TestCmdRestart:
 class TestCmdStatus:
     """--status コマンドのテスト."""
 
-    def test_ac15_status_running(self, capsys: pytest.CaptureFixture[str]) -> None:
-        """AC15: 起動中は Running (PID=xxxx) を表示し exit(0)."""
+    def test_status_running(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """起動中は Running (PID=xxxx) を表示し exit(0)."""
         with (
             patch("src.bot_manager.read_pid_file", return_value=12345),
             patch("src.bot_manager.is_process_alive", return_value=True),
@@ -307,8 +307,8 @@ class TestCmdStatus:
         captured = capsys.readouterr()
         assert "Running (PID=12345)" in captured.out
 
-    def test_ac15_status_not_running(self, capsys: pytest.CaptureFixture[str]) -> None:
-        """AC15: 未起動時は Not running を表示し exit(1)."""
+    def test_status_not_running(self, capsys: pytest.CaptureFixture[str]) -> None:
+        """未起動時は Not running を表示し exit(1)."""
         with (
             patch("src.bot_manager.read_pid_file", return_value=None),
             pytest.raises(SystemExit) as exc_info,
@@ -328,10 +328,10 @@ class TestCmdStatus:
 class TestStartBot:
     """起動処理のテスト."""
 
-    def test_ac18_log_file_created(
+    def test_log_file_created(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """AC18: .tmp/bot.log にログが出力される（ディレクトリ自動作成、stderr にファイル渡し）."""
+        """.tmp/bot.log にログが出力される（ディレクトリ自動作成、stderr にファイル渡し）."""
         log_dir = tmp_path / ".tmp"
         log_file = log_dir / "bot.log"
         monkeypatch.setattr("src.bot_manager.LOG_DIR", log_dir)
@@ -356,10 +356,10 @@ class TestStartBot:
         assert call_kwargs is not None
         assert call_kwargs.kwargs.get("stderr") is not None
 
-    def test_ac18_log_file_append_mode(
+    def test_log_file_append_mode(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """AC18: 既存ログファイルがある場合は追記モードで書き込まれる."""
+        """既存ログファイルがある場合は追記モードで書き込まれる."""
         log_dir = tmp_path / ".tmp"
         log_dir.mkdir()
         log_file = log_dir / "bot.log"
@@ -386,10 +386,10 @@ class TestStartBot:
         content = log_file.read_text(encoding="utf-8")
         assert "existing log" in content
 
-    def test_ac10_pid_file_fallback_to_proc_pid(
+    def test_pid_file_fallback_to_proc_pid(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """AC10: PIDファイルが読めない場合は proc.pid にフォールバックする."""
+        """PIDファイルが読めない場合は proc.pid にフォールバックする."""
         log_dir = tmp_path / ".tmp"
         log_file = log_dir / "bot.log"
         monkeypatch.setattr("src.bot_manager.LOG_DIR", log_dir)
@@ -407,10 +407,10 @@ class TestStartBot:
 
         assert pid == 99999
 
-    def test_ac16_start_timeout(
+    def test_start_timeout(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """AC16: タイムアウト時にエラー終了する."""
+        """タイムアウト時にエラー終了する."""
         log_dir = tmp_path / ".tmp"
         log_file = log_dir / "bot.log"
         monkeypatch.setattr("src.bot_manager.LOG_DIR", log_dir)
@@ -431,10 +431,10 @@ class TestStartBot:
         ):
             _start_bot()
 
-    def test_ac10_start_crash_cleanup(
+    def test_start_crash_cleanup(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """AC10: 子プロセス異常終了時にクリーンアップされる."""
+        """子プロセス異常終了時にクリーンアップされる."""
         log_dir = tmp_path / ".tmp"
         log_file = log_dir / "bot.log"
         monkeypatch.setattr("src.bot_manager.LOG_DIR", log_dir)
@@ -467,8 +467,8 @@ class TestStartBot:
 class TestWaitForReadyWindows:
     """Windows向け BOT_READY 待ちのテスト."""
 
-    def test_ac16_receives_bot_ready(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """AC16: BOT_READY を受信したら正常終了する."""
+    def test_receives_bot_ready(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """BOT_READY を受信したら正常終了する."""
         monkeypatch.setattr("sys.platform", "win32")
 
         mock_proc = MagicMock()
@@ -477,8 +477,8 @@ class TestWaitForReadyWindows:
         from src.bot_manager import _wait_for_ready_windows
         _wait_for_ready_windows(mock_proc, timeout=5)
 
-    def test_ac16_pipe_closed_exits(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """AC16: パイプが閉じた場合は exit(1)."""
+    def test_pipe_closed_exits(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """パイプが閉じた場合は exit(1)."""
         monkeypatch.setattr("sys.platform", "win32")
 
         mock_proc = MagicMock()
@@ -489,8 +489,8 @@ class TestWaitForReadyWindows:
         with pytest.raises(SystemExit, match="1"):
             _wait_for_ready_windows(mock_proc, timeout=5)
 
-    def test_ac16_timeout_exits(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        """AC16: タイムアウト時に exit(1)."""
+    def test_timeout_exits(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """タイムアウト時に exit(1)."""
         monkeypatch.setattr("sys.platform", "win32")
 
         mock_proc = MagicMock()
@@ -516,8 +516,8 @@ class TestWaitForReadyWindows:
 class TestWaitForReadyUnix:
     """Unix向け BOT_READY 待ちのテスト."""
 
-    def test_ac16_receives_bot_ready(self) -> None:
-        """AC16: BOT_READY を受信したら正常終了する."""
+    def test_receives_bot_ready(self) -> None:
+        """BOT_READY を受信したら正常終了する."""
         mock_proc = MagicMock()
         mock_proc.stdout.fileno.return_value = 3
         mock_proc.stdout.readline.return_value = b"BOT_READY\n"
@@ -526,8 +526,8 @@ class TestWaitForReadyUnix:
         with patch("select.select", return_value=([3], [], [])):
             _wait_for_ready_unix(mock_proc, timeout=5)
 
-    def test_ac16_pipe_closed_exits(self) -> None:
-        """AC16: パイプが閉じた場合は exit(1)."""
+    def test_pipe_closed_exits(self) -> None:
+        """パイプが閉じた場合は exit(1)."""
         mock_proc = MagicMock()
         mock_proc.stdout.fileno.return_value = 3
         mock_proc.stdout.readline.return_value = b""
@@ -540,8 +540,8 @@ class TestWaitForReadyUnix:
         ):
             _wait_for_ready_unix(mock_proc, timeout=5)
 
-    def test_ac16_timeout_exits(self) -> None:
-        """AC16: select タイムアウト時に exit(1)."""
+    def test_timeout_exits(self) -> None:
+        """select タイムアウト時に exit(1)."""
         mock_proc = MagicMock()
         mock_proc.stdout.fileno.return_value = 3
 
@@ -552,8 +552,8 @@ class TestWaitForReadyUnix:
         ):
             _wait_for_ready_unix(mock_proc, timeout=5)
 
-    def test_ac16_remaining_negative_exits(self) -> None:
-        """AC16: remaining が負になった場合もタイムアウトで exit(1)."""
+    def test_remaining_negative_exits(self) -> None:
+        """remaining が負になった場合もタイムアウトで exit(1)."""
         mock_proc = MagicMock()
         mock_proc.stdout.fileno.return_value = 3
         # 1行目はログ出力（BOT_READY でない）

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -9,8 +9,8 @@ import pytest
 from src.config.settings import Settings, load_assistant_config
 
 
-def test_ac1_settings_loads_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
-    """AC1: pydantic-settingsで.envから全設定値を読み込める."""
+def test_settings_loads_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """pydantic-settingsで.envから全設定値を読み込める."""
     monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxb-test")
     monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
@@ -25,8 +25,8 @@ def test_ac1_settings_loads_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
     assert s.online_llm_provider == "anthropic"
 
 
-def test_ac2_all_config_sections_present() -> None:
-    """AC2: Slack/OpenAI/Anthropic/LM Studio/DB/スケジューラの設定項目を網羅."""
+def test_all_config_sections_present() -> None:
+    """Slack/OpenAI/Anthropic/LM Studio/DB/スケジューラの設定項目を網羅."""
     fields = set(Settings.model_fields.keys())
     # Slack
     assert {"slack_bot_token", "slack_signing_secret", "slack_app_token"} <= fields
@@ -42,8 +42,8 @@ def test_ac2_all_config_sections_present() -> None:
     assert "timezone" in fields
 
 
-def test_ac3_assistant_yaml_loaded() -> None:
-    """AC3: assistant.yamlの読み込みユーティリティを含む.
+def test_assistant_yaml_loaded() -> None:
+    """assistant.yamlの読み込みユーティリティを含む.
 
     assistant.yamlはユーザーが自由にカスタマイズするファイルのため、
     具体的な値ではなく構造（必須キーの存在・型）のみ検証する。

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -23,8 +23,8 @@ async def session() -> AsyncGenerator[AsyncSession, None]:
     await engine.dispose()
 
 
-async def test_ac1_feed_crud(session: AsyncSession) -> None:
-    """AC1: feeds テーブルの CRUD."""
+async def test_feed_crud(session: AsyncSession) -> None:
+    """feeds テーブルの CRUD."""
     feed = Feed(url="https://example.com/rss", name="Example", category="tech")
     session.add(feed)
     await session.commit()
@@ -35,8 +35,8 @@ async def test_ac1_feed_crud(session: AsyncSession) -> None:
     assert rows[0].url == "https://example.com/rss"
 
 
-async def test_ac2_article_belongs_to_feed(session: AsyncSession) -> None:
-    """AC2: articles は feed_id で feeds に紐付く."""
+async def test_article_belongs_to_feed(session: AsyncSession) -> None:
+    """articles は feed_id で feeds に紐付く."""
     feed = Feed(url="https://example.com/rss", name="Example")
     session.add(feed)
     await session.flush()
@@ -50,8 +50,8 @@ async def test_ac2_article_belongs_to_feed(session: AsyncSession) -> None:
     assert a.feed_id == feed.id
 
 
-async def test_ac3_user_profile(session: AsyncSession) -> None:
-    """AC3: user_profiles テーブル."""
+async def test_user_profile(session: AsyncSession) -> None:
+    """user_profiles テーブル."""
     profile = UserProfile(slack_user_id="U123", interests="Python", skills="web", goals="ML")
     session.add(profile)
     await session.commit()
@@ -61,8 +61,8 @@ async def test_ac3_user_profile(session: AsyncSession) -> None:
     assert p.interests == "Python"
 
 
-async def test_ac4_conversation(session: AsyncSession) -> None:
-    """AC4: conversations テーブル."""
+async def test_conversation(session: AsyncSession) -> None:
+    """conversations テーブル."""
     conv = Conversation(slack_user_id="U123", thread_ts="123.456", role="user", content="hello")
     session.add(conv)
     await session.commit()
@@ -72,8 +72,8 @@ async def test_ac4_conversation(session: AsyncSession) -> None:
     assert c.role == "user"
 
 
-async def test_ac5_init_db_and_get_session(monkeypatch: pytest.MonkeyPatch) -> None:
-    """AC5: init_db/get_session 経由でテーブル作成とセッション取得ができる."""
+async def test_init_db_and_get_session(monkeypatch: pytest.MonkeyPatch) -> None:
+    """init_db/get_session 経由でテーブル作成とセッション取得ができる."""
     monkeypatch.setenv("DATABASE_URL", "sqlite+aiosqlite:///:memory:")
 
     # グローバル状態をリセット

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -10,8 +10,8 @@ from src.llm.factory import create_local_provider, create_online_provider, get_p
 from src.llm.lmstudio_provider import LMStudioProvider
 
 
-def test_ac1_llm_provider_abc_has_complete() -> None:
-    """AC1: LLMProvider ABCに async complete(messages) -> LLMResponse を定義."""
+def test_llm_provider_abc_has_complete() -> None:
+    """LLMProvider ABCに async complete(messages) -> LLMResponse を定義."""
     assert hasattr(LLMProvider, "complete")
     assert hasattr(LLMProvider, "is_available")
 
@@ -20,8 +20,8 @@ def test_ac1_llm_provider_abc_has_complete() -> None:
         LLMProvider()  # type: ignore[abstract]
 
 
-def test_ac2_three_providers_exist() -> None:
-    """AC2: OpenAI/Anthropic/LM Studio の3プロバイダーが存在する."""
+def test_three_providers_exist() -> None:
+    """OpenAI/Anthropic/LM Studio の3プロバイダーが存在する."""
     from src.llm.anthropic_provider import AnthropicProvider
     from src.llm.openai_provider import OpenAIProvider
 
@@ -30,8 +30,8 @@ def test_ac2_three_providers_exist() -> None:
     assert issubclass(LMStudioProvider, LLMProvider)
 
 
-def test_ac3_lmstudio_uses_openai_sdk() -> None:
-    """AC3: LM StudioはOpenAI SDKでbase_url変更で対応."""
+def test_lmstudio_uses_openai_sdk() -> None:
+    """LM StudioはOpenAI SDKでbase_url変更で対応."""
     provider = LMStudioProvider(base_url=DEFAULT_LMSTUDIO_BASE_URL)
     assert provider._client.base_url.host == "localhost"
     # base_url にホストのみ指定しても /v1 がコード側で付加される
@@ -44,8 +44,8 @@ def test_lmstudio_base_url_with_v1_suffix_no_duplication() -> None:
     assert provider._client.base_url.path == "/v1/"
 
 
-def test_ac4_factory_creates_openai_provider(monkeypatch: pytest.MonkeyPatch) -> None:
-    """AC4: ファクトリで設定値からOpenAIプロバイダーを生成できる."""
+def test_factory_creates_openai_provider(monkeypatch: pytest.MonkeyPatch) -> None:
+    """ファクトリで設定値からOpenAIプロバイダーを生成できる."""
     monkeypatch.setenv("ONLINE_LLM_PROVIDER", "openai")
     monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
     settings = Settings()
@@ -54,8 +54,8 @@ def test_ac4_factory_creates_openai_provider(monkeypatch: pytest.MonkeyPatch) ->
     assert isinstance(provider, OpenAIProvider)
 
 
-def test_ac4_factory_creates_anthropic_provider(monkeypatch: pytest.MonkeyPatch) -> None:
-    """AC4: ファクトリで設定値からAnthropicプロバイダーを生成できる."""
+def test_factory_creates_anthropic_provider(monkeypatch: pytest.MonkeyPatch) -> None:
+    """ファクトリで設定値からAnthropicプロバイダーを生成できる."""
     monkeypatch.setenv("ONLINE_LLM_PROVIDER", "anthropic")
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
     settings = Settings()
@@ -64,8 +64,8 @@ def test_ac4_factory_creates_anthropic_provider(monkeypatch: pytest.MonkeyPatch)
     assert isinstance(provider, AnthropicProvider)
 
 
-def test_ac4_factory_creates_local_provider() -> None:
-    """AC4: ファクトリでローカルプロバイダーを生成できる."""
+def test_factory_creates_local_provider() -> None:
+    """ファクトリでローカルプロバイダーを生成できる."""
     settings = Settings()
     provider = create_local_provider(settings)
     assert isinstance(provider, LMStudioProvider)

--- a/tests/test_process_guard.py
+++ b/tests/test_process_guard.py
@@ -29,12 +29,12 @@ from src.process_guard import (
 
 
 class TestPidFile:
-    """AC1, AC2: PIDファイルの読み書き・削除."""
+    """PIDファイルの読み書き・削除."""
 
-    def test_ac1_write_pid_file_creates_file(
+    def test_write_pid_file_creates_file(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """AC1: Bot起動時にPIDファイルが作成される."""
+        """Bot起動時にPIDファイルが作成される."""
         pid_file = tmp_path / "bot.pid"
         monkeypatch.setattr("src.process_guard.PID_FILE", pid_file)
 
@@ -43,10 +43,10 @@ class TestPidFile:
         assert pid_file.exists()
         assert pid_file.read_text(encoding="utf-8") == str(os.getpid())
 
-    def test_ac2_remove_pid_file_deletes_file(
+    def test_remove_pid_file_deletes_file(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """AC2: Bot終了時にPIDファイルが削除される."""
+        """Bot終了時にPIDファイルが削除される."""
         pid_file = tmp_path / "bot.pid"
         pid_file.write_text("12345", encoding="utf-8")
         monkeypatch.setattr("src.process_guard.PID_FILE", pid_file)
@@ -148,22 +148,22 @@ class TestPidFile:
 
 
 class TestIsProcessAliveUnix:
-    """AC6: Unix系OSでのプロセス生存確認."""
+    """Unix系OSでのプロセス生存確認."""
 
-    def test_ac6_alive_process_returns_true(self) -> None:
+    def test_alive_process_returns_true(self) -> None:
         """os.kill(pid, 0) が成功した場合はTrue."""
         with patch("src.process_guard.os.kill") as mock_kill:
             mock_kill.return_value = None
             assert _is_process_alive_unix(12345) is True
             mock_kill.assert_called_once_with(12345, 0)
 
-    def test_ac6_dead_process_returns_false(self) -> None:
+    def test_dead_process_returns_false(self) -> None:
         """ProcessLookupError が発生した場合はFalse."""
         with patch("src.process_guard.os.kill") as mock_kill:
             mock_kill.side_effect = ProcessLookupError()
             assert _is_process_alive_unix(12345) is False
 
-    def test_ac6_permission_error_returns_true(self) -> None:
+    def test_permission_error_returns_true(self) -> None:
         """PermissionError が発生した場合はTrue（プロセスは存在する）."""
         with patch("src.process_guard.os.kill") as mock_kill:
             mock_kill.side_effect = PermissionError()
@@ -176,23 +176,23 @@ class TestIsProcessAliveUnix:
 
 
 class TestIsProcessAliveWindows:
-    """AC5: Windowsでのプロセス生存確認."""
+    """Windowsでのプロセス生存確認."""
 
-    def test_ac5_alive_process_returns_true(self) -> None:
+    def test_alive_process_returns_true(self) -> None:
         """tasklist出力にPIDが含まれている場合はTrue."""
         mock_result = MagicMock()
         mock_result.stdout = "python.exe                   12345 Console  1    50,000 K\n"
         with patch("src.process_guard.subprocess.run", return_value=mock_result):
             assert _is_process_alive_windows(12345) is True
 
-    def test_ac5_dead_process_returns_false(self) -> None:
+    def test_dead_process_returns_false(self) -> None:
         """tasklist が "INFO: No tasks" を返す場合はFalse."""
         mock_result = MagicMock()
         mock_result.stdout = "INFO: No tasks are running which match the specified criteria.\n"
         with patch("src.process_guard.subprocess.run", return_value=mock_result):
             assert _is_process_alive_windows(12345) is False
 
-    def test_ac5_tasklist_not_found_returns_false(self) -> None:
+    def test_tasklist_not_found_returns_false(self) -> None:
         """tasklistコマンドが見つからない場合はFalse."""
         with patch(
             "src.process_guard.subprocess.run",
@@ -200,7 +200,7 @@ class TestIsProcessAliveWindows:
         ):
             assert _is_process_alive_windows(12345) is False
 
-    def test_ac5_tasklist_timeout_returns_false(self) -> None:
+    def test_tasklist_timeout_returns_false(self) -> None:
         """tasklistがタイムアウトした場合はFalse."""
         with patch(
             "src.process_guard.subprocess.run",
@@ -208,14 +208,14 @@ class TestIsProcessAliveWindows:
         ):
             assert _is_process_alive_windows(12345) is False
 
-    def test_ac5_pid_not_in_output_returns_false(self) -> None:
+    def test_pid_not_in_output_returns_false(self) -> None:
         """tasklist出力にPIDが含まれていない場合はFalse."""
         mock_result = MagicMock()
         mock_result.stdout = "python.exe                   99999 Console  1    50,000 K\n"
         with patch("src.process_guard.subprocess.run", return_value=mock_result):
             assert _is_process_alive_windows(12345) is False
 
-    def test_ac5_partial_pid_match_returns_false(self) -> None:
+    def test_partial_pid_match_returns_false(self) -> None:
         """PIDが別PIDの部分文字列として含まれる場合はFalse（誤判定防止）."""
         mock_result = MagicMock()
         # PID=123 を検索するが、出力には 12345 しかない
@@ -230,12 +230,12 @@ class TestIsProcessAliveWindows:
 
 
 class TestCheckAlreadyRunning:
-    """AC3, AC4: 重複起動チェック."""
+    """重複起動チェック."""
 
-    def test_ac3_exits_when_process_alive(
+    def test_exits_when_process_alive(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """AC3: 既にBotが起動中の場合、sys.exit(1) で終了する."""
+        """既にBotが起動中の場合、sys.exit(1) で終了する."""
         pid_file = tmp_path / "bot.pid"
         pid_file.write_text("12345", encoding="utf-8")
         monkeypatch.setattr("src.process_guard.PID_FILE", pid_file)
@@ -246,10 +246,10 @@ class TestCheckAlreadyRunning:
         ):
             check_already_running()
 
-    def test_ac4_continues_with_stale_pid(
+    def test_continues_with_stale_pid(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """AC4: stale PIDの場合、PIDファイルを削除して正常通過."""
+        """stale PIDの場合、PIDファイルを削除して正常通過."""
         pid_file = tmp_path / "bot.pid"
         pid_file.write_text("12345", encoding="utf-8")
         monkeypatch.setattr("src.process_guard.PID_FILE", pid_file)
@@ -275,12 +275,12 @@ class TestCheckAlreadyRunning:
 
 
 class TestCleanupChildren:
-    """AC7, AC8: 子プロセスクリーンアップ."""
+    """子プロセスクリーンアップ."""
 
-    def test_ac7_unix_cleanup_sends_sigterm(
+    def test_unix_cleanup_sends_sigterm(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """AC7 (Unix): 子プロセスにSIGTERMを送信する."""
+        """Unix: 子プロセスにSIGTERMを送信する."""
         import signal as sig
 
         mock_result = MagicMock()
@@ -296,10 +296,10 @@ class TestCleanupChildren:
             mock_kill.assert_any_call(111, sig.SIGTERM)
             mock_kill.assert_any_call(222, sig.SIGTERM)
 
-    def test_ac7_windows_cleanup_uses_taskkill(
+    def test_windows_cleanup_uses_taskkill(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """AC7 (Windows): wmic + taskkill で子プロセスを停止する."""
+        """Windows: wmic + taskkill で子プロセスを停止する."""
         wmic_result = MagicMock()
         wmic_result.stdout = "ProcessId\n111\n222\n\n"
         taskkill_result = MagicMock()
@@ -312,10 +312,10 @@ class TestCleanupChildren:
             # wmic 1回 + taskkill 2回 = 3回
             assert mock_run.call_count == 3
 
-    def test_ac8_cleanup_failure_does_not_raise(
+    def test_cleanup_failure_does_not_raise(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:
-        """AC8: クリーンアップ失敗時に例外を送出しない."""
+        """クリーンアップ失敗時に例外を送出しない."""
         monkeypatch.setattr("sys.platform", "linux")
 
         with patch(


### PR DESCRIPTION
## Change type

- [x] test: テスト追加・修正 ★

## Summary

- 5ファイル62件の `test_ac{N}_` プレフィックスを除去し、振る舞いベースのテスト名に統一
- docstring の `AC{N}:` プレフィックスも併せて除去
- 対象ファイル: `test_llm.py`(6件), `test_config.py`(3件), `test_db.py`(5件), `test_bot_manager.py`(32件), `test_process_guard.py`(16件)

## Test plan

- [x] `grep -rn "def test_ac[0-9]" tests/ --include="*.py"` の結果がゼロ
- [x] 全719テストがパス
- [x] ruff / mypy エラーなし

## Related issues

Closes #673