### PR TITLE
docs(rag-knowledge): RAG外部化に伴う不要情報の削除・仕様書整理 (#775)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,8 +18,6 @@ ENV/
 # Database
 *.db
 *.sqlite3
-chroma_db/
-bm25_index/
 
 # IDE
 .vscode/

--- a/docs/specs/infrastructure/rag-knowledge.md
+++ b/docs/specs/infrastructure/rag-knowledge.md
@@ -12,7 +12,7 @@ RAG 機能は独立リポジトリ（rag-knowledge）で実装・運用してお
 
 ## 制約
 
-- RAG の実装・設定・テストは rag-knowledge リポジトリで管理する。ツールの詳細仕様は rag-knowledge 側の仕様書を参照
+- RAG の実装・設定・テストは [rag-knowledge リポジトリ](https://github.com/becky3/rag-knowledge)で管理する。ツールの詳細仕様は [rag-knowledge 仕様書](https://github.com/becky3/rag-knowledge/blob/main/docs/specs/rag-knowledge.md)を参照
 - ai-assistant からは MCP サーバー設定（`config/mcp_servers.json`）で RAG サーバーに HTTP 接続する
 - RAG サーバーは別プロセスとして事前に起動しておく必要がある
 - RAG の利用可否は MCP 基盤の有効化（`MCP_ENABLED`）と MCP サーバー設定への登録で決まる
@@ -24,7 +24,7 @@ RAG 機能は独立リポジトリ（rag-knowledge）で実装・運用してお
 LLM がツールループ内で `rag_search` を呼ぶかどうかを自律的に判断する。
 MCP サーバー設定の `system_instruction` / `response_instruction` により、ナレッジベース関連の質問時に検索を促す。
 
-MCP ツールの定義・振る舞いは rag-knowledge リポジトリ側の仕様書で管理する。
+MCP ツールの定義・振る舞いは [rag-knowledge 仕様書](https://github.com/becky3/rag-knowledge/blob/main/docs/specs/rag-knowledge.md)で管理する。
 
 ## コンポーネント構成
 

--- a/docs/specs/infrastructure/rag-knowledge.md
+++ b/docs/specs/infrastructure/rag-knowledge.md
@@ -2,44 +2,33 @@
 
 ## 概要
 
-外部 Web ページから収集した知識をベクトル DB に蓄積し、
-チャット応答時に関連情報を自動検索して活用する
-RAG（Retrieval-Augmented Generation）基盤。
-
-RAG 機能は独立リポジトリ（rag-knowledge）に移行済み。
-MCP サーバーとして外部プロセスで動作し、HTTP トランスポート（Streamable HTTP）で接続する。
+RAG（Retrieval-Augmented Generation）基盤との連携仕様。
+RAG 機能は独立リポジトリ（rag-knowledge）で実装・運用しており、ai-assistant からは MCP サーバーとして HTTP 接続する。
 
 ## 背景
 
 - LLM の学習済み知識とリアルタイムの会話コンテキストのみでは、特定 Web サイトの情報に基づいた回答ができない
-- 知識ベースの蓄積・検索を MCP サーバーとして独立させ、本体アプリケーションとの疎結合を維持したい
-- 独立リポジトリ化により、RAG 固有の依存・テスト・設定を分離した
+- 知識ベースの蓄積・検索を MCP サーバーとして独立させ、本体アプリケーションとの疎結合を維持する
 
 ## 制約
 
-- RAG の実装・設定・テストは rag-knowledge リポジトリで管理する
+- RAG の実装・設定・テストは rag-knowledge リポジトリで管理する。ツールの詳細仕様は rag-knowledge 側の仕様書を参照
 - ai-assistant からは MCP サーバー設定（`config/mcp_servers.json`）で RAG サーバーに HTTP 接続する
 - RAG サーバーは別プロセスとして事前に起動しておく必要がある
-- RAG の利用可否は MCP 基盤の有効化と MCP サーバー設定への登録で決まる
+- RAG の利用可否は MCP 基盤の有効化（`MCP_ENABLED`）と MCP サーバー設定への登録で決まる
 
 ## インターフェース
 
-### MCP ツール
-
-RAG MCP サーバーが公開するツール。詳細は rag-knowledge リポジトリの仕様書を参照。
-
-| ツール | 概要 |
-| --- | --- |
-| rag_search | ベクトル検索と BM25 の生結果を個別に返す |
-| rag_add | 単一ページをクロールして取り込む |
-| rag_crawl | リンク集ページから一括クロールして取り込む |
-| rag_delete | ソース URL 指定でナレッジを削除する |
-| rag_stats | 統計情報を返す |
-
 ### チャット統合
 
-LLM がツールループ内で rag_search を呼ぶかどうかを自律的に判断する。
-MCP サーバー設定の指示文により、ナレッジベース関連の質問時に検索を促す。
+LLM がツールループ内で `rag_search` を呼ぶかどうかを自律的に判断する。
+MCP サーバー設定の `system_instruction` / `response_instruction` により、ナレッジベース関連の質問時に検索を促す。
+
+MCP ツールの定義・振る舞いは rag-knowledge リポジトリ側の仕様書で管理する。
+
+## コンポーネント構成
+
+本仕様書固有のコンポーネントはない。接続構成は [MCP 統合](mcp-integration.md) のコンポーネント構成図を参照。
 
 ## 外部連携
 
@@ -49,5 +38,5 @@ MCP サーバー設定の指示文により、ナレッジベース関連の質�
 
 ## 関連ドキュメント
 
-- [MCP 統合](mcp-integration.md) --- MCP サーバーの接続管理・ツール呼び出し基盤
-- [chat-response](../features/chat-response.md) --- チャット応答（ソース URL 付与）
+- [MCP 統合](mcp-integration.md) — MCP サーバーの接続管理・ツール呼び出し基盤
+- [chat-response](../features/chat-response.md) — チャット応答（ソース URL 付与）


### PR DESCRIPTION
## Change type

- [x] docs: ドキュメント更新

## Summary

- `.gitignore` から RAG 実装時の残存エントリ（`chroma_db/`, `bm25_index/`）を削除
- `docs/specs/infrastructure/rag-knowledge.md` を整理: MCP ツール一覧を削除し、接続設定と本リポ側の振る舞い（チャット統合）に絞った記述に変更
- テンプレート必須セクション（インターフェース・コンポーネント構成）を維持し、省略理由を明記
- ローカルの不要ファイル削除（`chroma_db/`, `bm25_index/`, `.tmp/plan/547-*`, `.tmp/rag-server.log`）

## Test plan

- [x] markdownlint 通過確認
- [x] ドキュメントレビュー実施・指摘対応済み

## Related issues

Closes #775