### PR TITLE
fix(test-runner-agent): permissionMode を bypassPermissions に変更

### DIFF
--- a/.claude/agents/test-runner.md
+++ b/.claude/agents/test-runner.md
@@ -2,7 +2,7 @@
 name: test-runner
 description: pytest・ruff・mypy・markdownlint・shellcheck・mermaid-lint による品質チェックの実行・分析・修正提案を行う専門家。
 tools: Bash, Read, Grep, Glob, Edit
-permissionMode: default
+permissionMode: bypassPermissions
 ---
 
 ## 実行手順


### PR DESCRIPTION
## Change type

- [x] fix: バグ修正 ★

## Summary

- `test-runner` エージェントの `permissionMode` を `default` から `bypassPermissions` に変更
- Bash 複合コマンド実行時の承認プロンプト発生を解消

## Test plan

- [ ] markdownlint 通過確認済み

## Related issues

Closes #715