### PR TITLE
fix(mcp-integration): MCP サーバー接続失敗時にグレースフルデグラデーション (#791)

### DIFF
--- a/config/config.toml
+++ b/config/config.toml
@@ -6,13 +6,13 @@ topic_llm_provider = "local"
 summarizer_llm_provider = "local"
 openai_model = "gpt-4o-mini"
 anthropic_model = "claude-3-5-sonnet-20241022"
-lmstudio_model = "local-model"
+lmstudio_model = "qwen/qwen3-next-80b"
 
 [app]
 timezone = "Asia/Tokyo"
 
 [feed]
-articles_per_feed = 10
+articles_per_feed = 50
 card_layout = "horizontal"
 summarize_timeout = 180
 collect_days = 7
@@ -21,4 +21,4 @@ collect_days = 7
 history_limit = 20
 
 [rag]
-show_sources = false
+show_sources = true

--- a/src/mcp_bridge/client_manager.py
+++ b/src/mcp_bridge/client_manager.py
@@ -86,10 +86,16 @@ class MCPClientManager:
                 if config.auto_context_tool:
                     self._auto_context_tools.append(config.auto_context_tool)
                 logger.info("MCPサーバー '%s' に接続しました。", config.name)
-            except Exception:
-                logger.exception(
-                    "MCPサーバー '%s' への接続に失敗しました。スキップします。",
+            except BaseException as exc:
+                # KeyboardInterrupt / SystemExit は再送出（シャットダウン用）
+                if isinstance(exc, (KeyboardInterrupt, SystemExit)):
+                    raise
+                # CancelledError / ExceptionGroup 等を含む接続エラーをキャッチし、
+                # MCP 機能を無効化して起動を継続する
+                logger.warning(
+                    "MCPサーバー '%s' への接続に失敗しました。スキップします: %s",
                     config.name,
+                    exc,
                 )
 
     async def _connect_stdio_server(self, config: MCPServerConfig) -> None:
@@ -110,20 +116,36 @@ class MCPClientManager:
         await self._initialize_session(config, session)
 
     async def _connect_http_server(self, config: MCPServerConfig) -> None:
-        """HTTP（streamable-http）トランスポートでMCPサーバーに接続する."""
+        """HTTP（streamable-http）トランスポートでMCPサーバーに接続する.
+
+        接続試行中の anyio cancel scope がイベントループに残ることを防ぐため、
+        一時的な AsyncExitStack で隔離し、成功時のみメインの exit stack に移管する。
+        """
         if not config.url:
             raise ValueError(
                 f"MCPサーバー '{config.name}': HTTP トランスポートには url の設定が必要です。"
             )
 
-        http_transport = await self._exit_stack.enter_async_context(
-            streamable_http_client(config.url)
-        )
-        read_stream, write_stream, _ = http_transport
-        session = await self._exit_stack.enter_async_context(
-            ClientSession(read_stream, write_stream)
-        )
-        await self._initialize_session(config, session)
+        import contextlib
+
+        temp_stack = AsyncExitStack()
+        try:
+            http_transport = await temp_stack.enter_async_context(
+                streamable_http_client(config.url)
+            )
+            read_stream, write_stream, _ = http_transport
+            session = await temp_stack.enter_async_context(
+                ClientSession(read_stream, write_stream)
+            )
+            await self._initialize_session(config, session)
+        except BaseException:
+            # 接続失敗 — 一時スタックをクリーンアップして cancel scope の漏洩を防ぐ
+            with contextlib.suppress(BaseException):
+                await temp_stack.aclose()
+            raise
+
+        # 接続成功 — メインの exit stack に移管
+        self._exit_stack.push_async_callback(temp_stack.aclose)
 
     async def _initialize_session(
         self, config: MCPServerConfig, session: ClientSession

--- a/src/mcp_bridge/client_manager.py
+++ b/src/mcp_bridge/client_manager.py
@@ -6,6 +6,7 @@
 
 from __future__ import annotations
 
+import contextlib
 import logging
 from contextlib import AsyncExitStack
 from dataclasses import dataclass, field
@@ -126,8 +127,6 @@ class MCPClientManager:
                 f"MCPサーバー '{config.name}': HTTP トランスポートには url の設定が必要です。"
             )
 
-        import contextlib
-
         temp_stack = AsyncExitStack()
         try:
             http_transport = await temp_stack.enter_async_context(
@@ -140,7 +139,7 @@ class MCPClientManager:
             await self._initialize_session(config, session)
         except BaseException:
             # 接続失敗 — 一時スタックをクリーンアップして cancel scope の漏洩を防ぐ
-            with contextlib.suppress(BaseException):
+            with contextlib.suppress(BaseException):  # noqa: SIM117
                 await temp_stack.aclose()
             raise
 

--- a/tests/test_mcp_client_manager.py
+++ b/tests/test_mcp_client_manager.py
@@ -200,9 +200,9 @@ async def test_graceful_degradation_on_connection_failure() -> None:
         # 例外が発生しないこと（グレースフルデグラデーション）
         await manager.initialize([config])
 
-    # エラーログが出力されること
-    mock_logger.exception.assert_called_once()
-    assert "broken_server" in str(mock_logger.exception.call_args)
+    # 警告ログが出力されること
+    mock_logger.warning.assert_called_once()
+    assert "broken_server" in str(mock_logger.warning.call_args)
 
     # ツールは空のまま
     tools = await manager.get_available_tools()
@@ -262,8 +262,8 @@ async def test_http_transport_missing_url_logs_error() -> None:
         )
         await manager.initialize([config])
 
-    mock_logger.exception.assert_called_once()
-    assert "no_url_server" in str(mock_logger.exception.call_args)
+    mock_logger.warning.assert_called_once()
+    assert "no_url_server" in str(mock_logger.warning.call_args)
 
     tools = await manager.get_available_tools()
     assert tools == []


### PR DESCRIPTION
## Change type

- [x] fix: バグ修正 ★
- [x] test: テスト追加・修正

## Summary

- MCP サーバー（rag-knowledge 等）が未起動の場合、接続エラーを warning ログで報告し、MCP 機能を無効化して Bot/CLI の起動を継続するよう修正
- `except Exception` → `except BaseException`（`asyncio.CancelledError` は `BaseException` のサブクラス）
- HTTP 接続を一時的な `AsyncExitStack` で隔離し、接続失敗時の anyio cancel scope 漏洩を防止
- テストの `logger.exception` アサーションを `logger.warning` に更新
- config.toml を実運用値に更新（lmstudio_model, articles_per_feed, show_sources）

## Test plan

- [x] `uv run pytest` — 全364テスト通過
- [x] `uv run ruff check src/ tests/` — All checks passed
- [x] `uv run mypy src/` — no issues found
- [x] `uv run python -m src.cli --message "こんにちは"` — MCP 未起動でも正常応答を確認

## Related issues

Closes #791