### PR TITLE
docs(claude-code-hooks): 情報補足4件を追加 (#664)

### DIFF
--- a/docs/specs/agentic/hooks/claude-code-hooks.md
+++ b/docs/specs/agentic/hooks/claude-code-hooks.md
@@ -43,6 +43,7 @@ Claude Code の hooks 機能を使用して、セッション開始時のコン�
 - `permission_prompt`: ツール許可ダイアログ表示時
 - `idle_prompt`: アイドル状態で入力待機時
 - `elicitation_dialog`: 選択肢提示時
+- `auth_success`: 認証成功時
 
 ## 処理内容
 
@@ -63,10 +64,12 @@ Claude Code の hooks 機能を使用して、セッション開始時のコン�
 
 エージェントチーム運用時に、リーダーの Edit / Write ツール使用をブロックする。
 
+**入力**: stdin から JSON を受け取り、`permission_mode` フィールドでリーダー／メンバーを判別する。
+
 **判定ロジック**:
 
 1. `permission_mode` が `"bypassPermissions"` または `"acceptEdits"` → メンバー → 通過
-2. チームディレクトリ配下にサブディレクトリなし → チーム非稼働 → 通過
+2. `~/.claude/teams/` 配下にサブディレクトリなし → チーム非稼働 → 通過
 3. チームの config.json から `pattern` を読み取る
    - `pattern` 未設定 → fail-open（通過）
    - `pattern` が `"fixed-theme"` 以外（`"mixed-genius"` 等）→ 通過
@@ -110,3 +113,7 @@ Claude Code の hooks 機能を使用して、セッション開始時のコン�
 ## 関連ドキュメント
 
 - [エージェントチーム共通仕様](../teams/common.md): リーダー管理専任ルール
+- `.claude/scripts/notify.sh`: 通知スクリプト
+- `.claude/scripts/leader-guard.sh`: リーダーガードスクリプト
+- `.claude/scripts/destructive-command-guard.sh`: 破壊コマンドガードスクリプト
+- `.claude/scripts/precompact_rule.sh`: コンテキスト圧縮前ルール注入スクリプト


### PR DESCRIPTION
## Change type

- [x] docs(pre-impl)

## Related specs

- `agentic/hooks/claude-code-hooks`

## Summary

- Notification イベントの matcher 値 `auth_success` を追加
- リーダーガードの入力方法（stdin JSON から `permission_mode` を取得）を明記
- チームディレクトリのパス `~/.claude/teams/` を明記
- 関連スクリプトファイル（`notify.sh`, `leader-guard.sh`, `destructive-command-guard.sh`, `precompact_rule.sh`）への参照を「関連ドキュメント」セクションに追加

Closes #664

🤖 Generated with [Claude Code](https://claude.com/claude-code)