### PR TITLE
docs(config-management): README・CLAUDE.md・overview.md を3層分離に合わせて更新 (#784)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,13 +5,21 @@
 @README.md
 @docs/specs/overview.md
 
+## 設定管理（3層分離）
+
+設定値は3層に分離して管理する。詳細は `docs/specs/infrastructure/config-management.md` を参照。
+
+- **シークレット**: keyring（`resolve_secret()` で取得、サービス名: `ai-assistant`）
+- **環境依存値**: `.env`（`_EnvLoader` で読み込み）
+- **共通設定値**: `config/config.toml`（git 管理、`_load_toml_config()` で読み込み）
+- 新しい設定値は分類基準に従い適切な層に配置すること
+- 外部 HTTP リクエストは py-common-lib の `ConstrainedClient` 経由で実行すること
+
 ## LLM使い分けルール
 
 - **デフォルト**: 全サービスでローカルLLM（LM Studio）を使用
-- **設定変更**: `.env` で各サービスごとにLLMを変更可能
-  - `CHAT_LLM_PROVIDER` / `PROFILER_LLM_PROVIDER` / `TOPIC_LLM_PROVIDER` / `SUMMARIZER_LLM_PROVIDER`
-  - 各設定は `"local"` または `"online"` を指定（デフォルト: `"local"`）
-- `MCP_ENABLED` — MCP機能の有効/無効（デフォルト: `false`）
+- **設定変更**: `config/config.toml` の `[llm]` セクションで各サービスごとにLLMを変更可能
+- `MCP_ENABLED` — MCP機能の有効/無効（`.env` で設定、デフォルト: `false`）
 - RAG機能は rag-knowledge リポジトリに移行済み。MCP サーバーとして `config/mcp_servers.json` で接続設定する
 
 ## 自動進行ルール（auto-progress）

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,17 +9,16 @@
 
 設定値は3層に分離して管理する。詳細は `docs/specs/infrastructure/config-management.md` を参照。
 
-- **シークレット**: keyring（`resolve_secret()` で取得、サービス名: `ai-assistant`）
-- **環境依存値**: `.env`（`_EnvLoader` で読み込み）
-- **共通設定値**: `config/config.toml`（git 管理、`_load_toml_config()` で読み込み）
+- **シークレット**: keyring で管理。`resolve_secret()` が環境変数 → `.env` → keyring の優先順位で取得
+- **環境依存値**: `.env` で管理。`src/config/settings.py` の `get_settings()` が読み込み
+- **共通設定値**: `config/config.toml`（git 管理）で管理。`get_settings()` が読み込み
 - 新しい設定値は分類基準に従い適切な層に配置すること
 - 外部 HTTP リクエストは py-common-lib の `ConstrainedClient` 経由で実行すること
 
 ## LLM使い分けルール
 
 - **デフォルト**: 全サービスでローカルLLM（LM Studio）を使用
-- **設定変更**: `config/config.toml` の `[llm]` セクションで各サービスごとにLLMを変更可能
-- `MCP_ENABLED` — MCP機能の有効/無効（`.env` で設定、デフォルト: `false`）
+- **設定変更**: `config/config.toml` の `[llm]` セクションで各サービスのLLMプロバイダーを変更可能（`local` / `online`）
 - RAG機能は rag-knowledge リポジトリに移行済み。MCP サーバーとして `config/mcp_servers.json` で接続設定する
 
 ## 自動進行ルール（auto-progress）

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ RSS記事の自動収集・要約配信、チャットでの質問応答、ユ�
 
 ## 技術スタック
 
-Python 3.11+ / uv / slack-bolt / OpenAI SDK / Anthropic SDK / SQLite + SQLAlchemy / feedparser / MCP SDK
+Python 3.11+ / uv / slack-bolt / OpenAI SDK / Anthropic SDK / SQLite + SQLAlchemy / feedparser / MCP SDK / py-common-lib (keyring, ConstrainedClient)
 
 詳細は [全体仕様概要](docs/specs/overview.md) を参照。
 
@@ -46,7 +46,17 @@ cp .env.example .env  # 環境依存値を編集
 API キー・トークンは py-common-lib の `get_secret` で OS セキュアストレージから取得する（サービス名: `ai-assistant`）。
 登録方法は [py-common-lib の仕様書](https://github.com/becky3/py-common-lib/blob/main/docs/specs/infrastructure/secret-store.md) を参照。
 
-詳細は `.env.example` および [設定管理仕様](docs/specs/infrastructure/config-management.md) を参照。
+## 設定管理
+
+設定値はセキュリティレベルに応じて3層に分離する。
+
+| 層 | 保管先 | git管理 | 分類基準 |
+|---|--------|---------|---------|
+| シークレット | OS セキュアストレージ (keyring) | 管理外 | 漏洩時に直接被害が発生する値（API キー、トークン） |
+| 環境依存値 | `.env` | 管理外 | デプロイ先・マシンごとに異なる値（接続先 URL、チャンネル ID） |
+| 共通設定値 | `config/config.toml` | **管理する** | プロジェクトとして統一管理する値（LLM 選択、チューニングパラメータ） |
+
+新しい設定値を追加する際は、上記の判断基準に従って適切な層に配置すること。詳細は [設定管理仕様](docs/specs/infrastructure/config-management.md) を参照。
 
 ## 起動
 

--- a/README.md
+++ b/README.md
@@ -43,7 +43,8 @@ uv sync
 cp .env.example .env  # 環境依存値を編集
 ```
 
-API キー・トークンは py-common-lib の `get_secret` で OS セキュアストレージから取得する（サービス名: `ai-assistant`）。
+API キー・トークンは OS セキュアストレージ（keyring）で管理する（サービス名: `ai-assistant`）。
+環境変数・`.env` でも設定可能（keyring より優先）。
 登録方法は [py-common-lib の仕様書](https://github.com/becky3/py-common-lib/blob/main/docs/specs/infrastructure/secret-store.md) を参照。
 
 ## 設定管理

--- a/docs/specs/overview.md
+++ b/docs/specs/overview.md
@@ -41,33 +41,34 @@ AI Assistantは、Slack上で動作するAIアシスタントである。
 ## 4. LLM使い分けルール
 
 全サービスでローカルLLM（LM Studio）をデフォルトで使用する。
-各サービスごとに `.env` ファイルで使用するLLMを変更可能。
+各サービスごとに `config/config.toml` の `[llm]` セクションで使用するLLMを変更可能。
 
 ### サービスごとのLLM設定
 
-| 環境変数 | 対象サービス | デフォルト | 説明 |
+| config.toml キー | 対象サービス | デフォルト | 説明 |
 |----------|-------------|-----------|------|
-| `CHAT_LLM_PROVIDER` | ChatService | local | チャット応答 |
-| `PROFILER_LLM_PROVIDER` | UserProfiler | local | ユーザー情報抽出 |
-| `TOPIC_LLM_PROVIDER` | TopicRecommender | local | トピック提案 |
-| `SUMMARIZER_LLM_PROVIDER` | Summarizer | local | 記事要約 |
+| `chat_llm_provider` | ChatService | local | チャット応答 |
+| `profiler_llm_provider` | UserProfiler | local | ユーザー情報抽出 |
+| `topic_llm_provider` | TopicRecommender | local | トピック提案 |
+| `summarizer_llm_provider` | Summarizer | local | 記事要約 |
 
 各設定には `"local"` または `"online"` を指定する。
-`"online"` の場合、`ONLINE_LLM_PROVIDER` の設定（`"openai"` or `"anthropic"`）が使用される。
+`"online"` の場合、`online_llm_provider` の設定（`"openai"` or `"anthropic"`）が使用される。
 
 ### 設定例
 
-```env
+```toml
+[llm]
 # 全てローカル（デフォルト）
-CHAT_LLM_PROVIDER=local
-PROFILER_LLM_PROVIDER=local
-TOPIC_LLM_PROVIDER=local
-SUMMARIZER_LLM_PROVIDER=local
+chat_llm_provider = "local"
+profiler_llm_provider = "local"
+topic_llm_provider = "local"
+summarizer_llm_provider = "local"
 
-# チャットとトピック提案のみオンライン
-CHAT_LLM_PROVIDER=online
-TOPIC_LLM_PROVIDER=online
-ONLINE_LLM_PROVIDER=openai
+# チャットとトピック提案のみオンラインにする場合
+# chat_llm_provider = "online"
+# topic_llm_provider = "online"
+# online_llm_provider = "openai"
 ```
 
 ## 5. DB設計

--- a/docs/specs/overview.md
+++ b/docs/specs/overview.md
@@ -36,6 +36,7 @@ AI Assistantは、Slack上で動作するAIアシスタントである。
 | スケジューラ | APScheduler |
 | RSS | feedparser |
 | 設定管理 | pydantic-settings (.env / config.toml / keyring) + YAML (アシスタント性格) |
+| 共通ライブラリ | py-common-lib (keyring シークレット取得, 制約付き HTTP クライアント) |
 
 ## 4. LLM使い分けルール
 


### PR DESCRIPTION
## Change type

- [x] docs: ドキュメント更新 ★

## Summary

- README.md: 技術スタックに py-common-lib を追加、設定管理セクション（3層分離テーブル）を追加
- CLAUDE.md: LLM 使い分けルールの設定参照先を `.env` → `config/config.toml` に更新、設定管理3層分離セクションを追加
- docs/specs/overview.md: 技術スタックに py-common-lib（共通ライブラリ）を追加

## Test plan

- [x] `uv run pytest` — 全364テスト通過
- [x] `uv run ruff check src/ tests/ scripts/` — All checks passed
- [x] `uv run mypy src/` — no issues found

## Related issues

Closes #784