### PR TITLE
docs: dotfiles → agent-commons 参照更新 (#125)

### DIFF
--- a/docs/specs/overview.md
+++ b/docs/specs/overview.md
@@ -114,7 +114,7 @@ GitHub Actions ワークフローの仕様書（auto-progress, copilot-auto-fix,
 
 ### 仕様書テンプレート
 
-共通テンプレートは dotfiles（`~/.claude/docs/templates/`）で管理。一覧は `~/.claude/docs/overview.md` を参照。
+共通テンプレートは agent-commons（`~/.claude/docs/templates/`）で管理。一覧は `~/.claude/docs/overview.md` を参照。
 
 ### Git運用（git-flow）
 

--- a/docs/specs/overview.md
+++ b/docs/specs/overview.md
@@ -114,7 +114,7 @@ GitHub Actions ワークフローの仕様書（auto-progress, copilot-auto-fix,
 
 ### 仕様書テンプレート
 
-共通テンプレートは agent-commons（`~/.claude/docs/templates/`）で管理。一覧は `~/.claude/docs/overview.md` を参照。
+共通テンプレートは agent-commons リポジトリ（`~/.claude/docs/templates/`）で管理。一覧は `~/.claude/docs/overview.md` を参照。
 
 ### Git運用（git-flow）
 


### PR DESCRIPTION
## Change type

- [x] docs — Documentation only

## Summary

- `docs/specs/overview.md` のテンプレート管理先を `dotfiles` → `agent-commons` に更新

## Test plan

- [x] リポジトリ全体の「dotfiles」検索で残留 0 件を確認

## Related issues

Closes becky3/agent-commons#125

🤖 Generated with [Claude Code](https://claude.com/claude-code)