### PR TITLE
ci(late-review-scanner): caller workflow にヘッダコメントを追加 (#760)

### DIFF
--- a/.github/workflows/late-review-scanner.yml
+++ b/.github/workflows/late-review-scanner.yml
@@ -1,3 +1,9 @@
+# Late Review Scanner — Caller
+#
+# マージ済みPRの未解決レビュースレッドを定期スキャンし、集約Issueとして可視化。
+# Reusable Workflow (shared-workflows) を呼び出す。
+# 設計書: shared-workflows/docs/specs/late-review-scanner.md
+
 name: Late Review Scanner
 
 permissions:

--- a/docs/specs/overview.md
+++ b/docs/specs/overview.md
@@ -49,6 +49,7 @@ AI Assistantは、Slack上で動作するAIアシスタントである。
 | `PROFILER_LLM_PROVIDER` | UserProfiler | local | ユーザー情報抽出 |
 | `TOPIC_LLM_PROVIDER` | TopicRecommender | local | トピック提案 |
 | `SUMMARIZER_LLM_PROVIDER` | Summarizer | local | 記事要約 |
+
 各設定には `"local"` または `"online"` を指定する。
 `"online"` の場合、`ONLINE_LLM_PROVIDER` の設定（`"openai"` or `"anthropic"`）が使用される。
 


### PR DESCRIPTION
## Change type

- [x] ci: CI/CD改善

## Summary

- `.github/workflows/late-review-scanner.yml` に他の caller workflow と統一されたヘッダコメントを追加
  - ワークフロー名（Late Review Scanner — Caller）
  - 目的の説明（マージ済みPRの未解決レビュースレッドを定期スキャンし集約Issue化）
  - Reusable Workflow 呼び出しである旨
  - 仕様書リンク（shared-workflows/docs/specs/late-review-scanner.md）
- `docs/specs/overview.md` の markdownlint エラー修正（テーブル後の空行追加）

## Test plan

- [x] pytest: 348 passed
- [x] ruff: All checks passed
- [x] mypy: Success, no issues found
- [x] markdownlint: 0 errors

## Related issues

Closes #760

Generated with [Claude Code](https://claude.ai/code)