### PR TITLE
feat(config-management): シークレット管理を keyring に移行 (#780)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,13 +1,11 @@
-# Slack Configuration
-SLACK_BOT_TOKEN=xoxb-your-bot-token
-SLACK_SIGNING_SECRET=your-signing-secret
-SLACK_APP_TOKEN=xapp-your-app-token
+# AI Assistant — 環境依存設定（git 管理外）
+# シークレットは keyring で管理（サービス名: ai-assistant）
+# 登録方法は py-common-lib の仕様書を参照:
+# https://github.com/becky3/py-common-lib/blob/main/docs/specs/infrastructure/secret-store.md
+# 設定管理仕様: docs/specs/infrastructure/config-management.md
 
-# Delivery Channel
+# Slack
 SLACK_NEWS_CHANNEL_ID=C0123456789
-
-# Auto Reply Channels (comma-separated channel IDs)
-# Channels where the bot responds to all messages without @mention
 SLACK_AUTO_REPLY_CHANNELS=
 
 # LLM Provider Selection ("openai" or "anthropic") - used when service is set to "online"
@@ -19,31 +17,23 @@ PROFILER_LLM_PROVIDER=local
 TOPIC_LLM_PROVIDER=local
 SUMMARIZER_LLM_PROVIDER=local
 
-# OpenAI Configuration
-OPENAI_API_KEY=sk-your-openai-key
+# OpenAI
 OPENAI_MODEL=gpt-4o-mini
 
-# Anthropic Configuration
-ANTHROPIC_API_KEY=sk-ant-your-anthropic-key
+# Anthropic
 ANTHROPIC_MODEL=claude-3-5-sonnet-20241022
 
-# LM Studio Configuration
+# LM Studio
 LMSTUDIO_BASE_URL=http://localhost:1234
 LMSTUDIO_MODEL=local-model
 
 # Timezone
 TIMEZONE=Asia/Tokyo
 
-# Feed Articles Per Feed (max articles to deliver per feed, default: 10)
+# Feed
 FEED_ARTICLES_PER_FEED=50
-
-# Feed Card Layout ("vertical" or "horizontal")
 FEED_CARD_LAYOUT=horizontal
-
-# Feed Summarize Timeout (seconds, 0=unlimited, default: 180)
 FEED_SUMMARIZE_TIMEOUT=180
-
-# Feed Collect Days (default: 7) — これより古い記事は収集しない
 FEED_COLLECT_DAYS=7
 
 # Database
@@ -56,12 +46,8 @@ ENV_NAME=
 MCP_ENABLED=false
 MCP_SERVERS_CONFIG=config/mcp_servers.json
 
-# Thread History (max messages to fetch from Slack thread)
+# Thread History
 THREAD_HISTORY_LIMIT=20
-
-# RAG settings are managed in the rag-knowledge repository.
-# https://github.com/becky3/rag-knowledge
-# Local path (default): ../rag-knowledge/mcp_servers/rag/.env.example
 
 # Logging
 LOG_LEVEL=INFO

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ htmlcov/
 
 # Zenn drafts (personal, not for repository)
 docs/zenn-drafts/
+.claude/scheduled_tasks.lock

--- a/README.md
+++ b/README.md
@@ -40,21 +40,13 @@ Python 3.11+ / uv / slack-bolt / OpenAI SDK / Anthropic SDK / SQLite + SQLAlchem
 
 ```bash
 uv sync
-cp .env.example .env  # 各種トークン・APIキーを設定
+cp .env.example .env  # 環境依存値を編集
 ```
 
-### 主な環境変数
+API キー・トークンは py-common-lib の `get_secret` で OS セキュアストレージから取得する（サービス名: `ai-assistant`）。
+登録方法は [py-common-lib の仕様書](https://github.com/becky3/py-common-lib/blob/main/docs/specs/infrastructure/secret-store.md) を参照。
 
-| 変数名 | 説明 |
-|--------|------|
-| `SLACK_BOT_TOKEN` | Slack Bot トークン |
-| `SLACK_APP_TOKEN` | Slack App トークン（Socket Mode用） |
-| `SLACK_NEWS_CHANNEL_ID` | フィード配信先チャンネルID |
-| `SLACK_AUTO_REPLY_CHANNELS` | 自動返信を有効にするチャンネルID（カンマ区切り） |
-| `CHAT_LLM_PROVIDER` | チャット応答のLLMプロバイダー（`local` / `online`） |
-| `MCP_ENABLED` | MCP機能の有効/無効（`true` / `false`、デフォルト: `false`） |
-
-詳細は `.env.example` を参照してください。
+詳細は `.env.example` および [設定管理仕様](docs/specs/infrastructure/config-management.md) を参照。
 
 ## 起動
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
     "pyyaml>=6.0,<7",
     "mcp>=1.0,<2",
     "tzdata>=2024.1",
+    "py-common-lib",
 ]
 
 [build-system]
@@ -26,6 +27,9 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src"]
+
+[tool.uv.sources]
+py-common-lib = { git = "https://github.com/becky3/py-common-lib" }
 
 [tool.ruff]
 target-version = "py311"

--- a/scripts/test_delivery.py
+++ b/scripts/test_delivery.py
@@ -19,7 +19,7 @@ from datetime import datetime, timezone
 
 from slack_sdk.web.async_client import AsyncWebClient
 
-from src.config.settings import get_settings
+from src.config.settings import get_settings, resolve_secret
 from src.db.models import Article, Feed
 from src.db.session import get_session_factory, init_db
 from src.scheduler.jobs import format_daily_digest, post_article_to_thread
@@ -91,8 +91,9 @@ DUMMY_ARTICLES = [
 async def main() -> None:
     settings = get_settings()
 
-    if not settings.slack_bot_token or not settings.slack_news_channel_id:
-        print("エラー: .env に SLACK_BOT_TOKEN と SLACK_NEWS_CHANNEL_ID を設定してください")
+    bot_token = resolve_secret("SLACK_BOT_TOKEN")
+    if not bot_token or not settings.slack_news_channel_id:
+        print("エラー: SLACK_BOT_TOKEN と SLACK_NEWS_CHANNEL_ID を設定してください")
         return
 
     # 引数があればそれを使う、なければ .env の設定
@@ -166,7 +167,7 @@ async def main() -> None:
         print("配信する記事がありません")
         return
 
-    client = AsyncWebClient(token=settings.slack_bot_token)
+    client = AsyncWebClient(token=bot_token)
     channel = settings.slack_news_channel_id
 
     # ヘッダー

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -1,19 +1,51 @@
 """アプリケーション設定管理
-仕様: docs/specs/overview.md
+仕様: docs/specs/infrastructure/config-management.md
 """
 
 from __future__ import annotations
 
 import functools
+import os
 from pathlib import Path
 from typing import Any, Literal
 
 import yaml
+from dotenv import load_dotenv
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+from py_common_lib.secrets import SecretNotFoundError, SecretStoreError, get_secret
+
+# .env を os.environ に読み込む。pydantic-settings は独自に .env を読むが、
+# resolve_secret() は os.environ.get() で環境変数を参照するため別途必要。
+load_dotenv()
 
 DEFAULT_LMSTUDIO_BASE_URL = "http://localhost:1234"
+
+_SERVICE_NAME = "ai-assistant"
+
+
+def resolve_secret(key: str) -> str:
+    """環境変数 → keyring の優先順位でシークレットを取得する.
+
+    仕様: docs/specs/infrastructure/config-management.md（設定値の解決優先順位）
+
+    環境変数には .env の値も含まれる（load_dotenv() で os.environ に展開済み）。
+    環境変数が空文字列または未設定の場合は keyring にフォールバックする。
+
+    Args:
+        key: 環境変数名と同一のキー名（例: "SLACK_BOT_TOKEN"）
+
+    Returns:
+        取得したシークレット値。未設定の場合は空文字列。
+    """
+    value = os.environ.get(key, "")
+    if value:
+        return value
+    try:
+        return get_secret(key, service=_SERVICE_NAME)
+    except (SecretNotFoundError, SecretStoreError):
+        return ""
 
 
 class Settings(BaseSettings):
@@ -26,9 +58,6 @@ class Settings(BaseSettings):
     )
 
     # Slack
-    slack_bot_token: str = ""
-    slack_signing_secret: str = ""
-    slack_app_token: str = ""
     slack_news_channel_id: str = ""
     slack_auto_reply_channels: str = ""
 
@@ -48,11 +77,9 @@ class Settings(BaseSettings):
     summarizer_llm_provider: Literal["local", "online"] = "local"
 
     # OpenAI
-    openai_api_key: str = ""
     openai_model: str = "gpt-4o-mini"
 
     # Anthropic
-    anthropic_api_key: str = ""
     anthropic_model: str = "claude-3-5-sonnet-20241022"
 
     # LM Studio (ローカルLLM)

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -5,20 +5,19 @@
 from __future__ import annotations
 
 import functools
+import logging
 import os
 from pathlib import Path
 from typing import Any, Literal
 
 import yaml
-from dotenv import load_dotenv
+from dotenv import dotenv_values
 from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from py_common_lib.secrets import SecretNotFoundError, SecretStoreError, get_secret
 
-# .env を os.environ に読み込む。pydantic-settings は独自に .env を読むが、
-# resolve_secret() は os.environ.get() で環境変数を参照するため別途必要。
-load_dotenv()
+logger = logging.getLogger(__name__)
 
 DEFAULT_LMSTUDIO_BASE_URL = "http://localhost:1234"
 
@@ -26,12 +25,11 @@ _SERVICE_NAME = "ai-assistant"
 
 
 def resolve_secret(key: str) -> str:
-    """環境変数 → keyring の優先順位でシークレットを取得する.
+    """環境変数 → .env → keyring の優先順位でシークレットを取得する.
 
     仕様: docs/specs/infrastructure/config-management.md（設定値の解決優先順位）
 
-    環境変数には .env の値も含まれる（load_dotenv() で os.environ に展開済み）。
-    環境変数が空文字列または未設定の場合は keyring にフォールバックする。
+    os.environ を汚染しないよう、.env は dotenv_values() で直接読み取る。
 
     Args:
         key: 環境変数名と同一のキー名（例: "SLACK_BOT_TOKEN"）
@@ -39,12 +37,22 @@ def resolve_secret(key: str) -> str:
     Returns:
         取得したシークレット値。未設定の場合は空文字列。
     """
+    # 1. シェル環境変数
     value = os.environ.get(key, "")
     if value:
         return value
+    # 2. .env ファイル（os.environ を変更せず直接読み取り）
+    env_values = dotenv_values()
+    value = env_values.get(key) or ""
+    if value:
+        return value
+    # 3. keyring
     try:
-        return get_secret(key, service=_SERVICE_NAME)
-    except (SecretNotFoundError, SecretStoreError):
+        return get_secret(key=key, service=_SERVICE_NAME)
+    except SecretNotFoundError:
+        return ""
+    except SecretStoreError:
+        logger.warning("keyring アクセスに失敗しました: key=%s", key, exc_info=True)
         return ""
 
 

--- a/src/llm/factory.py
+++ b/src/llm/factory.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from typing import Literal
 
-from src.config.settings import Settings
+from src.config.settings import Settings, resolve_secret
 from src.llm.anthropic_provider import AnthropicProvider
 from src.llm.base import LLMProvider
 from src.llm.lmstudio_provider import LMStudioProvider
@@ -17,11 +17,11 @@ def create_online_provider(settings: Settings) -> LLMProvider:
     """設定に応じたオンラインLLMプロバイダーを生成する."""
     if settings.online_llm_provider == "anthropic":
         return AnthropicProvider(
-            api_key=settings.anthropic_api_key,
+            api_key=resolve_secret("ANTHROPIC_API_KEY"),
             model=settings.anthropic_model,
         )
     return OpenAIProvider(
-        api_key=settings.openai_api_key,
+        api_key=resolve_secret("OPENAI_API_KEY"),
         model=settings.openai_model,
     )
 

--- a/src/main.py
+++ b/src/main.py
@@ -13,7 +13,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 from zoneinfo import ZoneInfo
 
-from src.config.settings import get_settings, load_assistant_config
+from src.config.settings import get_settings, load_assistant_config, resolve_secret
 from src.process_guard import (
     BOT_READY_SIGNAL,
     check_already_running,
@@ -84,6 +84,15 @@ async def main() -> None:
     from src.slack.app import create_app, socket_mode_handler
     from src.slack.handlers import register_handlers
 
+    # 必須シークレットの起動時バリデーション（仕様: config-management.md エッジケース）
+    _required_secrets = ["SLACK_BOT_TOKEN", "SLACK_APP_TOKEN"]
+    for _key in _required_secrets:
+        if not resolve_secret(_key):
+            raise SystemExit(
+                f"必須シークレット {_key} が未設定です。"
+                f"keyring または環境変数で設定してください。"
+            )
+
     mcp_manager: MCPClientManager | None = None
     try:
         # 起動時刻を記録 (F7)
@@ -114,7 +123,7 @@ async def main() -> None:
             logger.info("MCP無効: ツール呼び出し機能はオフです")
 
         # Slack アプリ（ThreadHistoryService に必要なため先に作成）
-        app = create_app(settings)
+        app = create_app()
         slack_client = app.client
 
         # Bot User ID を取得（スレッド履歴でボットの発言を識別するため）
@@ -187,7 +196,7 @@ async def main() -> None:
             channel_id=settings.slack_news_channel_id,
             max_articles_per_feed=settings.feed_articles_per_feed,
             feed_card_layout=settings.feed_card_layout,
-            bot_token=settings.slack_bot_token,
+            bot_token=resolve_secret("SLACK_BOT_TOKEN"),
             timezone=settings.timezone,
             env_name=settings.env_name,
             mcp_manager=mcp_manager,
@@ -201,7 +210,7 @@ async def main() -> None:
         )
 
         # Socket Mode で起動（グレースフルシャットダウン対応）
-        async with socket_mode_handler(app, settings) as handler:
+        async with socket_mode_handler(app) as handler:
             print(BOT_READY_SIGNAL, flush=True)
             try:
                 await handler.start_async()  # type: ignore[no-untyped-call]

--- a/src/slack/app.py
+++ b/src/slack/app.py
@@ -10,30 +10,28 @@ from typing import AsyncIterator
 from slack_bolt.async_app import AsyncApp
 from slack_bolt.adapter.socket_mode.async_handler import AsyncSocketModeHandler
 
-from src.config.settings import Settings
+from src.config.settings import resolve_secret
 
 
-def create_app(settings: Settings) -> AsyncApp:
+def create_app() -> AsyncApp:
     """Slack Bolt AsyncApp を生成する."""
     app = AsyncApp(
-        token=settings.slack_bot_token,
-        signing_secret=settings.slack_signing_secret,
+        token=resolve_secret("SLACK_BOT_TOKEN"),
+        signing_secret=resolve_secret("SLACK_SIGNING_SECRET"),
     )
     return app
 
 
-async def start_socket_mode(app: AsyncApp, settings: Settings) -> None:
+async def start_socket_mode(app: AsyncApp) -> None:
     """Socket Mode でアプリを起動する."""
-    handler = AsyncSocketModeHandler(app, settings.slack_app_token)
+    handler = AsyncSocketModeHandler(app, resolve_secret("SLACK_APP_TOKEN"))
     await handler.start_async()  # type: ignore[no-untyped-call]
 
 
 @asynccontextmanager
-async def socket_mode_handler(
-    app: AsyncApp, settings: Settings
-) -> AsyncIterator[AsyncSocketModeHandler]:
+async def socket_mode_handler(app: AsyncApp) -> AsyncIterator[AsyncSocketModeHandler]:
     """Socket Mode ハンドラーのコンテキストマネージャー."""
-    handler = AsyncSocketModeHandler(app, settings.slack_app_token)
+    handler = AsyncSocketModeHandler(app, resolve_secret("SLACK_APP_TOKEN"))
     try:
         yield handler
     finally:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,43 +3,77 @@
 from __future__ import annotations
 
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
+from py_common_lib.secrets import SecretNotFoundError, SecretStoreError
 
-from src.config.settings import Settings, load_assistant_config
+from src.config.settings import Settings, load_assistant_config, resolve_secret
 
 
 def test_settings_loads_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
-    """pydantic-settingsで.envから全設定値を読み込める."""
-    monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxb-test")
-    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
-    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
+    """pydantic-settingsで.envから設定値を読み込める."""
     monkeypatch.setenv("DATABASE_URL", "sqlite+aiosqlite:///./test.db")
     monkeypatch.setenv("ONLINE_LLM_PROVIDER", "anthropic")
 
     s = Settings()
-    assert s.slack_bot_token == "xoxb-test"
-    assert s.openai_api_key == "sk-test"
-    assert s.anthropic_api_key == "sk-ant-test"
     assert s.database_url == "sqlite+aiosqlite:///./test.db"
     assert s.online_llm_provider == "anthropic"
 
 
 def test_all_config_sections_present() -> None:
-    """Slack/OpenAI/Anthropic/LM Studio/DB/スケジューラの設定項目を網羅."""
+    """Settings にシークレット以外の設定項目を網羅."""
     fields = set(Settings.model_fields.keys())
-    # Slack
-    assert {"slack_bot_token", "slack_signing_secret", "slack_app_token"} <= fields
-    # OpenAI
-    assert {"openai_api_key", "openai_model"} <= fields
-    # Anthropic
-    assert {"anthropic_api_key", "anthropic_model"} <= fields
+    # OpenAI (モデル名のみ、API キーは resolve_secret 経由)
+    assert "openai_model" in fields
+    # Anthropic (モデル名のみ、API キーは resolve_secret 経由)
+    assert "anthropic_model" in fields
     # LM Studio
     assert {"lmstudio_base_url", "lmstudio_model"} <= fields
     # DB
     assert "database_url" in fields
     # Timezone
     assert "timezone" in fields
+    # シークレットフィールドが Settings から削除されていること
+    assert "slack_bot_token" not in fields
+    assert "openai_api_key" not in fields
+    assert "anthropic_api_key" not in fields
+
+
+def test_resolve_secret_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """resolve_secret は環境変数を優先する."""
+    monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxb-from-env")
+    assert resolve_secret("SLACK_BOT_TOKEN") == "xoxb-from-env"
+
+
+def test_resolve_secret_from_keyring(monkeypatch: pytest.MonkeyPatch) -> None:
+    """環境変数未設定時は keyring から取得する."""
+    monkeypatch.delenv("SLACK_BOT_TOKEN", raising=False)
+    with patch("src.config.settings.get_secret", return_value="xoxb-from-keyring"):
+        assert resolve_secret("SLACK_BOT_TOKEN") == "xoxb-from-keyring"
+
+
+def test_resolve_secret_returns_empty_when_not_found(monkeypatch: pytest.MonkeyPatch) -> None:
+    """環境変数も keyring もない場合は空文字列を返す."""
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    with patch("src.config.settings.get_secret", side_effect=SecretNotFoundError("not found")):
+        assert resolve_secret("OPENAI_API_KEY") == ""
+
+
+def test_resolve_secret_returns_empty_on_store_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """keyring バックエンドアクセス失敗時も空文字列を返す."""
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    with patch("src.config.settings.get_secret", side_effect=SecretStoreError("backend error")):
+        assert resolve_secret("OPENAI_API_KEY") == ""
+
+
+def test_resolve_secret_empty_env_falls_through_to_keyring(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """環境変数が空文字列の場合は keyring にフォールバックする."""
+    monkeypatch.setenv("SLACK_BOT_TOKEN", "")
+    with patch("src.config.settings.get_secret", return_value="xoxb-from-keyring"):
+        assert resolve_secret("SLACK_BOT_TOKEN") == "xoxb-from-keyring"
 
 
 def test_assistant_yaml_loaded() -> None:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -47,32 +47,51 @@ def test_resolve_secret_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
 
 
 def test_resolve_secret_from_keyring(monkeypatch: pytest.MonkeyPatch) -> None:
-    """環境変数未設定時は keyring から取得する."""
+    """環境変数・.env 未設定時は keyring から取得する."""
     monkeypatch.delenv("SLACK_BOT_TOKEN", raising=False)
-    with patch("src.config.settings.get_secret", return_value="xoxb-from-keyring"):
+    with (
+        patch("src.config.settings.dotenv_values", return_value={}),
+        patch("src.config.settings.get_secret", return_value="xoxb-from-keyring"),
+    ):
         assert resolve_secret("SLACK_BOT_TOKEN") == "xoxb-from-keyring"
 
 
+def test_resolve_secret_from_dotenv(monkeypatch: pytest.MonkeyPatch) -> None:
+    """.env ファイルから取得できる（os.environ は汚染しない）."""
+    monkeypatch.delenv("SLACK_BOT_TOKEN", raising=False)
+    with patch("src.config.settings.dotenv_values", return_value={"SLACK_BOT_TOKEN": "xoxb-dotenv"}):
+        assert resolve_secret("SLACK_BOT_TOKEN") == "xoxb-dotenv"
+
+
 def test_resolve_secret_returns_empty_when_not_found(monkeypatch: pytest.MonkeyPatch) -> None:
-    """環境変数も keyring もない場合は空文字列を返す."""
+    """環境変数も .env も keyring もない場合は空文字列を返す."""
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-    with patch("src.config.settings.get_secret", side_effect=SecretNotFoundError("not found")):
+    with (
+        patch("src.config.settings.dotenv_values", return_value={}),
+        patch("src.config.settings.get_secret", side_effect=SecretNotFoundError("not found")),
+    ):
         assert resolve_secret("OPENAI_API_KEY") == ""
 
 
 def test_resolve_secret_returns_empty_on_store_error(monkeypatch: pytest.MonkeyPatch) -> None:
-    """keyring バックエンドアクセス失敗時も空文字列を返す."""
+    """keyring バックエンドアクセス失敗時も空文字列を返す（warning ログ出力）."""
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-    with patch("src.config.settings.get_secret", side_effect=SecretStoreError("backend error")):
+    with (
+        patch("src.config.settings.dotenv_values", return_value={}),
+        patch("src.config.settings.get_secret", side_effect=SecretStoreError("backend error")),
+    ):
         assert resolve_secret("OPENAI_API_KEY") == ""
 
 
 def test_resolve_secret_empty_env_falls_through_to_keyring(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """環境変数が空文字列の場合は keyring にフォールバックする."""
+    """環境変数が空文字列の場合は .env → keyring にフォールバックする."""
     monkeypatch.setenv("SLACK_BOT_TOKEN", "")
-    with patch("src.config.settings.get_secret", return_value="xoxb-from-keyring"):
+    with (
+        patch("src.config.settings.dotenv_values", return_value={}),
+        patch("src.config.settings.get_secret", return_value="xoxb-from-keyring"),
+    ):
         assert resolve_secret("SLACK_BOT_TOKEN") == "xoxb-from-keyring"
 
 

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -467,11 +467,7 @@ def test_settings_feed_card_layout_defaults_to_horizontal() -> None:
     """AC12.1: Settings に feed_card_layout フィールドがあり、デフォルトは 'horizontal'."""
     from src.config.settings import Settings
 
-    s = Settings(
-        slack_bot_token="x",
-        slack_signing_secret="x",
-        slack_app_token="x",
-    )
+    s = Settings()
     assert s.feed_card_layout == "horizontal"
 
 
@@ -613,9 +609,6 @@ def test_settings_rejects_invalid_feed_card_layout() -> None:
 
     with pytest.raises(ValidationError):
         Settings(
-            slack_bot_token="x",
-            slack_signing_secret="x",
-            slack_app_token="x",
             feed_card_layout="invalid",  # type: ignore[arg-type]
         )
 

--- a/uv.lock
+++ b/uv.lock
@@ -17,6 +17,7 @@ dependencies = [
     { name = "feedparser" },
     { name = "mcp" },
     { name = "openai" },
+    { name = "py-common-lib" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "python-dotenv" },
@@ -45,6 +46,7 @@ requires-dist = [
     { name = "feedparser", specifier = ">=6.0,<7" },
     { name = "mcp", specifier = ">=1.0,<2" },
     { name = "openai", specifier = ">=1.12,<2" },
+    { name = "py-common-lib", git = "https://github.com/becky3/py-common-lib" },
     { name = "pydantic", specifier = ">=2.6,<3" },
     { name = "pydantic-settings", specifier = ">=2.1,<3" },
     { name = "python-dotenv", specifier = ">=1.0,<2" },
@@ -246,6 +248,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6b/5c/685e6633917e101e5dcb62b9dd76946cbb57c26e133bae9e0cd36033c0a9/attrs-25.4.0.tar.gz", hash = "sha256:16d5969b87f0859ef33a48b35d55ac1be6e42ae49d5e853b597db70c35c57e11", size = 934251, upload-time = "2025-10-06T13:54:44.725Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3a/2a/7cc015f5b9f5db42b7d48157e23356022889fc354a2813c15934b7cb5c0e/attrs-25.4.0-py3-none-any.whl", hash = "sha256:adcf7e2a1fb3b36ac48d97835bb6d8ade15b8dcce26aba8bf1d14847b57a3373", size = 67615, upload-time = "2025-10-06T13:54:43.17Z" },
+]
+
+[[package]]
+name = "backports-tarfile"
+version = "1.2.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/86/72/cd9b395f25e290e633655a100af28cb253e4393396264a98bd5f5951d50f/backports_tarfile-1.2.0.tar.gz", hash = "sha256:d75e02c268746e1b8144c278978b6e98e85de6ad16f8e4b0844a154557eca991", size = 86406, upload-time = "2024-05-28T17:01:54.731Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b9/fa/123043af240e49752f1c4bd24da5053b6bd00cad78c2be53c0d1e8b975bc/backports.tarfile-1.2.0-py3-none-any.whl", hash = "sha256:77e284d754527b01fb1e6fa8a1afe577858ebe4e9dad8919e34c862cb399bc34", size = 30181, upload-time = "2024-05-28T17:01:53.112Z" },
 ]
 
 [[package]]
@@ -737,12 +748,69 @@ wheels = [
 ]
 
 [[package]]
+name = "importlib-metadata"
+version = "8.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "zipp", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f3/49/3b30cad09e7771a4982d9975a8cbf64f00d4a1ececb53297f1d9a7be1b10/importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb", size = 57107, upload-time = "2025-12-21T10:00:19.278Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/5e/f8e9a1d23b9c20a551a8a02ea3637b4642e22c2626e3a13a9a29cdea99eb/importlib_metadata-8.7.1-py3-none-any.whl", hash = "sha256:5a1f80bf1daa489495071efbb095d75a634cf28a8bc299581244063b53176151", size = 27865, upload-time = "2025-12-21T10:00:18.329Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "jaraco-classes"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/c0/ed4a27bc5571b99e3cff68f8a9fa5b56ff7df1c2251cc715a652ddd26402/jaraco.classes-3.4.0.tar.gz", hash = "sha256:47a024b51d0239c0dd8c8540c6c7f484be3b8fcf0b2d85c13825780d3b3f3acd", size = 11780, upload-time = "2024-03-31T07:27:36.643Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7f/66/b15ce62552d84bbfcec9a4873ab79d993a1dd4edb922cbfccae192bd5b5f/jaraco.classes-3.4.0-py3-none-any.whl", hash = "sha256:f662826b6bed8cace05e7ff873ce0f9283b5c924470fe664fff1c2f00f581790", size = 6777, upload-time = "2024-03-31T07:27:34.792Z" },
+]
+
+[[package]]
+name = "jaraco-context"
+version = "6.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "backports-tarfile", marker = "python_full_version < '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/27/7b/c3081ff1af947915503121c649f26a778e1a2101fd525f74aef997d75b7e/jaraco_context-6.1.1.tar.gz", hash = "sha256:bc046b2dc94f1e5532bd02402684414575cc11f565d929b6563125deb0a6e581", size = 15832, upload-time = "2026-03-07T15:46:04.63Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/49/c152890d49102b280ecf86ba5f80a8c111c3a155dafa3bd24aeb64fde9e1/jaraco_context-6.1.1-py3-none-any.whl", hash = "sha256:0df6a0287258f3e364072c3e40d5411b20cafa30cb28c4839d24319cecf9f808", size = 7005, upload-time = "2026-03-07T15:46:03.515Z" },
+]
+
+[[package]]
+name = "jaraco-functools"
+version = "4.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "more-itertools" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0f/27/056e0638a86749374d6f57d0b0db39f29509cce9313cf91bdc0ac4d91084/jaraco_functools-4.4.0.tar.gz", hash = "sha256:da21933b0417b89515562656547a77b4931f98176eb173644c0d35032a33d6bb", size = 19943, upload-time = "2025-12-21T09:29:43.6Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/c4/813bb09f0985cb21e959f21f2464169eca882656849adf727ac7bb7e1767/jaraco_functools-4.4.0-py3-none-any.whl", hash = "sha256:9eec1e36f45c818d9bf307c8948eb03b2b56cd44087b3cdc989abca1f20b9176", size = 10481, upload-time = "2025-12-21T09:29:42.27Z" },
+]
+
+[[package]]
+name = "jeepney"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7b/6f/357efd7602486741aa73ffc0617fb310a29b588ed0fd69c2399acbb85b0c/jeepney-0.9.0.tar.gz", hash = "sha256:cf0e9e845622b81e4a28df94c40345400256ec608d0e55bb8a3feaa9163f5732", size = 106758, upload-time = "2025-02-27T18:51:01.684Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b2/a3/e137168c9c44d18eff0376253da9f1e9234d0239e0ee230d2fee6cea8e55/jeepney-0.9.0-py3-none-any.whl", hash = "sha256:97e5714520c16fc0a45695e5365a2e11b81ea79bba796e26f9f1d178cb182683", size = 49010, upload-time = "2025-02-27T18:51:00.104Z" },
 ]
 
 [[package]]
@@ -858,6 +926,24 @@ wheels = [
 ]
 
 [[package]]
+name = "keyring"
+version = "25.7.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "importlib-metadata", marker = "python_full_version < '3.12'" },
+    { name = "jaraco-classes" },
+    { name = "jaraco-context" },
+    { name = "jaraco-functools" },
+    { name = "jeepney", marker = "sys_platform == 'linux'" },
+    { name = "pywin32-ctypes", marker = "sys_platform == 'win32'" },
+    { name = "secretstorage", marker = "sys_platform == 'linux'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/43/4b/674af6ef2f97d56f0ab5153bf0bfa28ccb6c3ed4d1babf4305449668807b/keyring-25.7.0.tar.gz", hash = "sha256:fe01bd85eb3f8fb3dd0405defdeac9a5b4f6f0439edbb3149577f244a2e8245b", size = 63516, upload-time = "2025-11-16T16:26:09.482Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/db/e655086b7f3a705df045bf0933bdd9c2f79bb3c97bfef1384598bb79a217/keyring-25.7.0-py3-none-any.whl", hash = "sha256:be4a0b195f149690c166e850609a477c532ddbfbaed96a404d4e43f8d5e2689f", size = 39160, upload-time = "2025-11-16T16:26:08.402Z" },
+]
+
+[[package]]
 name = "librt"
 version = "0.7.8"
 source = { registry = "https://pypi.org/simple" }
@@ -943,6 +1029,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/fc/6d/62e76bbb8144d6ed86e202b5edd8a4cb631e7c8130f3f4893c3f90262b10/mcp-1.26.0.tar.gz", hash = "sha256:db6e2ef491eecc1a0d93711a76f28dec2e05999f93afd48795da1c1137142c66", size = 608005, upload-time = "2026-01-24T19:40:32.468Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fd/d9/eaa1f80170d2b7c5ba23f3b59f766f3a0bb41155fbc32a69adfa1adaaef9/mcp-1.26.0-py3-none-any.whl", hash = "sha256:904a21c33c25aa98ddbeb47273033c435e595bbacfdb177f4bd87f6dceebe1ca", size = 233615, upload-time = "2026-01-24T19:40:30.652Z" },
+]
+
+[[package]]
+name = "more-itertools"
+version = "10.8.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ea/5d/38b681d3fce7a266dd9ab73c66959406d565b3e85f21d5e66e1181d93721/more_itertools-10.8.0.tar.gz", hash = "sha256:f638ddf8a1a0d134181275fb5d58b086ead7c6a72429ad725c67503f13ba30bd", size = 137431, upload-time = "2025-09-02T15:23:11.018Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a4/8e/469e5a4a2f5855992e425f3cb33804cc07bf18d48f2db061aec61ce50270/more_itertools-10.8.0-py3-none-any.whl", hash = "sha256:52d4362373dcf7c52546bc4af9a86ee7c4579df9a8dc268be0a2f949d376cc9b", size = 69667, upload-time = "2025-09-02T15:23:09.635Z" },
 ]
 
 [[package]]
@@ -1256,6 +1351,15 @@ wheels = [
 ]
 
 [[package]]
+name = "py-common-lib"
+version = "0.1.0"
+source = { git = "https://github.com/becky3/py-common-lib#65ce072c1c052269ace49495c6b4bec58efc9a10" }
+dependencies = [
+    { name = "httpx" },
+    { name = "keyring" },
+]
+
+[[package]]
 name = "pycparser"
 version = "3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1492,6 +1596,15 @@ wheels = [
 ]
 
 [[package]]
+name = "pywin32-ctypes"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/9f/01a1a99704853cb63f253eea009390c88e7131c67e66a0a02099a8c917cb/pywin32-ctypes-0.2.3.tar.gz", hash = "sha256:d162dc04946d704503b2edc4d55f3dba5c1d539ead017afa00142c38b9885755", size = 29471, upload-time = "2024-08-14T10:15:34.626Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/de/3d/8161f7711c017e01ac9f008dfddd9410dff3674334c233bde66e7ba65bbf/pywin32_ctypes-0.2.3-py3-none-any.whl", hash = "sha256:8a1513379d709975552d202d942d9837758905c8d01eb82b8bcc30918929e7b8", size = 30756, upload-time = "2024-08-14T10:15:33.187Z" },
+]
+
+[[package]]
 name = "pyyaml"
 version = "6.0.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1692,6 +1805,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/2c/aa/9f89c719c467dfaf8ad799b9bae0df494513fb21d31a6059cb5870e57e74/ruff-0.14.14-py3-none-win32.whl", hash = "sha256:b530c191970b143375b6a68e6f743800b2b786bbcf03a7965b06c4bf04568167", size = 10502442, upload-time = "2026-01-22T22:30:38.93Z" },
     { url = "https://files.pythonhosted.org/packages/87/44/90fa543014c45560cae1fffc63ea059fb3575ee6e1cb654562197e5d16fb/ruff-0.14.14-py3-none-win_amd64.whl", hash = "sha256:3dde1435e6b6fe5b66506c1dff67a421d0b7f6488d466f651c07f4cab3bf20fd", size = 11630486, upload-time = "2026-01-22T22:30:10.852Z" },
     { url = "https://files.pythonhosted.org/packages/9e/6a/40fee331a52339926a92e17ae748827270b288a35ef4a15c9c8f2ec54715/ruff-0.14.14-py3-none-win_arm64.whl", hash = "sha256:56e6981a98b13a32236a72a8da421d7839221fa308b223b9283312312e5ac76c", size = 10920448, upload-time = "2026-01-22T22:30:15.417Z" },
+]
+
+[[package]]
+name = "secretstorage"
+version = "3.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cryptography" },
+    { name = "jeepney" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b7/46/f5af3402b579fd5e11573ce652019a67074317e18c1935cc0b4ba9b35552/secretstorage-3.5.0-py3-none-any.whl", hash = "sha256:0ce65888c0725fcb2c5bc0fdb8e5438eece02c523557ea40ce0703c266248137", size = 15554, upload-time = "2025-11-23T19:02:51.545Z" },
 ]
 
 [[package]]
@@ -2043,4 +2169,13 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/f9/86/0f0dccb6e59a9e7f122c5afd43568b1d31b8ab7dda5f1b01fb5c7025c9a9/yarl-1.22.0-cp314-cp314t-win_amd64.whl", hash = "sha256:9fb17ea16e972c63d25d4a97f016d235c78dd2344820eb35bc034bc32012ee27", size = 96292, upload-time = "2025-10-06T14:12:15.398Z" },
     { url = "https://files.pythonhosted.org/packages/48/b7/503c98092fb3b344a179579f55814b613c1fbb1c23b3ec14a7b008a66a6e/yarl-1.22.0-cp314-cp314t-win_arm64.whl", hash = "sha256:9f6d73c1436b934e3f01df1e1b21ff765cd1d28c77dfb9ace207f746d4610ee1", size = 85171, upload-time = "2025-10-06T14:12:16.935Z" },
     { url = "https://files.pythonhosted.org/packages/73/ae/b48f95715333080afb75a4504487cbe142cae1268afc482d06692d605ae6/yarl-1.22.0-py3-none-any.whl", hash = "sha256:1380560bdba02b6b6c90de54133c81c9f2a453dee9912fe58c1dcced1edb7cff", size = 46814, upload-time = "2025-10-06T14:12:53.872Z" },
+]
+
+[[package]]
+name = "zipp"
+version = "3.23.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e3/02/0f2892c661036d50ede074e376733dca2ae7c6eb617489437771209d4180/zipp-3.23.0.tar.gz", hash = "sha256:a07157588a12518c9d4034df3fbbee09c814741a33ff63c05fa29d26a2404166", size = 25547, upload-time = "2025-06-08T17:06:39.4Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2e/54/647ade08bf0db230bfea292f893923872fd20be6ac6f53b2b936ba839d75/zipp-3.23.0-py3-none-any.whl", hash = "sha256:071652d6115ed432f5ce1d34c336c0adfd6a884660d1e9712a256d3d3bd4b14e", size = 10276, upload-time = "2025-06-08T17:06:38.034Z" },
 ]


### PR DESCRIPTION
## Change type

- [x] feat: 新機能実装 ★
- [x] docs: ドキュメント更新
- [x] test: テスト追加・修正

## Summary

- Settings クラスからシークレットフィールド（`slack_bot_token`, `slack_signing_secret`, `slack_app_token`, `openai_api_key`, `anthropic_api_key`）を削除
- py-common-lib の `get_secret()` + 環境変数フォールバックの `resolve_secret()` 関数を導入
- 起動時に必須シークレット（`SLACK_BOT_TOKEN`, `SLACK_APP_TOKEN`）の存在をバリデーション
- `.env.example` からシークレット項目を削除し、keyring 管理の案内を追記（rag-knowledge 準拠）
- README.md のセットアップ手順を keyring 方式に更新
- `resolve_secret()` のテスト追加（環境変数優先、keyring フォールバック、SecretStoreError、空文字列フォールバック）

## Test plan

- [x] `uv run pytest` — 全359テスト通過
- [x] `uv run ruff check src/ tests/ scripts/` — All checks passed
- [x] `uv run mypy src/` — no issues found

## Related issues

Closes #780