### PR TITLE
fix(rag-knowledge): 事後レビュー指摘対応 (#768)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -48,7 +48,7 @@ MCP サーバーは独立プロセスとして動作し、MCP プロトコル経
 |---|---|
 | `mcp_servers/weather/` | 天気予報サーバー（気象庁 API） |
 
-RAG ナレッジサーバーは rag-knowledge リポジトリに移行済み。`config/mcp_servers.json` で外部リポの RAG サーバーを stdio 起動する。
+RAG ナレッジサーバーは rag-knowledge リポジトリに移行済み。`config/mcp_servers.json` で外部リポの RAG サーバーに HTTP で接続する。
 
 ## 補助ディレクトリ
 

--- a/tests/test_message_router.py
+++ b/tests/test_message_router.py
@@ -397,6 +397,45 @@ async def test_rag_tool_not_found() -> None:
     assert "利用できません" in adapter.sent_messages[0][0]
 
 
+async def test_rag_delete_command() -> None:
+    """rag delete コマンドで rag_delete ツールが呼ばれる."""
+    mcp_manager = AsyncMock()
+    mcp_manager.call_tool.return_value = "削除しました"
+    adapter, router = _make_router(mcp_manager=mcp_manager)
+
+    await router.process_message(_make_msg("rag delete https://example.com/page"))
+
+    assert len(adapter.sent_messages) == 1
+    assert "削除しました" in adapter.sent_messages[0][0]
+    mcp_manager.call_tool.assert_called_once_with(
+        "rag_delete", {"url": "https://example.com/page"}
+    )
+
+
+async def test_rag_status_generic_error() -> None:
+    """rag status で予期しない例外が発生した場合のエラーメッセージ."""
+    mcp_manager = AsyncMock()
+    mcp_manager.call_tool.side_effect = RuntimeError("connection failed")
+    adapter, router = _make_router(mcp_manager=mcp_manager)
+
+    await router.process_message(_make_msg("rag status"))
+
+    assert len(adapter.sent_messages) == 1
+    assert "エラー" in adapter.sent_messages[0][0]
+
+
+async def test_rag_add_missing_url_shows_error() -> None:
+    """rag add で URL を省略した場合にエラーメッセージが返る."""
+    mcp_manager = AsyncMock()
+    adapter, router = _make_router(mcp_manager=mcp_manager)
+
+    await router.process_message(_make_msg("rag add"))
+
+    assert len(adapter.sent_messages) == 1
+    assert "エラー" in adapter.sent_messages[0][0]
+    mcp_manager.call_tool.assert_not_called()
+
+
 async def test_rag_without_mcp_falls_through_to_chat() -> None:
     """MCP マネージャーが無い場合は rag がチャットにフォールスルーする."""
     chat_service = AsyncMock()


### PR DESCRIPTION
## Change type

- [x] fix: バグ修正 ★
- [x] docs: ドキュメント更新
- [x] test: テスト追加・修正

## Summary

事後レビュー指摘 (Issue #768) への対応:

- **ARCHITECTURE.md**: RAG ナレッジサーバーの接続方式の記述を実態 (`config/mcp_servers.json`: `transport: "http"`) に合わせて「stdio 起動する」→「HTTP で接続する」に修正
- **tests/test_message_router.py**: rag コマンドルーティングのテスト追加
  - `rag delete` サブコマンドの正常系テスト
  - `rag status` で予期しない例外発生時のエラーハンドリングテスト
  - `rag add` で URL 省略時のエラーメッセージテスト

### 対応不要と判断した指摘

- **PR #766 指摘1** (`assistant.yaml` の `format_instruction` キー変更): コード全体で `format_instruction` キーのみ使用されており、旧キー `slack_format_instruction` の参照は存在しない。後方互換の問題なし
- **PR #764 指摘1** (`_parse_rag_command` の URL 検証): 既に `urlparse` + `netloc` による検証が実装済み

## Test plan

- [x] `uv run pytest` — 全363テスト通過
- [x] `uv run ruff check src/ tests/` — All checks passed
- [x] `uv run mypy src/` — no issues found
- [x] `npx markdownlint-cli2` — 0 error(s)

## Related issues

Closes #768

Generated with [Claude Code](https://claude.ai/code)