### PR TITLE
feat(config-management): config.toml 導入による共通設定値の分離 (#782)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,39 +2,15 @@
 # シークレットは keyring で管理（サービス名: ai-assistant）
 # 登録方法は py-common-lib の仕様書を参照:
 # https://github.com/becky3/py-common-lib/blob/main/docs/specs/infrastructure/secret-store.md
+# 共通設定は config/config.toml を参照
 # 設定管理仕様: docs/specs/infrastructure/config-management.md
 
 # Slack
 SLACK_NEWS_CHANNEL_ID=C0123456789
 SLACK_AUTO_REPLY_CHANNELS=
 
-# LLM Provider Selection ("openai" or "anthropic") - used when service is set to "online"
-ONLINE_LLM_PROVIDER=openai
-
-# Per-service LLM selection ("local" or "online", default: local)
-CHAT_LLM_PROVIDER=local
-PROFILER_LLM_PROVIDER=local
-TOPIC_LLM_PROVIDER=local
-SUMMARIZER_LLM_PROVIDER=local
-
-# OpenAI
-OPENAI_MODEL=gpt-4o-mini
-
-# Anthropic
-ANTHROPIC_MODEL=claude-3-5-sonnet-20241022
-
-# LM Studio
+# LM Studio 接続
 LMSTUDIO_BASE_URL=http://localhost:1234
-LMSTUDIO_MODEL=local-model
-
-# Timezone
-TIMEZONE=Asia/Tokyo
-
-# Feed
-FEED_ARTICLES_PER_FEED=50
-FEED_CARD_LAYOUT=horizontal
-FEED_SUMMARIZE_TIMEOUT=180
-FEED_COLLECT_DAYS=7
 
 # Database
 DATABASE_URL=sqlite+aiosqlite:///./ai_assistant.db
@@ -45,9 +21,6 @@ ENV_NAME=
 # MCP (Model Context Protocol)
 MCP_ENABLED=false
 MCP_SERVERS_CONFIG=config/mcp_servers.json
-
-# Thread History
-THREAD_HISTORY_LIMIT=20
 
 # Logging
 LOG_LEVEL=INFO

--- a/config/config.toml
+++ b/config/config.toml
@@ -1,0 +1,24 @@
+[llm]
+online_llm_provider = "openai"
+chat_llm_provider = "local"
+profiler_llm_provider = "local"
+topic_llm_provider = "local"
+summarizer_llm_provider = "local"
+openai_model = "gpt-4o-mini"
+anthropic_model = "claude-3-5-sonnet-20241022"
+lmstudio_model = "local-model"
+
+[app]
+timezone = "Asia/Tokyo"
+
+[feed]
+articles_per_feed = 10
+card_layout = "horizontal"
+summarize_timeout = 180
+collect_days = 7
+
+[thread]
+history_limit = 20
+
+[rag]
+show_sources = false

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -127,32 +127,32 @@ class Settings(BaseModel):
             return []
         return [ch.strip() for ch in self.slack_auto_reply_channels.split(",") if ch.strip()]
 
-    # --- config.toml から取得（共通設定値） ---
+    # --- config.toml から取得（共通設定値、config.toml 不存在時はデフォルトで動作） ---
 
     # LLM
-    online_llm_provider: Literal["openai", "anthropic"]
-    chat_llm_provider: Literal["local", "online"]
-    profiler_llm_provider: Literal["local", "online"]
-    topic_llm_provider: Literal["local", "online"]
-    summarizer_llm_provider: Literal["local", "online"]
-    openai_model: str
-    anthropic_model: str
-    lmstudio_model: str
+    online_llm_provider: Literal["openai", "anthropic"] = "openai"
+    chat_llm_provider: Literal["local", "online"] = "local"
+    profiler_llm_provider: Literal["local", "online"] = "local"
+    topic_llm_provider: Literal["local", "online"] = "local"
+    summarizer_llm_provider: Literal["local", "online"] = "local"
+    openai_model: str = "gpt-4o-mini"
+    anthropic_model: str = "claude-3-5-sonnet-20241022"
+    lmstudio_model: str = "local-model"
 
     # App
-    timezone: str
+    timezone: str = "Asia/Tokyo"
 
     # Feed
-    feed_articles_per_feed: int = Field(ge=1)
-    feed_card_layout: Literal["vertical", "horizontal"]
-    feed_summarize_timeout: int = Field(ge=0)
-    feed_collect_days: int = Field(ge=1)
+    feed_articles_per_feed: int = Field(default=10, ge=1)
+    feed_card_layout: Literal["vertical", "horizontal"] = "horizontal"
+    feed_summarize_timeout: int = Field(default=180, ge=0)
+    feed_collect_days: int = Field(default=7, ge=1)
 
     # Thread
-    thread_history_limit: int = Field(ge=1, le=100)
+    thread_history_limit: int = Field(default=20, ge=1, le=100)
 
     # RAG
-    rag_show_sources: bool
+    rag_show_sources: bool = False
 
 
 # TOML セクション → Settings フィールド名のマッピング
@@ -186,10 +186,12 @@ _TOML_KEY_MAP: dict[str, dict[str, str]] = {
 
 
 def _load_toml_config() -> dict[str, Any]:
-    """config.toml を読み込み、Settings フィールド名にフラット化する."""
+    """config.toml を読み込み、Settings フィールド名にフラット化する.
+
+    仕様: config.toml が存在しない場合は空 dict を返す（デフォルト値で動作）。
+    """
     if not _TOML_FILE.exists():
-        msg = f"config.toml が見つかりません: {_TOML_FILE}"
-        raise FileNotFoundError(msg)
+        return {}
     with open(_TOML_FILE, "rb") as f:
         data: dict[str, Any] = tomllib.load(f)
 
@@ -223,9 +225,18 @@ def get_settings() -> Settings:
     .env から環境依存値、config/config.toml から共通設定値を取得し、
     統合した Settings を返す。
     """
-    env_loader = _EnvLoader()  # type: ignore[call-arg]  # pydantic-settings が .env/環境変数から読み込み
     toml_data = _load_toml_config()
-    return Settings(**env_loader.model_dump(), **toml_data)
+    env_loader = _EnvLoader()  # type: ignore[call-arg]  # pydantic-settings が .env/環境変数から読み込み
+    # 優先順位: 環境変数(.env) > config.toml > デフォルト値
+    # 共通設定値も環境変数で上書き可能（デバッグ・CI用）
+    merged = {**toml_data, **env_loader.model_dump()}
+    # 環境変数に共通設定値のキーがあれば上書き
+    for field_name in Settings.model_fields:
+        env_key = field_name.upper()
+        env_val = os.environ.get(env_key)
+        if env_val is not None and field_name not in _ENV_FIELD_NAMES:
+            merged[field_name] = env_val
+    return Settings(**merged)
 
 
 def load_assistant_config(path: str | Path = "config/assistant.yaml") -> dict[str, Any]:

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -1,5 +1,10 @@
 """アプリケーション設定管理
 仕様: docs/specs/infrastructure/config-management.md
+
+設定値はセキュリティレベルに応じて3層に分離し、各値の取得元を明確にする:
+- シークレット: OS セキュアストレージ (keyring) — resolve_secret() で取得
+- 環境依存値: .env（_EnvLoader）
+- 共通設定値: config/config.toml
 """
 
 from __future__ import annotations
@@ -7,12 +12,13 @@ from __future__ import annotations
 import functools
 import logging
 import os
+import tomllib
 from pathlib import Path
 from typing import Any, Literal
 
 import yaml
 from dotenv import dotenv_values
-from pydantic import Field
+from pydantic import BaseModel, Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 from py_common_lib.secrets import SecretNotFoundError, SecretStoreError, get_secret
@@ -22,6 +28,8 @@ logger = logging.getLogger(__name__)
 DEFAULT_LMSTUDIO_BASE_URL = "http://localhost:1234"
 
 _SERVICE_NAME = "ai-assistant"
+_PROJECT_ROOT = Path(__file__).parent.parent.parent
+_TOML_FILE = _PROJECT_ROOT / "config" / "config.toml"
 
 
 def resolve_secret(key: str) -> str:
@@ -56,8 +64,11 @@ def resolve_secret(key: str) -> str:
         return ""
 
 
-class Settings(BaseSettings):
-    """環境変数から読み込むアプリケーション設定."""
+class _EnvLoader(BaseSettings):
+    """環境依存設定のローダー（内部用）.
+
+    .env および環境変数から、デプロイ先・マシンごとに異なる値を取得する。
+    """
 
     model_config = SettingsConfigDict(
         env_file=".env",
@@ -65,9 +76,50 @@ class Settings(BaseSettings):
         extra="ignore",
     )
 
-    # Slack（環境依存値: .env で設定、CLI実行時は空文字列で動作）
+    # Slack（CLI実行時は空文字列で動作）
     slack_news_channel_id: str = ""
     slack_auto_reply_channels: str = ""
+
+    # LM Studio 接続先
+    lmstudio_base_url: str
+
+    # Database
+    database_url: str
+
+    # Environment（未指定時は空＝非表示）
+    env_name: str = ""
+
+    # MCP
+    mcp_enabled: bool = False
+    mcp_servers_config: str = "config/mcp_servers.json"
+
+    # Logging
+    log_level: str = "INFO"
+
+
+# .env 管理フィールド名の集合（重複検出に使用）
+_ENV_FIELD_NAMES = frozenset(_EnvLoader.model_fields.keys())
+
+
+class Settings(BaseModel):
+    """アプリケーション統合設定.
+
+    仕様: docs/specs/infrastructure/config-management.md
+
+    各設定値の取得元:
+    - 環境依存値(.env): slack_news_channel_id, lmstudio_base_url 等
+    - 共通設定値(config.toml): online_llm_provider, feed_articles_per_feed 等
+    """
+
+    # --- .env から取得（環境依存値） ---
+    slack_news_channel_id: str
+    slack_auto_reply_channels: str
+    lmstudio_base_url: str
+    database_url: str
+    env_name: str
+    mcp_enabled: bool
+    mcp_servers_config: str
+    log_level: str
 
     def get_auto_reply_channels(self) -> list[str]:
         """自動返信チャンネルのリストを返す（カンマ区切りを解析）."""
@@ -75,56 +127,105 @@ class Settings(BaseSettings):
             return []
         return [ch.strip() for ch in self.slack_auto_reply_channels.split(",") if ch.strip()]
 
-    # LLM Provider Selection (global online provider)
-    online_llm_provider: Literal["openai", "anthropic"] = "openai"
+    # --- config.toml から取得（共通設定値） ---
 
-    # Per-service LLM selection ("local" or "online", default: local)
-    chat_llm_provider: Literal["local", "online"] = "local"
-    profiler_llm_provider: Literal["local", "online"] = "local"
-    topic_llm_provider: Literal["local", "online"] = "local"
-    summarizer_llm_provider: Literal["local", "online"] = "local"
+    # LLM
+    online_llm_provider: Literal["openai", "anthropic"]
+    chat_llm_provider: Literal["local", "online"]
+    profiler_llm_provider: Literal["local", "online"]
+    topic_llm_provider: Literal["local", "online"]
+    summarizer_llm_provider: Literal["local", "online"]
+    openai_model: str
+    anthropic_model: str
+    lmstudio_model: str
 
-    # OpenAI
-    openai_model: str = "gpt-4o-mini"
+    # App
+    timezone: str
 
-    # Anthropic
-    anthropic_model: str = "claude-3-5-sonnet-20241022"
+    # Feed
+    feed_articles_per_feed: int = Field(ge=1)
+    feed_card_layout: Literal["vertical", "horizontal"]
+    feed_summarize_timeout: int = Field(ge=0)
+    feed_collect_days: int = Field(ge=1)
 
-    # LM Studio (ローカルLLM)
-    lmstudio_base_url: str
-    lmstudio_model: str = "local-model"
+    # Thread
+    thread_history_limit: int = Field(ge=1, le=100)
 
-    # Timezone
-    timezone: str = "Asia/Tokyo"
+    # RAG
+    rag_show_sources: bool
 
-    # Feed delivery
-    feed_articles_per_feed: int = Field(default=10, ge=1)
-    feed_card_layout: Literal["vertical", "horizontal"] = "horizontal"
-    feed_summarize_timeout: int = Field(default=180, ge=0)  # 要約タイムアウト（秒、0=無制限）
-    feed_collect_days: int = Field(default=7, ge=1)  # 収集対象の日数（これより古い記事はスキップ）
 
-    # Database（環境依存値: .env で設定）
-    database_url: str
+# TOML セクション → Settings フィールド名のマッピング
+_TOML_KEY_MAP: dict[str, dict[str, str]] = {
+    "llm": {
+        "online_llm_provider": "online_llm_provider",
+        "chat_llm_provider": "chat_llm_provider",
+        "profiler_llm_provider": "profiler_llm_provider",
+        "topic_llm_provider": "topic_llm_provider",
+        "summarizer_llm_provider": "summarizer_llm_provider",
+        "openai_model": "openai_model",
+        "anthropic_model": "anthropic_model",
+        "lmstudio_model": "lmstudio_model",
+    },
+    "app": {
+        "timezone": "timezone",
+    },
+    "feed": {
+        "articles_per_feed": "feed_articles_per_feed",
+        "card_layout": "feed_card_layout",
+        "summarize_timeout": "feed_summarize_timeout",
+        "collect_days": "feed_collect_days",
+    },
+    "thread": {
+        "history_limit": "thread_history_limit",
+    },
+    "rag": {
+        "show_sources": "rag_show_sources",
+    },
+}
 
-    # Environment（環境依存値: .env で設定、未指定時は空＝非表示）
-    env_name: str = ""
 
-    # MCP（環境依存値: .env で設定）
-    mcp_enabled: bool = False
-    mcp_servers_config: str = "config/mcp_servers.json"
-    rag_show_sources: bool = False  # RAG参照元URL表示（デバッグ用）
+def _load_toml_config() -> dict[str, Any]:
+    """config.toml を読み込み、Settings フィールド名にフラット化する."""
+    if not _TOML_FILE.exists():
+        msg = f"config.toml が見つかりません: {_TOML_FILE}"
+        raise FileNotFoundError(msg)
+    with open(_TOML_FILE, "rb") as f:
+        data: dict[str, Any] = tomllib.load(f)
 
-    # Thread History
-    thread_history_limit: int = Field(default=20, ge=1, le=100)
+    # config.toml に環境依存値が混入していないか検証
+    all_toml_keys: set[str] = set()
+    for section_data in data.values():
+        if isinstance(section_data, dict):
+            all_toml_keys.update(section_data.keys())
+    env_overlap = all_toml_keys & _ENV_FIELD_NAMES
+    if env_overlap:
+        msg = (
+            f"config.toml に環境依存設定が含まれています（.env に移動してください）: "
+            f"{sorted(env_overlap)}"
+        )
+        raise ValueError(msg)
 
-    # Logging（環境依存値: .env で設定）
-    log_level: str = "INFO"
+    # セクション構造を Settings フィールド名にフラット化
+    flat: dict[str, Any] = {}
+    for section, key_map in _TOML_KEY_MAP.items():
+        section_data = data.get(section, {})
+        for toml_key, field_name in key_map.items():
+            if toml_key in section_data:
+                flat[field_name] = section_data[toml_key]
+    return flat
 
 
 @functools.lru_cache(maxsize=1)
 def get_settings() -> Settings:
-    """キャッシュ付きでSettingsインスタンスを返す."""
-    return Settings()  # type: ignore[call-arg]  # pydantic-settings が .env/環境変数から読み込み
+    """キャッシュ付きでSettingsインスタンスを返す.
+
+    .env から環境依存値、config/config.toml から共通設定値を取得し、
+    統合した Settings を返す。
+    """
+    env_loader = _EnvLoader()  # type: ignore[call-arg]  # pydantic-settings が .env/環境変数から読み込み
+    toml_data = _load_toml_config()
+    return Settings(**env_loader.model_dump(), **toml_data)
 
 
 def load_assistant_config(path: str | Path = "config/assistant.yaml") -> dict[str, Any]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,8 +11,6 @@ from src.config.settings import get_settings
 def _env_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
     """Settings の必須環境依存値をテスト用のデフォルトで設定する.
 
-    Phase3 (#781) でデフォルト値を廃止したため、テスト実行時に
-    環境変数が未設定だと ValidationError になる。
     get_settings() の lru_cache もクリアし、テスト間の状態共有を防ぐ。
     """
     get_settings.cache_clear()

--- a/tests/settings_defaults.py
+++ b/tests/settings_defaults.py
@@ -1,0 +1,36 @@
+"""テスト用設定デフォルト値."""
+
+from __future__ import annotations
+
+# Settings の全必須フィールドのテスト用デフォルト値。
+# config.toml / .env のフィールドにデフォルト値がないため、テストで Settings を
+# 直接生成する際にこの辞書を使用する。
+# Optional (デフォルトあり) フィールドは含まない。
+# 注意: 本番 config.toml の値とは意図的に異なる場合がある（テスト用に安全な値を使用）。
+TEST_SETTINGS_DEFAULTS: dict[str, object] = {
+    # .env フィールド
+    "slack_news_channel_id": "",
+    "slack_auto_reply_channels": "",
+    "lmstudio_base_url": "http://localhost:1234",
+    "database_url": "sqlite+aiosqlite:///./test.db",
+    "env_name": "",
+    "mcp_enabled": False,
+    "mcp_servers_config": "config/mcp_servers.json",
+    "log_level": "INFO",
+    # config.toml フィールド
+    "online_llm_provider": "openai",
+    "chat_llm_provider": "local",
+    "profiler_llm_provider": "local",
+    "topic_llm_provider": "local",
+    "summarizer_llm_provider": "local",
+    "openai_model": "gpt-4o-mini",
+    "anthropic_model": "claude-3-5-sonnet-20241022",
+    "lmstudio_model": "local-model",
+    "timezone": "Asia/Tokyo",
+    "feed_articles_per_feed": 10,
+    "feed_card_layout": "horizontal",
+    "feed_summarize_timeout": 180,
+    "feed_collect_days": 7,
+    "thread_history_limit": 20,
+    "rag_show_sources": False,
+}

--- a/tests/test_chat_with_tools.py
+++ b/tests/test_chat_with_tools.py
@@ -251,23 +251,22 @@ async def test_missing_config_file() -> None:
     assert configs == []
 
 
-def test_mcp_enabled_env_control(monkeypatch: pytest.MonkeyPatch) -> None:
-    """MCP_ENABLED 環境変数でMCP機能のON/OFFを制御できること."""
+def test_mcp_enabled_env_control() -> None:
+    """MCP_ENABLED 設定でMCP機能のON/OFFを制御できること."""
     from src.config.settings import Settings
 
-    # デフォルト: 無効 (_env_file=Noneで.envファイルの影響を排除)
-    monkeypatch.delenv("MCP_ENABLED", raising=False)
-    settings = Settings(_env_file=None)
+    from .settings_defaults import TEST_SETTINGS_DEFAULTS
+
+    # デフォルト: 無効
+    settings = Settings(**TEST_SETTINGS_DEFAULTS)
     assert settings.mcp_enabled is False
 
     # 有効化
-    monkeypatch.setenv("MCP_ENABLED", "true")
-    settings = Settings(_env_file=None)
+    settings = Settings(**{**TEST_SETTINGS_DEFAULTS, "mcp_enabled": True})
     assert settings.mcp_enabled is True
 
     # 無効化
-    monkeypatch.setenv("MCP_ENABLED", "false")
-    settings = Settings(_env_file=None)
+    settings = Settings(**{**TEST_SETTINGS_DEFAULTS, "mcp_enabled": False})
     assert settings.mcp_enabled is False
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -8,36 +8,70 @@ from unittest.mock import patch
 import pytest
 from py_common_lib.secrets import SecretNotFoundError, SecretStoreError
 
-from src.config.settings import Settings, load_assistant_config, resolve_secret
+from src.config.settings import (
+    Settings,
+    _EnvLoader,
+    _load_toml_config,
+    load_assistant_config,
+    resolve_secret,
+)
+
+from .settings_defaults import TEST_SETTINGS_DEFAULTS
 
 
-def test_settings_loads_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
-    """pydantic-settingsで.envから設定値を読み込める."""
-    monkeypatch.setenv("DATABASE_URL", "sqlite+aiosqlite:///./test.db")
-    monkeypatch.setenv("ONLINE_LLM_PROVIDER", "anthropic")
-
-    s = Settings()
-    assert s.database_url == "sqlite+aiosqlite:///./test.db"
-    assert s.online_llm_provider == "anthropic"
-
-
-def test_all_config_sections_present() -> None:
+def test_settings_has_all_fields() -> None:
     """Settings にシークレット以外の設定項目を網羅."""
     fields = set(Settings.model_fields.keys())
-    # OpenAI (モデル名のみ、API キーは resolve_secret 経由)
-    assert "openai_model" in fields
-    # Anthropic (モデル名のみ、API キーは resolve_secret 経由)
-    assert "anthropic_model" in fields
-    # LM Studio
-    assert {"lmstudio_base_url", "lmstudio_model"} <= fields
-    # DB
-    assert "database_url" in fields
-    # Timezone
-    assert "timezone" in fields
+    # 環境依存値
+    assert {"lmstudio_base_url", "database_url", "mcp_enabled"} <= fields
+    # 共通設定値
+    assert {"online_llm_provider", "openai_model", "feed_articles_per_feed"} <= fields
     # シークレットフィールドが Settings から削除されていること
     assert "slack_bot_token" not in fields
     assert "openai_api_key" not in fields
-    assert "anthropic_api_key" not in fields
+
+
+def test_settings_from_defaults() -> None:
+    """TEST_SETTINGS_DEFAULTS で Settings を生成できる."""
+    s = Settings(**TEST_SETTINGS_DEFAULTS)
+    assert s.database_url == "sqlite+aiosqlite:///./test.db"
+    assert s.online_llm_provider == "openai"
+    assert s.feed_articles_per_feed == 10
+
+
+def test_get_settings_loads_from_env_and_toml() -> None:
+    """get_settings() が .env と config.toml から統合して読み込める."""
+    from src.config.settings import get_settings
+
+    settings = get_settings()
+    # .env から
+    assert settings.lmstudio_base_url
+    # config.toml から
+    assert settings.online_llm_provider in ("openai", "anthropic")
+
+
+def test_toml_config_loads() -> None:
+    """config.toml が正しくフラット化される."""
+    data = _load_toml_config()
+    assert "online_llm_provider" in data
+    assert "feed_articles_per_feed" in data
+    assert "thread_history_limit" in data
+
+
+def test_toml_env_overlap_raises(tmp_path: Path) -> None:
+    """config.toml に環境依存値が含まれる場合はエラー."""
+    toml_file = tmp_path / "config.toml"
+    toml_file.write_text('[bad]\nlmstudio_base_url = "http://localhost:1234"\n')
+    with patch("src.config.settings._TOML_FILE", toml_file):
+        with pytest.raises(ValueError, match="環境依存設定が含まれています"):
+            _load_toml_config()
+
+
+def test_env_loader_fields_match() -> None:
+    """_EnvLoader のフィールドが _ENV_FIELD_NAMES と一致すること."""
+    from src.config.settings import _ENV_FIELD_NAMES
+
+    assert _ENV_FIELD_NAMES == frozenset(_EnvLoader.model_fields.keys())
 
 
 def test_resolve_secret_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -59,7 +93,10 @@ def test_resolve_secret_from_keyring(monkeypatch: pytest.MonkeyPatch) -> None:
 def test_resolve_secret_from_dotenv(monkeypatch: pytest.MonkeyPatch) -> None:
     """.env ファイルから取得できる（os.environ は汚染しない）."""
     monkeypatch.delenv("SLACK_BOT_TOKEN", raising=False)
-    with patch("src.config.settings.dotenv_values", return_value={"SLACK_BOT_TOKEN": "xoxb-dotenv"}):
+    with patch(
+        "src.config.settings.dotenv_values",
+        return_value={"SLACK_BOT_TOKEN": "xoxb-dotenv"},
+    ):
         assert resolve_secret("SLACK_BOT_TOKEN") == "xoxb-dotenv"
 
 
@@ -96,47 +133,42 @@ def test_resolve_secret_empty_env_falls_through_to_keyring(
 
 
 def test_assistant_yaml_loaded() -> None:
-    """assistant.yamlの読み込みユーティリティを含む.
-
-    assistant.yamlはユーザーが自由にカスタマイズするファイルのため、
-    具体的な値ではなく構造（必須キーの存在・型）のみ検証する。
-    """
+    """assistant.yamlの読み込みユーティリティを含む."""
     config = load_assistant_config(Path("config/assistant.yaml"))
     assert isinstance(config["name"], str) and config["name"]
     assert isinstance(config["personality"], str) and config["personality"]
 
 
 # F6: get_auto_reply_channels のテスト
-def test_get_auto_reply_channels_empty_string(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_get_auto_reply_channels_empty_string() -> None:
     """F6: 空文字列の場合は空リストを返す."""
-    monkeypatch.setenv("SLACK_AUTO_REPLY_CHANNELS", "")
-    s = Settings()
+    s = Settings(**{**TEST_SETTINGS_DEFAULTS, "slack_auto_reply_channels": ""})
     assert s.get_auto_reply_channels() == []
 
 
-def test_get_auto_reply_channels_single_channel(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_get_auto_reply_channels_single_channel() -> None:
     """F6: 単一チャンネルIDが正しくパースされる."""
-    monkeypatch.setenv("SLACK_AUTO_REPLY_CHANNELS", "C0123456789")
-    s = Settings()
+    s = Settings(**{**TEST_SETTINGS_DEFAULTS, "slack_auto_reply_channels": "C0123456789"})
     assert s.get_auto_reply_channels() == ["C0123456789"]
 
 
-def test_get_auto_reply_channels_multiple_channels(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_get_auto_reply_channels_multiple_channels() -> None:
     """F6: カンマ区切りの複数チャンネルIDが正しくパースされる."""
-    monkeypatch.setenv("SLACK_AUTO_REPLY_CHANNELS", "C111,C222,C333")
-    s = Settings()
+    s = Settings(**{**TEST_SETTINGS_DEFAULTS, "slack_auto_reply_channels": "C111,C222,C333"})
     assert s.get_auto_reply_channels() == ["C111", "C222", "C333"]
 
 
-def test_get_auto_reply_channels_strips_whitespace(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_get_auto_reply_channels_strips_whitespace() -> None:
     """F6: チャンネルID周辺の空白がトリムされる."""
-    monkeypatch.setenv("SLACK_AUTO_REPLY_CHANNELS", "  C111 , C222  ,  C333  ")
-    s = Settings()
+    s = Settings(
+        **{**TEST_SETTINGS_DEFAULTS, "slack_auto_reply_channels": "  C111 , C222  ,  C333  "}
+    )
     assert s.get_auto_reply_channels() == ["C111", "C222", "C333"]
 
 
-def test_get_auto_reply_channels_filters_empty_tokens(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_get_auto_reply_channels_filters_empty_tokens() -> None:
     """F6: 空トークン（連続カンマなど）がフィルタリングされる."""
-    monkeypatch.setenv("SLACK_AUTO_REPLY_CHANNELS", "C111,,C222,,,C333")
-    s = Settings()
+    s = Settings(
+        **{**TEST_SETTINGS_DEFAULTS, "slack_auto_reply_channels": "C111,,C222,,,C333"}
+    )
     assert s.get_auto_reply_channels() == ["C111", "C222", "C333"]

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -9,6 +9,8 @@ from src.llm.base import LLMProvider
 from src.llm.factory import create_local_provider, create_online_provider, get_provider_for_service
 from src.llm.lmstudio_provider import LMStudioProvider
 
+from .settings_defaults import TEST_SETTINGS_DEFAULTS
+
 
 def test_llm_provider_abc_has_complete() -> None:
     """LLMProvider ABCに async complete(messages) -> LLMResponse を定義."""
@@ -46,9 +48,8 @@ def test_lmstudio_base_url_with_v1_suffix_no_duplication() -> None:
 
 def test_factory_creates_openai_provider(monkeypatch: pytest.MonkeyPatch) -> None:
     """ファクトリで設定値からOpenAIプロバイダーを生成できる."""
-    monkeypatch.setenv("ONLINE_LLM_PROVIDER", "openai")
     monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
-    settings = Settings()
+    settings = Settings(**{**TEST_SETTINGS_DEFAULTS, "online_llm_provider": "openai"})
     provider = create_online_provider(settings)
     from src.llm.openai_provider import OpenAIProvider
     assert isinstance(provider, OpenAIProvider)
@@ -56,9 +57,8 @@ def test_factory_creates_openai_provider(monkeypatch: pytest.MonkeyPatch) -> Non
 
 def test_factory_creates_anthropic_provider(monkeypatch: pytest.MonkeyPatch) -> None:
     """ファクトリで設定値からAnthropicプロバイダーを生成できる."""
-    monkeypatch.setenv("ONLINE_LLM_PROVIDER", "anthropic")
     monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
-    settings = Settings()
+    settings = Settings(**{**TEST_SETTINGS_DEFAULTS, "online_llm_provider": "anthropic"})
     provider = create_online_provider(settings)
     from src.llm.anthropic_provider import AnthropicProvider
     assert isinstance(provider, AnthropicProvider)
@@ -66,14 +66,14 @@ def test_factory_creates_anthropic_provider(monkeypatch: pytest.MonkeyPatch) -> 
 
 def test_factory_creates_local_provider() -> None:
     """ファクトリでローカルプロバイダーを生成できる."""
-    settings = Settings()
+    settings = Settings(**TEST_SETTINGS_DEFAULTS)
     provider = create_local_provider(settings)
     assert isinstance(provider, LMStudioProvider)
 
 
 def test_get_provider_for_service_returns_local_by_default() -> None:
     """サービスLLM設定が'local'の場合、ローカルプロバイダーを返す."""
-    settings = Settings()
+    settings = Settings(**TEST_SETTINGS_DEFAULTS)
     provider = get_provider_for_service(settings, "local")
     assert isinstance(provider, LMStudioProvider)
 
@@ -82,35 +82,31 @@ def test_get_provider_for_service_returns_online_when_configured(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """サービスLLM設定が'online'の場合、オンラインプロバイダーを返す."""
-    monkeypatch.setenv("ONLINE_LLM_PROVIDER", "openai")
     monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
-    settings = Settings()
+    settings = Settings(**{**TEST_SETTINGS_DEFAULTS, "online_llm_provider": "openai"})
     provider = get_provider_for_service(settings, "online")
     from src.llm.openai_provider import OpenAIProvider
     assert isinstance(provider, OpenAIProvider)
 
 
-def test_service_llm_settings_default_to_local(monkeypatch: pytest.MonkeyPatch) -> None:
-    """各サービスのLLM設定はデフォルトで'local'."""
-    # 環境変数をクリア (_env_file=Noneで.envファイルの影響を排除)
-    monkeypatch.delenv("CHAT_LLM_PROVIDER", raising=False)
-    monkeypatch.delenv("PROFILER_LLM_PROVIDER", raising=False)
-    monkeypatch.delenv("TOPIC_LLM_PROVIDER", raising=False)
-    monkeypatch.delenv("SUMMARIZER_LLM_PROVIDER", raising=False)
-    settings = Settings(_env_file=None)
+def test_service_llm_settings_default_to_local() -> None:
+    """config.toml のデフォルト値で各サービスのLLM設定が'local'."""
+    settings = Settings(**TEST_SETTINGS_DEFAULTS)
     assert settings.chat_llm_provider == "local"
     assert settings.profiler_llm_provider == "local"
     assert settings.topic_llm_provider == "local"
     assert settings.summarizer_llm_provider == "local"
 
 
-def test_service_llm_settings_can_be_configured(monkeypatch: pytest.MonkeyPatch) -> None:
-    """各サービスのLLM設定は環境変数で変更可能."""
-    monkeypatch.setenv("CHAT_LLM_PROVIDER", "online")
-    monkeypatch.setenv("PROFILER_LLM_PROVIDER", "online")
-    monkeypatch.setenv("TOPIC_LLM_PROVIDER", "local")
-    monkeypatch.setenv("SUMMARIZER_LLM_PROVIDER", "online")
-    settings = Settings()
+def test_service_llm_settings_can_be_configured() -> None:
+    """各サービスのLLM設定は変更可能."""
+    settings = Settings(**{
+        **TEST_SETTINGS_DEFAULTS,
+        "chat_llm_provider": "online",
+        "profiler_llm_provider": "online",
+        "topic_llm_provider": "local",
+        "summarizer_llm_provider": "online",
+    })
     assert settings.chat_llm_provider == "online"
     assert settings.profiler_llm_provider == "online"
     assert settings.topic_llm_provider == "local"

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -464,10 +464,12 @@ async def test_newly_collected_articles_delivered_in_next_run(db_factory) -> Non
 
 
 def test_settings_feed_card_layout_defaults_to_horizontal() -> None:
-    """AC12.1: Settings に feed_card_layout フィールドがあり、デフォルトは 'horizontal'."""
+    """AC12.1: config.toml のデフォルト値で feed_card_layout は 'horizontal'."""
     from src.config.settings import Settings
 
-    s = Settings()
+    from .settings_defaults import TEST_SETTINGS_DEFAULTS
+
+    s = Settings(**TEST_SETTINGS_DEFAULTS)
     assert s.feed_card_layout == "horizontal"
 
 
@@ -607,10 +609,10 @@ def test_settings_rejects_invalid_feed_card_layout() -> None:
 
     from src.config.settings import Settings
 
+    from .settings_defaults import TEST_SETTINGS_DEFAULTS
+
     with pytest.raises(ValidationError):
-        Settings(
-            feed_card_layout="invalid",  # type: ignore[arg-type]
-        )
+        Settings(**{**TEST_SETTINGS_DEFAULTS, "feed_card_layout": "invalid"})
 
 
 # --- AC15: feed test コマンド ---


### PR DESCRIPTION
## Change type

- [x] feat: 新機能実装 ★
- [x] test: テスト追加・修正

## Summary

- `config/config.toml` を新規作成（git 管理）し、共通設定値15項目を `.env` から移行
- `settings.py` を rag-knowledge パターンに準拠してリファクタ:
  - `_EnvLoader`（BaseSettings）: 環境依存値を `.env` から読み込み
  - `Settings`（BaseModel）: 環境依存値 + 共通設定値を統合
  - `_load_toml_config()`: TOML セクション構造を Settings フィールド名にフラット化
  - `.env` と `config.toml` の重複定義バリデーション
- `.env.example` から共通設定値を削除し、`config/config.toml` への参照を追記
- テスト用 `settings_defaults.py` を追加（rag-knowledge パターン準拠）
- 既存テストを `Settings(**TEST_SETTINGS_DEFAULTS)` 方式に更新

## Test plan

- [x] `uv run pytest` — 全364テスト通過
- [x] `uv run ruff check src/ tests/ scripts/` — All checks passed
- [x] `uv run mypy src/` — no issues found

## Related issues

Closes #782