### PR TITLE
fix(config-management): 設定管理を rag-knowledge の方針に合わせて見直し (#793)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,16 +9,16 @@
 
 設定値は3層に分離して管理する。詳細は `docs/specs/infrastructure/config-management.md` を参照。
 
-- **シークレット**: keyring で管理。`resolve_secret()` が環境変数 → `.env` → keyring の優先順位で取得
+- **シークレット**: keyring で管理。サービス層で `get_secret()` を直接呼び出し（フォールバックなし）
 - **環境依存値**: `.env` で管理。`src/config/settings.py` の `get_settings()` が読み込み
-- **共通設定値**: `config/config.toml`（git 管理）で管理。`get_settings()` が読み込み
+- **共通設定値**: `config/config.toml`（git 管理、フラット構造）で管理。`get_settings()` が読み込み
 - 新しい設定値は分類基準に従い適切な層に配置すること
 - 外部 HTTP リクエストは py-common-lib の `ConstrainedClient` 経由で実行すること
 
 ## LLM使い分けルール
 
 - **デフォルト**: 全サービスでローカルLLM（LM Studio）を使用
-- **設定変更**: `config/config.toml` の `[llm]` セクションで各サービスのLLMプロバイダーを変更可能（`local` / `online`）
+- **設定変更**: `config/config.toml` で各サービスのLLMプロバイダーを変更可能（`local` / `online`）
 - RAG機能は rag-knowledge リポジトリに移行済み。MCP サーバーとして `config/mcp_servers.json` で接続設定する
 
 ## 自動進行ルール（auto-progress）

--- a/README.md
+++ b/README.md
@@ -44,7 +44,6 @@ cp .env.example .env  # 環境依存値を編集
 ```
 
 API キー・トークンは OS セキュアストレージ（keyring）で管理する（サービス名: `ai-assistant`）。
-環境変数・`.env` でも設定可能（keyring より優先）。
 登録方法は [py-common-lib の仕様書](https://github.com/becky3/py-common-lib/blob/main/docs/specs/infrastructure/secret-store.md) を参照。
 
 ## 設定管理

--- a/config/config.toml
+++ b/config/config.toml
@@ -1,4 +1,3 @@
-[llm]
 online_llm_provider = "openai"
 chat_llm_provider = "local"
 profiler_llm_provider = "local"
@@ -7,18 +6,10 @@ summarizer_llm_provider = "local"
 openai_model = "gpt-4o-mini"
 anthropic_model = "claude-3-5-sonnet-20241022"
 lmstudio_model = "qwen/qwen3-next-80b"
-
-[app]
 timezone = "Asia/Tokyo"
-
-[feed]
-articles_per_feed = 50
-card_layout = "horizontal"
-summarize_timeout = 180
-collect_days = 7
-
-[thread]
-history_limit = 20
-
-[rag]
-show_sources = true
+feed_articles_per_feed = 50
+feed_card_layout = "horizontal"
+feed_summarize_timeout = 180
+feed_collect_days = 7
+thread_history_limit = 20
+rag_show_sources = true

--- a/docs/specs/infrastructure/config-management.md
+++ b/docs/specs/infrastructure/config-management.md
@@ -12,7 +12,6 @@
 
 ## 制約
 
-- 移行は段階的に行う。本仕様書は最終形の設計を定義し、実装は後続 Issue で段階的に進める
 - 既存の `pydantic-settings` ベースの `Settings` クラスを拡張する形で実装する（フレームワーク変更は行わない）
 - `config/assistant.yaml`（アシスタント性格設定）および `config/mcp_servers.json`（MCP サーバー設定）は本仕様の対象外とする。それぞれ独自の形式で適切に管理されている
 - keyring のバックエンドは OS に依存する（Windows: Credential Manager、macOS: Keychain、Linux: Secret Service）。バックエンド固有の挙動差異は keyring ライブラリが吸収する
@@ -27,31 +26,31 @@
 | 環境依存値 | `.env` | 管理外 | デプロイ先・マシンごとに異なる値 |
 | 共通設定値 | `config/config.toml` | **管理する** | プロジェクトとして統一管理するパラメータ |
 
-### 設定値の解決優先順位
+### 設定値の取得元
 
-同一の設定項目が複数の層に存在する場合、以下の優先順位で解決する:
+各設定値の取得元は1つに固定する（フォールバックなし）:
 
-1. 環境変数（`.env` / シェル環境変数）
-2. keyring（シークレット層の設定項目のみ）
-3. `config/config.toml`
-4. コード上のデフォルト値
+| 層 | 取得元 | 取得方法 |
+|---|---|---|
+| シークレット | keyring のみ | py-common-lib の `get_secret(key=..., service="ai-assistant")` をサービス層で直接呼び出す |
+| 環境依存値 | `.env` のみ | `_EnvLoader`（pydantic-settings）が読み込み、`Settings` に統合 |
+| 共通設定値 | `config/config.toml` のみ | `_load_toml_config()` が読み込み、`Settings` に統合 |
 
-シークレット層の設定項目は、まず環境変数を確認し、未設定の場合に keyring から取得する。環境変数による上書きは、デバッグ・一時的な変更・CI 環境での挙動変更に使用する。
+環境変数による上書きは行わない。各層の設定値は指定された取得元からのみ取得する。
 
 ### 設定値の取得
 
-`get_settings()` 関数がキャッシュ付きで `Settings` オブジェクトを返す。呼び出し元は設定値のソース（keyring / `.env` / `config.toml`）を意識しない。
+`get_settings()` 関数がキャッシュ付きで `Settings` オブジェクトを返す。`Settings` にはシークレット層のフィールドを含まない。シークレットは使用箇所で `get_secret()` を直接呼び出して取得する。
 
 ### keyring 連携
 
 keyring のサービス名は `ai-assistant`、キー名は環境変数名と同一にする（例: `SLACK_BOT_TOKEN`）。
 
-keyring からの取得に失敗した場合（keyring 未インストール・キー未登録等）、従来どおり環境変数からの読み込みにフォールバックする。これにより、keyring 未設定の開発環境でも `.env` のみで動作する。
+keyring からの取得に失敗した場合（keyring 未インストール・キー未登録等）は `SecretNotFoundError` を送出する。フォールバックは行わない。
 
 ### config.toml の構造
 
 ```toml
-[llm]
 online_llm_provider = "openai"
 chat_llm_provider = "local"
 profiler_llm_provider = "local"
@@ -60,32 +59,24 @@ summarizer_llm_provider = "local"
 openai_model = "gpt-4o-mini"
 anthropic_model = "claude-3-5-sonnet-20241022"
 lmstudio_model = "local-model"
-
-[app]
 timezone = "Asia/Tokyo"
-
-[feed]
-articles_per_feed = 10
-card_layout = "horizontal"
-summarize_timeout = 180
-collect_days = 7
-
-[thread]
-history_limit = 20
-
-[rag]
-show_sources = false
+feed_articles_per_feed = 10
+feed_card_layout = "horizontal"
+feed_summarize_timeout = 180
+feed_collect_days = 7
+thread_history_limit = 20
+rag_show_sources = false
 ```
 
-TOML のキー名は Settings クラスの属性名からプレフィックス（セクション名に対応する部分）を除いた形とする。例: `feed_articles_per_feed` → `[feed]` セクションの `articles_per_feed`。`[llm]` セクションのキーは Settings 属性名と同一（`online_llm_provider` 等）とし、サブテーブルは使用しない。
+TOML はフラット構造（セクションなし）とし、キー名は `Settings` クラスのフィールド名と一致させる。
 
 ### 全設定値の3層分類
 
-#### シークレット層（keyring へ移行）
+#### シークレット層（keyring）
 
 漏洩時に直接被害が発生する認証情報。OS のセキュアストレージ（keyring）で管理する。
 
-| 設定項目 | 現行環境変数 | 説明 |
+| 設定項目 | keyring キー名 | 説明 |
 |---|---|---|
 | `slack_bot_token` | `SLACK_BOT_TOKEN` | Slack Bot トークン |
 | `slack_signing_secret` | `SLACK_SIGNING_SECRET` | Slack 署名シークレット |
@@ -93,42 +84,42 @@ TOML のキー名は Settings クラスの属性名からプレフィックス�
 | `openai_api_key` | `OPENAI_API_KEY` | OpenAI API キー |
 | `anthropic_api_key` | `ANTHROPIC_API_KEY` | Anthropic API キー |
 
-#### 環境依存値層（.env に残留）
+#### 環境依存値層（.env）
 
 デプロイ先・マシンごとに異なる値。`.env` ファイルで管理する。
 
-| 設定項目 | 現行環境変数 | デフォルト | 説明 |
+| 設定項目 | 環境変数名 | デフォルト | 説明 |
 |---|---|---|---|
-| `lmstudio_base_url` | `LMSTUDIO_BASE_URL` | `http://localhost:1234` | LM Studio の接続先 URL |
-| `database_url` | `DATABASE_URL` | `sqlite+aiosqlite:///./ai_assistant.db` | データベース接続文字列 |
-| `slack_news_channel_id` | `SLACK_NEWS_CHANNEL_ID` | （なし） | フィード配信先チャンネル ID |
-| `slack_auto_reply_channels` | `SLACK_AUTO_REPLY_CHANNELS` | （なし） | 自動返信チャンネル ID（カンマ区切り） |
-| `env_name` | `ENV_NAME` | （なし） | 環境名（ステータス表示用） |
+| `lmstudio_base_url` | `LMSTUDIO_BASE_URL` | — | LM Studio の接続先 URL |
+| `database_url` | `DATABASE_URL` | — | データベース接続文字列 |
+| `slack_news_channel_id` | `SLACK_NEWS_CHANNEL_ID` | `""`（空文字列） | フィード配信先チャンネル ID |
+| `slack_auto_reply_channels` | `SLACK_AUTO_REPLY_CHANNELS` | `""`（空文字列） | 自動返信チャンネル ID（カンマ区切り） |
+| `env_name` | `ENV_NAME` | `""`（空文字列） | 環境名（ステータス表示用） |
 | `mcp_enabled` | `MCP_ENABLED` | `false` | MCP 機能の有効/無効 |
 | `mcp_servers_config` | `MCP_SERVERS_CONFIG` | `config/mcp_servers.json` | MCP サーバー設定ファイルパス |
 | `log_level` | `LOG_LEVEL` | `INFO` | ログ出力レベル |
 
-#### 共通設定値層（config.toml へ移行）
+#### 共通設定値層（config.toml）
 
-プロジェクトとして統一管理するパラメータ。`config/config.toml` で git 管理する。
+プロジェクトとして統一管理するパラメータ。`config/config.toml` で git 管理する。デフォルト値は持たない（config.toml に全値を明示する）。
 
-| 設定項目 | 現行環境変数 | デフォルト | 許容範囲 | 説明 |
-|---|---|---|---|---|
-| `online_llm_provider` | `ONLINE_LLM_PROVIDER` | `openai` | `openai` / `anthropic` | オンライン LLM プロバイダー |
-| `chat_llm_provider` | `CHAT_LLM_PROVIDER` | `local` | `local` / `online` | チャット応答の LLM 選択 |
-| `profiler_llm_provider` | `PROFILER_LLM_PROVIDER` | `local` | `local` / `online` | ユーザー情報抽出の LLM 選択 |
-| `topic_llm_provider` | `TOPIC_LLM_PROVIDER` | `local` | `local` / `online` | トピック提案の LLM 選択 |
-| `summarizer_llm_provider` | `SUMMARIZER_LLM_PROVIDER` | `local` | `local` / `online` | 記事要約の LLM 選択 |
-| `openai_model` | `OPENAI_MODEL` | `gpt-4o-mini` | — | OpenAI モデル名 |
-| `anthropic_model` | `ANTHROPIC_MODEL` | `claude-3-5-sonnet-20241022` | — | Anthropic モデル名 |
-| `lmstudio_model` | `LMSTUDIO_MODEL` | `local-model` | — | LM Studio モデル名 |
-| `timezone` | `TIMEZONE` | `Asia/Tokyo` | IANA タイムゾーン | アプリケーションのタイムゾーン |
-| `feed_articles_per_feed` | `FEED_ARTICLES_PER_FEED` | `10` | 1 以上の整数 | フィードごとの配信記事数上限 |
-| `feed_card_layout` | `FEED_CARD_LAYOUT` | `horizontal` | `vertical` / `horizontal` | フィードカードのレイアウト |
-| `feed_summarize_timeout` | `FEED_SUMMARIZE_TIMEOUT` | `180` | 0 以上の整数（秒、0=無制限） | 要約タイムアウト |
-| `feed_collect_days` | `FEED_COLLECT_DAYS` | `7` | 1 以上の整数 | 収集対象の日数 |
-| `thread_history_limit` | `THREAD_HISTORY_LIMIT` | `20` | 1〜100 | スレッド履歴取得の最大件数 |
-| `rag_show_sources` | `RAG_SHOW_SOURCES` | `false` | `true` / `false` | RAG 参照元 URL 表示（デバッグ用） |
+| 設定項目 | config.toml キー名 | 許容範囲 | 説明 |
+|---|---|---|---|
+| `online_llm_provider` | `online_llm_provider` | `openai` / `anthropic` | オンライン LLM プロバイダー |
+| `chat_llm_provider` | `chat_llm_provider` | `local` / `online` | チャット応答の LLM 選択 |
+| `profiler_llm_provider` | `profiler_llm_provider` | `local` / `online` | ユーザー情報抽出の LLM 選択 |
+| `topic_llm_provider` | `topic_llm_provider` | `local` / `online` | トピック提案の LLM 選択 |
+| `summarizer_llm_provider` | `summarizer_llm_provider` | `local` / `online` | 記事要約の LLM 選択 |
+| `openai_model` | `openai_model` | — | OpenAI モデル名 |
+| `anthropic_model` | `anthropic_model` | — | Anthropic モデル名 |
+| `lmstudio_model` | `lmstudio_model` | — | LM Studio モデル名 |
+| `timezone` | `timezone` | IANA タイムゾーン | アプリケーションのタイムゾーン |
+| `feed_articles_per_feed` | `feed_articles_per_feed` | 1 以上の整数 | フィードごとの配信記事数上限 |
+| `feed_card_layout` | `feed_card_layout` | `vertical` / `horizontal` | フィードカードのレイアウト |
+| `feed_summarize_timeout` | `feed_summarize_timeout` | 0 以上の整数（秒、0=無制限） | 要約タイムアウト |
+| `feed_collect_days` | `feed_collect_days` | 1 以上の整数 | 収集対象の日数 |
+| `thread_history_limit` | `thread_history_limit` | 1〜100 | スレッド履歴取得の最大件数 |
+| `rag_show_sources` | `rag_show_sources` | `true` / `false` | RAG 参照元 URL 表示（デバッグ用） |
 
 #### 分類判断の根拠
 
@@ -142,8 +133,8 @@ TOML のキー名は Settings クラスの属性名からプレフィックス�
 | `ENV_NAME` | 環境依存値 | 環境識別子はデプロイ先ごとに異なる |
 | `MCP_ENABLED` | 環境依存値 | MCP サーバーの有無はデプロイ環境に依存 |
 | `LOG_LEVEL` | 環境依存値 | 本番・開発でログレベルを変えるため |
-| `TIMEZONE` | 共通設定値 | Issue #779 では環境依存値としていたが、タイムゾーンはプロジェクト共通の運用方針であり環境ごとに変える必要がないため再分類。環境ごとに変えたい場合は環境変数で上書き可能 |
-| LLM プロバイダー選択 | 共通設定値 | プロジェクトとしてどの LLM を使うかの方針。環境ごとに変えたい場合は環境変数で上書き |
+| `TIMEZONE` | 共通設定値 | タイムゾーンはプロジェクト共通の運用方針であり環境ごとに変える必要がない |
+| LLM プロバイダー選択 | 共通設定値 | プロジェクトとしてどの LLM を使うかの方針 |
 | モデル名 | 共通設定値 | プロジェクトとして使用するモデルの統一管理 |
 | Feed パラメータ | 共通設定値 | チューニングパラメータ。プロジェクト共通の値を git 管理する |
 | `THREAD_HISTORY_LIMIT` | 共通設定値 | アプリケーション動作パラメータ。プロジェクト共通 |
@@ -152,34 +143,31 @@ TOML のキー名は Settings クラスの属性名からプレフィックス�
 
 ```mermaid
 flowchart TD
-    A["アプリケーション起動"] --> B["keyring からシークレット取得"]
+    A["アプリケーション起動"] --> B["keyring からシークレット取得（使用箇所で直接）"]
     A --> C[".env から環境依存値読み込み"]
     A --> D["config/config.toml から共通設定値読み込み"]
-    B --> E["Settings オブジェクト構築"]
-    C --> E
+    C --> E["Settings オブジェクト構築"]
     D --> E
-    E --> F["環境変数による上書き適用"]
-    F --> G["バリデーション（pydantic）"]
-    G --> H["キャッシュして返却"]
+    E --> F["バリデーション（pydantic）"]
+    F --> G["キャッシュして返却"]
 ```
 
 | コンポーネント | 役割 |
 |---|---|
-| Settings クラス | 3つのソースを統合し、バリデーション済みの設定オブジェクトを提供する |
-| TOML ローダー | `config/config.toml` を読み込み、共通設定値を `Settings` に供給する |
-| keyring アクセサー | OS セキュアストレージからシークレットを取得し、`Settings` に供給する |
+| Settings クラス | 環境依存値と共通設定値を統合し、バリデーション済みの設定オブジェクトを提供する（シークレットは含まない） |
+| TOML ローダー | `config/config.toml` を読み込み、未知キー検証を行い、共通設定値を `Settings` に供給する |
 | `get_settings()` | `Settings` のキャッシュ付きシングルトンアクセスを提供する |
 
 ## エッジケース
 
 | ケース | 振る舞い |
 |---|---|
-| `config/config.toml` が存在しない | デフォルト値で動作する（`config/config.toml` は任意） |
-| keyring 未インストール・取得失敗 | 環境変数にフォールバック |
-| 環境変数と `config/config.toml` の両方に同一キーが存在 | 環境変数を優先 |
+| `config/config.toml` が存在しない | `FileNotFoundError` で起動中止 |
+| `config/config.toml` に未知のキーが含まれる | `ValueError` で起動中止 |
 | `config/config.toml` のバリデーションエラー | 起動時にエラーメッセージを出力して中止 |
-| Slack 必須シークレットが未設定（keyring にも環境変数にもない） | 起動時にエラーメッセージを出力して中止する。必須項目: `SLACK_BOT_TOKEN`、`SLACK_APP_TOKEN` |
-| 任意シークレットが未設定（`OPENAI_API_KEY` 等） | 空文字列のまま（該当機能使用時にエラー） |
+| keyring 未設定（キー未登録） | `SecretNotFoundError` を送出（フォールバックなし） |
+| Slack 必須シークレットが未設定 | 起動時にエラーメッセージを出力して中止する。必須項目: `SLACK_BOT_TOKEN`、`SLACK_APP_TOKEN` |
+| 任意シークレットが未設定（`OPENAI_API_KEY` 等） | 該当機能使用時に `SecretNotFoundError` |
 
 ## 関連ドキュメント
 

--- a/docs/specs/infrastructure/config-management.md
+++ b/docs/specs/infrastructure/config-management.md
@@ -166,7 +166,7 @@ flowchart TD
 | `config/config.toml` に未知のキーが含まれる | `ValueError` で起動中止 |
 | `config/config.toml` のバリデーションエラー | 起動時にエラーメッセージを出力して中止 |
 | keyring 未設定（キー未登録） | `SecretNotFoundError` を送出（フォールバックなし） |
-| Slack 必須シークレットが未設定 | 起動時にエラーメッセージを出力して中止する。必須項目: `SLACK_BOT_TOKEN`、`SLACK_APP_TOKEN` |
+| Slack 必須シークレットが未設定 | 起動時にエラーメッセージを出力して中止する。必須項目: `SLACK_BOT_TOKEN`、`SLACK_APP_TOKEN`、`SLACK_SIGNING_SECRET` |
 | 任意シークレットが未設定（`OPENAI_API_KEY` 等） | 該当機能使用時に `SecretNotFoundError` |
 
 ## 関連ドキュメント

--- a/docs/specs/overview.md
+++ b/docs/specs/overview.md
@@ -41,7 +41,7 @@ AI Assistantは、Slack上で動作するAIアシスタントである。
 ## 4. LLM使い分けルール
 
 全サービスでローカルLLM（LM Studio）をデフォルトで使用する。
-各サービスごとに `config/config.toml` の `[llm]` セクションで使用するLLMを変更可能。
+各サービスごとに `config/config.toml` で使用するLLMを変更可能。
 
 ### サービスごとのLLM設定
 
@@ -58,7 +58,6 @@ AI Assistantは、Slack上で動作するAIアシスタントである。
 ### 設定例
 
 ```toml
-[llm]
 # 全てローカル（デフォルト）
 chat_llm_provider = "local"
 profiler_llm_provider = "local"

--- a/scripts/test_delivery.py
+++ b/scripts/test_delivery.py
@@ -19,7 +19,9 @@ from datetime import datetime, timezone
 
 from slack_sdk.web.async_client import AsyncWebClient
 
-from src.config.settings import get_settings, resolve_secret
+from py_common_lib.secrets import SecretNotFoundError, get_secret
+
+from src.config.settings import SERVICE_NAME, get_settings
 from src.db.models import Article, Feed
 from src.db.session import get_session_factory, init_db
 from src.scheduler.jobs import format_daily_digest, post_article_to_thread
@@ -91,9 +93,13 @@ DUMMY_ARTICLES = [
 async def main() -> None:
     settings = get_settings()
 
-    bot_token = resolve_secret("SLACK_BOT_TOKEN")
-    if not bot_token or not settings.slack_news_channel_id:
-        print("エラー: SLACK_BOT_TOKEN と SLACK_NEWS_CHANNEL_ID を設定してください")
+    try:
+        bot_token = get_secret(key="SLACK_BOT_TOKEN", service=SERVICE_NAME)
+    except SecretNotFoundError:
+        print("エラー: SLACK_BOT_TOKEN が keyring に未設定です")
+        return
+    if not settings.slack_news_channel_id:
+        print("エラー: SLACK_NEWS_CHANNEL_ID を .env に設定してください")
         return
 
     # 引数があればそれを使う、なければ .env の設定

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -1,8 +1,8 @@
 """アプリケーション設定管理
 仕様: docs/specs/infrastructure/config-management.md
 
-設定値はセキュリティレベルに応じて3層に分離し、各値の取得元を明確にする:
-- シークレット: OS セキュアストレージ (keyring) — resolve_secret() で取得
+設定値はセキュリティレベルに応じて3層に分離し、各値の取得元を1つに固定する（フォールバックなし）:
+- シークレット: OS セキュアストレージ (keyring) — サービス層で get_secret() を直接呼び出す
 - 環境依存値: .env（_EnvLoader）
 - 共通設定値: config/config.toml
 """
@@ -10,58 +10,19 @@
 from __future__ import annotations
 
 import functools
-import logging
-import os
 import tomllib
 from pathlib import Path
 from typing import Any, Literal
 
 import yaml
-from dotenv import dotenv_values
 from pydantic import BaseModel, Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
-from py_common_lib.secrets import SecretNotFoundError, SecretStoreError, get_secret
-
-logger = logging.getLogger(__name__)
-
 DEFAULT_LMSTUDIO_BASE_URL = "http://localhost:1234"
 
-_SERVICE_NAME = "ai-assistant"
+SERVICE_NAME = "ai-assistant"
 _PROJECT_ROOT = Path(__file__).parent.parent.parent
 _TOML_FILE = _PROJECT_ROOT / "config" / "config.toml"
-
-
-def resolve_secret(key: str) -> str:
-    """環境変数 → .env → keyring の優先順位でシークレットを取得する.
-
-    仕様: docs/specs/infrastructure/config-management.md（設定値の解決優先順位）
-
-    os.environ を汚染しないよう、.env は dotenv_values() で直接読み取る。
-
-    Args:
-        key: 環境変数名と同一のキー名（例: "SLACK_BOT_TOKEN"）
-
-    Returns:
-        取得したシークレット値。未設定の場合は空文字列。
-    """
-    # 1. シェル環境変数
-    value = os.environ.get(key, "")
-    if value:
-        return value
-    # 2. .env ファイル（os.environ を変更せず直接読み取り）
-    env_values = dotenv_values()
-    value = env_values.get(key) or ""
-    if value:
-        return value
-    # 3. keyring
-    try:
-        return get_secret(key=key, service=_SERVICE_NAME)
-    except SecretNotFoundError:
-        return ""
-    except SecretStoreError:
-        logger.warning("keyring アクセスに失敗しました: key=%s", key, exc_info=True)
-        return ""
 
 
 class _EnvLoader(BaseSettings):
@@ -106,9 +67,10 @@ class Settings(BaseModel):
 
     仕様: docs/specs/infrastructure/config-management.md
 
-    各設定値の取得元:
+    各設定値の取得元は1つに固定（フォールバックなし）:
     - 環境依存値(.env): slack_news_channel_id, lmstudio_base_url 等
     - 共通設定値(config.toml): online_llm_provider, feed_articles_per_feed 等
+    - シークレットは Settings に含まない（使用箇所で get_secret() を直接呼び出す）
     """
 
     # --- .env から取得（環境依存値） ---
@@ -127,80 +89,47 @@ class Settings(BaseModel):
             return []
         return [ch.strip() for ch in self.slack_auto_reply_channels.split(",") if ch.strip()]
 
-    # --- config.toml から取得（共通設定値、config.toml 不存在時はデフォルトで動作） ---
+    # --- config.toml から取得（共通設定値、config.toml 必須） ---
 
     # LLM
-    online_llm_provider: Literal["openai", "anthropic"] = "openai"
-    chat_llm_provider: Literal["local", "online"] = "local"
-    profiler_llm_provider: Literal["local", "online"] = "local"
-    topic_llm_provider: Literal["local", "online"] = "local"
-    summarizer_llm_provider: Literal["local", "online"] = "local"
-    openai_model: str = "gpt-4o-mini"
-    anthropic_model: str = "claude-3-5-sonnet-20241022"
-    lmstudio_model: str = "local-model"
+    online_llm_provider: Literal["openai", "anthropic"]
+    chat_llm_provider: Literal["local", "online"]
+    profiler_llm_provider: Literal["local", "online"]
+    topic_llm_provider: Literal["local", "online"]
+    summarizer_llm_provider: Literal["local", "online"]
+    openai_model: str
+    anthropic_model: str
+    lmstudio_model: str
 
     # App
-    timezone: str = "Asia/Tokyo"
+    timezone: str
 
     # Feed
-    feed_articles_per_feed: int = Field(default=10, ge=1)
-    feed_card_layout: Literal["vertical", "horizontal"] = "horizontal"
-    feed_summarize_timeout: int = Field(default=180, ge=0)
-    feed_collect_days: int = Field(default=7, ge=1)
+    feed_articles_per_feed: int = Field(ge=1)
+    feed_card_layout: Literal["vertical", "horizontal"]
+    feed_summarize_timeout: int = Field(ge=0)
+    feed_collect_days: int = Field(ge=1)
 
     # Thread
-    thread_history_limit: int = Field(default=20, ge=1, le=100)
+    thread_history_limit: int = Field(ge=1, le=100)
 
     # RAG
-    rag_show_sources: bool = False
-
-
-# TOML セクション → Settings フィールド名のマッピング
-_TOML_KEY_MAP: dict[str, dict[str, str]] = {
-    "llm": {
-        "online_llm_provider": "online_llm_provider",
-        "chat_llm_provider": "chat_llm_provider",
-        "profiler_llm_provider": "profiler_llm_provider",
-        "topic_llm_provider": "topic_llm_provider",
-        "summarizer_llm_provider": "summarizer_llm_provider",
-        "openai_model": "openai_model",
-        "anthropic_model": "anthropic_model",
-        "lmstudio_model": "lmstudio_model",
-    },
-    "app": {
-        "timezone": "timezone",
-    },
-    "feed": {
-        "articles_per_feed": "feed_articles_per_feed",
-        "card_layout": "feed_card_layout",
-        "summarize_timeout": "feed_summarize_timeout",
-        "collect_days": "feed_collect_days",
-    },
-    "thread": {
-        "history_limit": "thread_history_limit",
-    },
-    "rag": {
-        "show_sources": "rag_show_sources",
-    },
-}
+    rag_show_sources: bool
 
 
 def _load_toml_config() -> dict[str, Any]:
-    """config.toml を読み込み、Settings フィールド名にフラット化する.
+    """config.toml を読み込み、層の重複と未知キーを検証する.
 
-    仕様: config.toml が存在しない場合は空 dict を返す（デフォルト値で動作）。
+    仕様: config.toml が存在しない場合は FileNotFoundError を送出する。
     """
     if not _TOML_FILE.exists():
-        return {}
+        msg = f"config.toml が見つかりません: {_TOML_FILE}"
+        raise FileNotFoundError(msg)
     with open(_TOML_FILE, "rb") as f:
         data: dict[str, Any] = tomllib.load(f)
 
     # config.toml に環境依存値が混入していないか検証
-    all_toml_keys: set[str] = set()
-    for section_data in data.values():
-        if isinstance(section_data, dict):
-            all_toml_keys.update(section_data.keys())
-    env_overlap = all_toml_keys & _ENV_FIELD_NAMES
+    env_overlap = set(data.keys()) & _ENV_FIELD_NAMES
     if env_overlap:
         msg = (
             f"config.toml に環境依存設定が含まれています（.env に移動してください）: "
@@ -208,14 +137,14 @@ def _load_toml_config() -> dict[str, Any]:
         )
         raise ValueError(msg)
 
-    # セクション構造を Settings フィールド名にフラット化
-    flat: dict[str, Any] = {}
-    for section, key_map in _TOML_KEY_MAP.items():
-        section_data = data.get(section, {})
-        for toml_key, field_name in key_map.items():
-            if toml_key in section_data:
-                flat[field_name] = section_data[toml_key]
-    return flat
+    # 未知のキーを検証
+    toml_field_names = frozenset(Settings.model_fields.keys()) - _ENV_FIELD_NAMES
+    unknown = set(data.keys()) - toml_field_names
+    if unknown:
+        msg = f"config.toml に未知の設定が含まれています: {sorted(unknown)}"
+        raise ValueError(msg)
+
+    return data
 
 
 @functools.lru_cache(maxsize=1)
@@ -227,16 +156,7 @@ def get_settings() -> Settings:
     """
     toml_data = _load_toml_config()
     env_loader = _EnvLoader()  # type: ignore[call-arg]  # pydantic-settings が .env/環境変数から読み込み
-    # 優先順位: 環境変数(.env) > config.toml > デフォルト値
-    # 共通設定値も環境変数で上書き可能（デバッグ・CI用）
-    merged = {**toml_data, **env_loader.model_dump()}
-    # 環境変数に共通設定値のキーがあれば上書き
-    for field_name in Settings.model_fields:
-        env_key = field_name.upper()
-        env_val = os.environ.get(env_key)
-        if env_val is not None and field_name not in _ENV_FIELD_NAMES:
-            merged[field_name] = env_val
-    return Settings(**merged)
+    return Settings(**toml_data, **env_loader.model_dump())
 
 
 def load_assistant_config(path: str | Path = "config/assistant.yaml") -> dict[str, Any]:

--- a/src/llm/factory.py
+++ b/src/llm/factory.py
@@ -6,7 +6,9 @@ from __future__ import annotations
 
 from typing import Literal
 
-from src.config.settings import Settings, resolve_secret
+from py_common_lib.secrets import get_secret
+
+from src.config.settings import SERVICE_NAME, Settings
 from src.llm.anthropic_provider import AnthropicProvider
 from src.llm.base import LLMProvider
 from src.llm.lmstudio_provider import LMStudioProvider
@@ -17,11 +19,11 @@ def create_online_provider(settings: Settings) -> LLMProvider:
     """設定に応じたオンラインLLMプロバイダーを生成する."""
     if settings.online_llm_provider == "anthropic":
         return AnthropicProvider(
-            api_key=resolve_secret("ANTHROPIC_API_KEY"),
+            api_key=get_secret(key="ANTHROPIC_API_KEY", service=SERVICE_NAME),
             model=settings.anthropic_model,
         )
     return OpenAIProvider(
-        api_key=resolve_secret("OPENAI_API_KEY"),
+        api_key=get_secret(key="OPENAI_API_KEY", service=SERVICE_NAME),
         model=settings.openai_model,
     )
 

--- a/src/main.py
+++ b/src/main.py
@@ -13,7 +13,9 @@ from pathlib import Path
 from typing import TYPE_CHECKING
 from zoneinfo import ZoneInfo
 
-from src.config.settings import get_settings, load_assistant_config, resolve_secret
+from py_common_lib.secrets import SecretNotFoundError, get_secret
+
+from src.config.settings import SERVICE_NAME, get_settings, load_assistant_config
 from src.process_guard import (
     BOT_READY_SIGNAL,
     check_already_running,
@@ -87,10 +89,12 @@ async def main() -> None:
     # 必須シークレットの起動時バリデーション（仕様: config-management.md エッジケース）
     _required_secrets = ["SLACK_BOT_TOKEN", "SLACK_APP_TOKEN"]
     for _key in _required_secrets:
-        if not resolve_secret(_key):
+        try:
+            get_secret(key=_key, service=SERVICE_NAME)
+        except SecretNotFoundError:
             raise SystemExit(
                 f"必須シークレット {_key} が未設定です。"
-                f"keyring または環境変数で設定してください。"
+                f"keyring で設定してください。"
             )
 
     mcp_manager: MCPClientManager | None = None
@@ -196,7 +200,7 @@ async def main() -> None:
             channel_id=settings.slack_news_channel_id,
             max_articles_per_feed=settings.feed_articles_per_feed,
             feed_card_layout=settings.feed_card_layout,
-            bot_token=resolve_secret("SLACK_BOT_TOKEN"),
+            bot_token=get_secret(key="SLACK_BOT_TOKEN", service=SERVICE_NAME),
             timezone=settings.timezone,
             env_name=settings.env_name,
             mcp_manager=mcp_manager,

--- a/src/main.py
+++ b/src/main.py
@@ -87,7 +87,7 @@ async def main() -> None:
     from src.slack.handlers import register_handlers
 
     # 必須シークレットの起動時バリデーション（仕様: config-management.md エッジケース）
-    _required_secrets = ["SLACK_BOT_TOKEN", "SLACK_APP_TOKEN"]
+    _required_secrets = ["SLACK_BOT_TOKEN", "SLACK_APP_TOKEN", "SLACK_SIGNING_SECRET"]
     for _key in _required_secrets:
         try:
             get_secret(key=_key, service=SERVICE_NAME)

--- a/src/slack/app.py
+++ b/src/slack/app.py
@@ -7,31 +7,36 @@ from __future__ import annotations
 from contextlib import asynccontextmanager
 from typing import AsyncIterator
 
+from py_common_lib.secrets import get_secret
 from slack_bolt.async_app import AsyncApp
 from slack_bolt.adapter.socket_mode.async_handler import AsyncSocketModeHandler
 
-from src.config.settings import resolve_secret
+from src.config.settings import SERVICE_NAME
 
 
 def create_app() -> AsyncApp:
     """Slack Bolt AsyncApp を生成する."""
     app = AsyncApp(
-        token=resolve_secret("SLACK_BOT_TOKEN"),
-        signing_secret=resolve_secret("SLACK_SIGNING_SECRET"),
+        token=get_secret(key="SLACK_BOT_TOKEN", service=SERVICE_NAME),
+        signing_secret=get_secret(key="SLACK_SIGNING_SECRET", service=SERVICE_NAME),
     )
     return app
 
 
 async def start_socket_mode(app: AsyncApp) -> None:
     """Socket Mode でアプリを起動する."""
-    handler = AsyncSocketModeHandler(app, resolve_secret("SLACK_APP_TOKEN"))
+    handler = AsyncSocketModeHandler(
+        app, get_secret(key="SLACK_APP_TOKEN", service=SERVICE_NAME),
+    )
     await handler.start_async()  # type: ignore[no-untyped-call]
 
 
 @asynccontextmanager
 async def socket_mode_handler(app: AsyncApp) -> AsyncIterator[AsyncSocketModeHandler]:
     """Socket Mode ハンドラーのコンテキストマネージャー."""
-    handler = AsyncSocketModeHandler(app, resolve_secret("SLACK_APP_TOKEN"))
+    handler = AsyncSocketModeHandler(
+        app, get_secret(key="SLACK_APP_TOKEN", service=SERVICE_NAME),
+    )
     try:
         yield handler
     finally:

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -6,14 +6,12 @@ from pathlib import Path
 from unittest.mock import patch
 
 import pytest
-from py_common_lib.secrets import SecretNotFoundError, SecretStoreError
 
 from src.config.settings import (
     Settings,
     _EnvLoader,
     _load_toml_config,
     load_assistant_config,
-    resolve_secret,
 )
 
 from .settings_defaults import TEST_SETTINGS_DEFAULTS
@@ -39,6 +37,17 @@ def test_settings_from_defaults() -> None:
     assert s.feed_articles_per_feed == 10
 
 
+def test_settings_no_defaults_for_toml_fields() -> None:
+    """共通設定値フィールドにデフォルト値がないこと."""
+    from src.config.settings import _ENV_FIELD_NAMES
+
+    for name, field_info in Settings.model_fields.items():
+        if name not in _ENV_FIELD_NAMES:
+            assert field_info.is_required(), (
+                f"Settings.{name} にデフォルト値があります（config.toml 必須のため不要）"
+            )
+
+
 def test_get_settings_loads_from_env_and_toml() -> None:
     """get_settings() が .env と config.toml から統合して読み込める."""
     from src.config.settings import get_settings
@@ -51,19 +60,35 @@ def test_get_settings_loads_from_env_and_toml() -> None:
 
 
 def test_toml_config_loads() -> None:
-    """config.toml が正しくフラット化される."""
+    """config.toml がフラット構造で正しく読み込まれる."""
     data = _load_toml_config()
     assert "online_llm_provider" in data
     assert "feed_articles_per_feed" in data
     assert "thread_history_limit" in data
 
 
+def test_toml_missing_raises_file_not_found(tmp_path: Path) -> None:
+    """config.toml が存在しない場合は FileNotFoundError."""
+    with patch("src.config.settings._TOML_FILE", tmp_path / "nonexistent.toml"):
+        with pytest.raises(FileNotFoundError, match="config.toml が見つかりません"):
+            _load_toml_config()
+
+
 def test_toml_env_overlap_raises(tmp_path: Path) -> None:
     """config.toml に環境依存値が含まれる場合はエラー."""
     toml_file = tmp_path / "config.toml"
-    toml_file.write_text('[bad]\nlmstudio_base_url = "http://localhost:1234"\n')
+    toml_file.write_text('lmstudio_base_url = "http://localhost:1234"\n')
     with patch("src.config.settings._TOML_FILE", toml_file):
         with pytest.raises(ValueError, match="環境依存設定が含まれています"):
+            _load_toml_config()
+
+
+def test_toml_unknown_key_raises(tmp_path: Path) -> None:
+    """config.toml に未知のキーが含まれる場合はエラー."""
+    toml_file = tmp_path / "config.toml"
+    toml_file.write_text('unknown_setting = "value"\n')
+    with patch("src.config.settings._TOML_FILE", toml_file):
+        with pytest.raises(ValueError, match="未知の設定が含まれています"):
             _load_toml_config()
 
 
@@ -72,64 +97,6 @@ def test_env_loader_fields_match() -> None:
     from src.config.settings import _ENV_FIELD_NAMES
 
     assert _ENV_FIELD_NAMES == frozenset(_EnvLoader.model_fields.keys())
-
-
-def test_resolve_secret_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
-    """resolve_secret は環境変数を優先する."""
-    monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxb-from-env")
-    assert resolve_secret("SLACK_BOT_TOKEN") == "xoxb-from-env"
-
-
-def test_resolve_secret_from_keyring(monkeypatch: pytest.MonkeyPatch) -> None:
-    """環境変数・.env 未設定時は keyring から取得する."""
-    monkeypatch.delenv("SLACK_BOT_TOKEN", raising=False)
-    with (
-        patch("src.config.settings.dotenv_values", return_value={}),
-        patch("src.config.settings.get_secret", return_value="xoxb-from-keyring"),
-    ):
-        assert resolve_secret("SLACK_BOT_TOKEN") == "xoxb-from-keyring"
-
-
-def test_resolve_secret_from_dotenv(monkeypatch: pytest.MonkeyPatch) -> None:
-    """.env ファイルから取得できる（os.environ は汚染しない）."""
-    monkeypatch.delenv("SLACK_BOT_TOKEN", raising=False)
-    with patch(
-        "src.config.settings.dotenv_values",
-        return_value={"SLACK_BOT_TOKEN": "xoxb-dotenv"},
-    ):
-        assert resolve_secret("SLACK_BOT_TOKEN") == "xoxb-dotenv"
-
-
-def test_resolve_secret_returns_empty_when_not_found(monkeypatch: pytest.MonkeyPatch) -> None:
-    """環境変数も .env も keyring もない場合は空文字列を返す."""
-    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-    with (
-        patch("src.config.settings.dotenv_values", return_value={}),
-        patch("src.config.settings.get_secret", side_effect=SecretNotFoundError("not found")),
-    ):
-        assert resolve_secret("OPENAI_API_KEY") == ""
-
-
-def test_resolve_secret_returns_empty_on_store_error(monkeypatch: pytest.MonkeyPatch) -> None:
-    """keyring バックエンドアクセス失敗時も空文字列を返す（warning ログ出力）."""
-    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-    with (
-        patch("src.config.settings.dotenv_values", return_value={}),
-        patch("src.config.settings.get_secret", side_effect=SecretStoreError("backend error")),
-    ):
-        assert resolve_secret("OPENAI_API_KEY") == ""
-
-
-def test_resolve_secret_empty_env_falls_through_to_keyring(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """環境変数が空文字列の場合は .env → keyring にフォールバックする."""
-    monkeypatch.setenv("SLACK_BOT_TOKEN", "")
-    with (
-        patch("src.config.settings.dotenv_values", return_value={}),
-        patch("src.config.settings.get_secret", return_value="xoxb-from-keyring"),
-    ):
-        assert resolve_secret("SLACK_BOT_TOKEN") == "xoxb-from-keyring"
 
 
 def test_assistant_yaml_loaded() -> None:

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from unittest.mock import patch
+
 import pytest
 
 from src.config.settings import DEFAULT_LMSTUDIO_BASE_URL, Settings
@@ -46,20 +48,20 @@ def test_lmstudio_base_url_with_v1_suffix_no_duplication() -> None:
     assert provider._client.base_url.path == "/v1/"
 
 
-def test_factory_creates_openai_provider(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_factory_creates_openai_provider() -> None:
     """ファクトリで設定値からOpenAIプロバイダーを生成できる."""
-    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
     settings = Settings(**{**TEST_SETTINGS_DEFAULTS, "online_llm_provider": "openai"})
-    provider = create_online_provider(settings)
+    with patch("src.llm.factory.get_secret", return_value="sk-test"):
+        provider = create_online_provider(settings)
     from src.llm.openai_provider import OpenAIProvider
     assert isinstance(provider, OpenAIProvider)
 
 
-def test_factory_creates_anthropic_provider(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_factory_creates_anthropic_provider() -> None:
     """ファクトリで設定値からAnthropicプロバイダーを生成できる."""
-    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-ant-test")
     settings = Settings(**{**TEST_SETTINGS_DEFAULTS, "online_llm_provider": "anthropic"})
-    provider = create_online_provider(settings)
+    with patch("src.llm.factory.get_secret", return_value="sk-ant-test"):
+        provider = create_online_provider(settings)
     from src.llm.anthropic_provider import AnthropicProvider
     assert isinstance(provider, AnthropicProvider)
 
@@ -78,13 +80,11 @@ def test_get_provider_for_service_returns_local_by_default() -> None:
     assert isinstance(provider, LMStudioProvider)
 
 
-def test_get_provider_for_service_returns_online_when_configured(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
+def test_get_provider_for_service_returns_online_when_configured() -> None:
     """サービスLLM設定が'online'の場合、オンラインプロバイダーを返す."""
-    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
     settings = Settings(**{**TEST_SETTINGS_DEFAULTS, "online_llm_provider": "openai"})
-    provider = get_provider_for_service(settings, "online")
+    with patch("src.llm.factory.get_secret", return_value="sk-test"):
+        provider = get_provider_for_service(settings, "online")
     from src.llm.openai_provider import OpenAIProvider
     assert isinstance(provider, OpenAIProvider)
 


### PR DESCRIPTION
## Change type

- [x] fix: バグ修正
- [x] docs: ドキュメント更新
- [x] test: テスト追加・修正

## Summary

- `resolve_secret()` を廃止し、py-common-lib の `get_secret()` をサービス層で直接呼び出すよう変更（フォールバックなし）
- `config/config.toml` をセクション構造からフラット構造に変更し、`_TOML_KEY_MAP` を廃止
- `_load_toml_config()` で config.toml 不存在時に `FileNotFoundError`、未知キー時に `ValueError` を送出
- `Settings` の共通設定値からデフォルト値を削除（config.toml 必須化）
- `get_settings()` から環境変数による config.toml 値の上書きコードを削除
- 仕様書・CLAUDE.md・README.md・overview.md を rag-knowledge の方針に整合するよう更新
- テストを新方針に合わせて更新（`resolve_secret` テスト削除、`FileNotFoundError`/未知キー/デフォルト値なし検証を追加、LLM ファクトリテストの keyring モック化）

## Test plan

- [x] `uv run pytest` 全 361 テストパス
- [x] `uv run ruff check` lint エラーなし
- [x] `uv run mypy` 型エラーなし

## Related issues

Closes #793