### PR TITLE
feat(rag-knowledge): rag update / rag rebuild サブコマンド追加 (#800, #801)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -24,3 +24,7 @@ MCP_SERVERS_CONFIG=config/mcp_servers.json
 
 # Logging
 LOG_LEVEL=INFO
+
+# RAG 定期更新アカウント（rag update コマンドで使用）
+RAG_BLUESKY_HANDLE=user.bsky.social
+RAG_ZENN_USERNAME=username

--- a/docs/specs/infrastructure/config-management.md
+++ b/docs/specs/infrastructure/config-management.md
@@ -100,6 +100,8 @@ TOML はフラット構造（セクションなし）とし、キー名は `Sett
 | `mcp_enabled` | `MCP_ENABLED` | `false` | MCP 機能の有効/無効 |
 | `mcp_servers_config` | `MCP_SERVERS_CONFIG` | `config/mcp_servers.json` | MCP サーバー設定ファイルパス |
 | `log_level` | `LOG_LEVEL` | `INFO` | ログ出力レベル |
+| `rag_bluesky_handle` | `RAG_BLUESKY_HANDLE` | `""`（空文字列） | RAG 定期更新対象の BlueSky ハンドル |
+| `rag_zenn_username` | `RAG_ZENN_USERNAME` | `""`（空文字列） | RAG 定期更新対象の Zenn ユーザー名 |
 
 #### 共通設定値層（config.toml）
 
@@ -139,6 +141,8 @@ TOML はフラット構造（セクションなし）とし、キー名は `Sett
 | `ENV_NAME` | 環境依存値 | 環境識別子はデプロイ先ごとに異なる |
 | `MCP_ENABLED` | 環境依存値 | MCP サーバーの有無はデプロイ環境に依存 |
 | `LOG_LEVEL` | 環境依存値 | 本番・開発でログレベルを変えるため |
+| `RAG_BLUESKY_HANDLE` | 環境依存値 | 取得対象アカウントはデプロイ環境ごとに異なりうる |
+| `RAG_ZENN_USERNAME` | 環境依存値 | 取得対象アカウントはデプロイ環境ごとに異なりうる |
 | `TIMEZONE` | 共通設定値 | タイムゾーンはプロジェクト共通の運用方針であり環境ごとに変える必要がない |
 | LLM プロバイダー選択 | 共通設定値 | プロジェクトとしてどの LLM を使うかの方針 |
 | モデル名 | 共通設定値 | プロジェクトとして使用するモデルの統一管理 |
@@ -182,4 +186,4 @@ flowchart TD
 - [全体仕様概要](../overview.md) — LLM 使い分けルール・設定一覧
 - [MCP 統合](mcp-integration.md) — MCP 関連設定（`mcp_enabled`、`mcp_servers_config`）
 - [チャット応答](../features/chat-response.md) — Claude CLI モード（`claude_allowed_tools`、`claude_timeout`）
-- [RAG ナレッジ](rag-knowledge.md) — RAG 関連設定（`rag_show_sources`）
+- [RAG ナレッジ](rag-knowledge.md) — RAG 関連設定（`rag_show_sources`、`rag_bluesky_handle`、`rag_zenn_username`）

--- a/docs/specs/infrastructure/rag-knowledge.md
+++ b/docs/specs/infrastructure/rag-knowledge.md
@@ -26,6 +26,24 @@ MCP サーバー設定の `system_instruction` / `response_instruction` によ�
 
 MCP ツールの定義・振る舞いは [rag-knowledge 仕様書](https://github.com/becky3/rag-knowledge/blob/main/docs/specs/rag-knowledge.md)で管理する。
 
+### Slack コマンド
+
+| コマンド | 説明 |
+|---|---|
+| `rag crawl <URL> [パターン]` | リンク集ページからクロール＆取り込み |
+| `rag add <URL>` | 単一ページ取り込み |
+| `rag status` | ナレッジベース統計表示 |
+| `rag delete <URL>` | ソース URL 指定で削除 |
+| `rag update` | BlueSky・Zenn の定期更新（`.env` のアカウント設定を使用） |
+| `rag rebuild [mode]` | インデックス再構築（mode: `full` / `convert` / `index` / `incremental`、デフォルト: `index`）。各モードの詳細は [rag-knowledge 仕様書](https://github.com/becky3/rag-knowledge/blob/main/docs/specs/rag-knowledge.md)を参照 |
+
+`rag update` は以下を順次実行する:
+
+1. `rag_crawl_bluesky` — `.env` の `RAG_BLUESKY_HANDLE` を対象に最大 100 件取得
+2. `rag_crawl_zenn` — `.env` の `RAG_ZENN_USERNAME` を対象に最大 10 件取得
+
+定期実行は Slack のワークフロー/スケジュール機能から呼び出す想定。Bot 側は呼ばれたら実行するのみ。
+
 ## コンポーネント構成
 
 本仕様書固有のコンポーネントはない。接続構成は [MCP 統合](mcp-integration.md) のコンポーネント構成図を参照。

--- a/src/cli.py
+++ b/src/cli.py
@@ -187,6 +187,8 @@ async def _setup(
         env_name=settings.env_name,
         mcp_manager=mcp_manager,
         bot_start_time=bot_start_time,
+        rag_bluesky_handle=settings.rag_bluesky_handle,
+        rag_zenn_username=settings.rag_zenn_username,
     )
 
     return router, cli_adapter, mcp_manager

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -57,6 +57,10 @@ class _EnvLoader(BaseSettings):
     # Logging
     log_level: str = "INFO"
 
+    # RAG 定期更新アカウント（rag update コマンドで使用）
+    rag_bluesky_handle: str = ""
+    rag_zenn_username: str = ""
+
 
 # .env 管理フィールド名の集合（重複検出に使用）
 _ENV_FIELD_NAMES = frozenset(_EnvLoader.model_fields.keys())
@@ -82,6 +86,8 @@ class Settings(BaseModel):
     mcp_enabled: bool
     mcp_servers_config: str
     log_level: str
+    rag_bluesky_handle: str
+    rag_zenn_username: str
 
     def get_auto_reply_channels(self) -> list[str]:
         """自動返信チャンネルのリストを返す（カンマ区切りを解析）."""

--- a/src/main.py
+++ b/src/main.py
@@ -222,6 +222,8 @@ async def main() -> None:
             mcp_manager=mcp_manager,
             bot_start_time=bot_start_time,
             slack_client=slack_client,
+            rag_bluesky_handle=settings.rag_bluesky_handle,
+            rag_zenn_username=settings.rag_zenn_username,
         )
 
         register_handlers(

--- a/src/messaging/router.py
+++ b/src/messaging/router.py
@@ -499,6 +499,8 @@ class MessageRouter:
         mcp_manager: MCPClientManager | None = None,
         bot_start_time: datetime | None = None,
         slack_client: AsyncWebClient | None = None,
+        rag_bluesky_handle: str = "",
+        rag_zenn_username: str = "",
     ) -> None:
         self._messaging = messaging
         self._chat_service = chat_service
@@ -515,6 +517,8 @@ class MessageRouter:
         self._mcp_manager = mcp_manager
         self._bot_start_time = bot_start_time
         self._slack_client = slack_client
+        self._rag_bluesky_handle = rag_bluesky_handle
+        self._rag_zenn_username = rag_zenn_username
 
     async def process_message(self, msg: IncomingMessage) -> None:
         """受信メッセージをキーワードルーティングし、適切なサービスに委譲する."""
@@ -827,13 +831,23 @@ class MessageRouter:
                 "rag_delete", url, raw_url_token,
                 usage_hint="例: `@bot rag delete https://example.com/page`",
             )
+        elif subcommand == "update":
+            await self._handle_rag_update(thread_id, channel)
+            return
+        elif subcommand == "rebuild":
+            tokens = cleaned_text.split()
+            mode = tokens[2] if len(tokens) >= 3 else "index"
+            await self._handle_rag_rebuild(mode, thread_id, channel)
+            return
         else:
             response_text = (
                 "使用方法:\n"
                 "• `@bot rag crawl <URL> [パターン]` — リンク集ページからクロール＆取り込み\n"
                 "• `@bot rag add <URL>` — 単一ページ取り込み\n"
                 "• `@bot rag status` — ナレッジベース統計表示\n"
-                "• `@bot rag delete <URL>` — ソースURL指定で削除"
+                "• `@bot rag delete <URL>` — ソースURL指定で削除\n"
+                "• `@bot rag update` — BlueSky・Zenn の定期更新\n"
+                "• `@bot rag rebuild [mode]` — インデックス再構築（mode: full/convert/index/incremental、デフォルト: index）"
             )
 
         if response_text:
@@ -899,4 +913,79 @@ class MessageRouter:
         except Exception:
             logger.exception("Failed to call %s tool", tool_name)
             return f"エラー: ツール '{tool_name}' の実行中にエラーが発生しました。"
+
+    async def _handle_rag_update(
+        self, thread_id: str, channel: str,
+    ) -> None:
+        """BlueSky・Zenn の定期更新を一括実行する."""
+        assert self._mcp_manager is not None
+
+        if not self._rag_bluesky_handle and not self._rag_zenn_username:
+            await self._messaging.send_message(
+                "エラー: RAG_BLUESKY_HANDLE / RAG_ZENN_USERNAME が .env に設定されていません。",
+                thread_id, channel,
+            )
+            return
+
+        targets: list[tuple[str, str, dict[str, object]]] = []
+        if self._rag_bluesky_handle:
+            targets.append(("BlueSky", "rag_crawl_bluesky", {
+                "handle": self._rag_bluesky_handle, "max_posts": 100,
+            }))
+        if self._rag_zenn_username:
+            targets.append(("Zenn", "rag_crawl_zenn", {
+                "username": self._rag_zenn_username, "max_articles": 10,
+            }))
+
+        await self._messaging.send_message(
+            "RAG更新を開始します...", thread_id, channel,
+        )
+
+        results: list[str] = []
+        for label, tool, args in targets:
+            try:
+                result = await self._mcp_manager.call_tool(tool, args)
+                results.append(f"*{label}*: {result}")
+            except MCPToolNotFoundError:
+                results.append(f"*{label}*: エラー — ツール '{tool}' が利用できません")
+            except Exception:
+                logger.exception("Failed to call %s tool", tool)
+                results.append(f"*{label}*: エラー — 実行中にエラーが発生しました")
+
+        await self._messaging.send_message(
+            "\n".join(results), thread_id, channel,
+        )
+
+    _VALID_REBUILD_MODES = frozenset({"full", "convert", "index", "incremental"})
+
+    async def _handle_rag_rebuild(
+        self, mode: str, thread_id: str, channel: str,
+    ) -> None:
+        """RAG インデックスの再構築を実行する."""
+        assert self._mcp_manager is not None
+
+        if mode not in self._VALID_REBUILD_MODES:
+            await self._messaging.send_message(
+                f"エラー: 無効なモードです: {mode}\n"
+                f"有効な mode: {', '.join(sorted(self._VALID_REBUILD_MODES))}",
+                thread_id, channel,
+            )
+            return
+
+        await self._messaging.send_message(
+            f"RAGリビルドを開始します（mode: {mode}）...", thread_id, channel,
+        )
+
+        try:
+            result = await self._mcp_manager.call_tool(
+                "rag_rebuild", {"mode": mode},
+            )
+            response_text = result
+        except MCPToolNotFoundError:
+            response_text = "エラー: RAGリビルドツールが利用できません。"
+        except Exception:
+            logger.exception("Failed to call rag_rebuild tool")
+            response_text = "エラー: リビルド中にエラーが発生しました。"
+
+        await self._messaging.send_message(response_text, thread_id, channel)
 

--- a/tests/settings_defaults.py
+++ b/tests/settings_defaults.py
@@ -17,6 +17,8 @@ TEST_SETTINGS_DEFAULTS: dict[str, object] = {
     "mcp_enabled": False,
     "mcp_servers_config": "config/mcp_servers.json",
     "log_level": "INFO",
+    "rag_bluesky_handle": "",
+    "rag_zenn_username": "",
     # config.toml フィールド
     "online_llm_provider": "openai",
     "chat_llm_provider": "local",

--- a/tests/test_message_router.py
+++ b/tests/test_message_router.py
@@ -68,6 +68,8 @@ def _make_router(
     session_factory: AsyncMock | None = None,
     mcp_manager: AsyncMock | None = None,
     bot_start_time: datetime | None = None,
+    rag_bluesky_handle: str = "",
+    rag_zenn_username: str = "",
 ) -> tuple[MockAdapter, MessageRouter]:
     if adapter is None:
         adapter = MockAdapter()
@@ -87,6 +89,8 @@ def _make_router(
         env_name="test",
         mcp_manager=mcp_manager,
         bot_start_time=bot_start_time,
+        rag_bluesky_handle=rag_bluesky_handle,
+        rag_zenn_username=rag_zenn_username,
     )
     return adapter, router
 
@@ -434,6 +438,118 @@ async def test_rag_add_missing_url_shows_error() -> None:
     assert len(adapter.sent_messages) == 1
     assert "エラー" in adapter.sent_messages[0][0]
     mcp_manager.call_tool.assert_not_called()
+
+
+async def test_rag_update_both_configured() -> None:
+    """rag update で BlueSky・Zenn 両方が設定済みなら両方呼ばれる."""
+    mcp_manager = AsyncMock()
+    mcp_manager.call_tool.return_value = "取り込み完了"
+    adapter, router = _make_router(
+        mcp_manager=mcp_manager,
+        rag_bluesky_handle="user.bsky.social",
+        rag_zenn_username="testuser",
+    )
+
+    await router.process_message(_make_msg("rag update"))
+
+    assert len(adapter.sent_messages) == 2  # start message + results
+    assert mcp_manager.call_tool.call_count == 2
+    calls = mcp_manager.call_tool.call_args_list
+    assert calls[0].args == ("rag_crawl_bluesky", {"handle": "user.bsky.social", "max_posts": 100})
+    assert calls[1].args == ("rag_crawl_zenn", {"username": "testuser", "max_articles": 10})
+
+
+async def test_rag_update_bluesky_only() -> None:
+    """rag update で BlueSky のみ設定なら BlueSky だけ呼ばれる."""
+    mcp_manager = AsyncMock()
+    mcp_manager.call_tool.return_value = "取り込み完了"
+    adapter, router = _make_router(
+        mcp_manager=mcp_manager,
+        rag_bluesky_handle="user.bsky.social",
+    )
+
+    await router.process_message(_make_msg("rag update"))
+
+    assert len(adapter.sent_messages) == 2
+    mcp_manager.call_tool.assert_called_once_with(
+        "rag_crawl_bluesky", {"handle": "user.bsky.social", "max_posts": 100}
+    )
+
+
+async def test_rag_update_none_configured() -> None:
+    """rag update で両方未設定ならエラーメッセージが返る."""
+    mcp_manager = AsyncMock()
+    adapter, router = _make_router(mcp_manager=mcp_manager)
+
+    await router.process_message(_make_msg("rag update"))
+
+    assert len(adapter.sent_messages) == 1
+    assert "エラー" in adapter.sent_messages[0][0]
+    mcp_manager.call_tool.assert_not_called()
+
+
+async def test_rag_update_tool_not_found() -> None:
+    """rag update でツールが見つからない場合のエラーハンドリング."""
+    mcp_manager = AsyncMock()
+    mcp_manager.call_tool.side_effect = MCPToolNotFoundError("rag_crawl_bluesky")
+    adapter, router = _make_router(
+        mcp_manager=mcp_manager,
+        rag_bluesky_handle="user.bsky.social",
+        rag_zenn_username="testuser",
+    )
+
+    await router.process_message(_make_msg("rag update"))
+
+    assert len(adapter.sent_messages) == 2
+    result_msg = adapter.sent_messages[1][0]
+    assert "利用できません" in result_msg
+
+
+async def test_rag_rebuild_default_mode() -> None:
+    """rag rebuild でモード省略時は index になる."""
+    mcp_manager = AsyncMock()
+    mcp_manager.call_tool.return_value = "リビルド完了"
+    adapter, router = _make_router(mcp_manager=mcp_manager)
+
+    await router.process_message(_make_msg("rag rebuild"))
+
+    assert len(adapter.sent_messages) == 2  # start message + result
+    mcp_manager.call_tool.assert_called_once_with("rag_rebuild", {"mode": "index"})
+
+
+async def test_rag_rebuild_explicit_mode() -> None:
+    """rag rebuild full で指定したモードが渡される."""
+    mcp_manager = AsyncMock()
+    mcp_manager.call_tool.return_value = "リビルド完了"
+    adapter, router = _make_router(mcp_manager=mcp_manager)
+
+    await router.process_message(_make_msg("rag rebuild full"))
+
+    mcp_manager.call_tool.assert_called_once_with("rag_rebuild", {"mode": "full"})
+
+
+async def test_rag_rebuild_invalid_mode() -> None:
+    """rag rebuild に無効なモードを指定するとエラーメッセージが返る."""
+    mcp_manager = AsyncMock()
+    adapter, router = _make_router(mcp_manager=mcp_manager)
+
+    await router.process_message(_make_msg("rag rebuild invalid"))
+
+    assert len(adapter.sent_messages) == 1
+    assert "無効なモード" in adapter.sent_messages[0][0]
+    mcp_manager.call_tool.assert_not_called()
+
+
+async def test_rag_rebuild_tool_not_found() -> None:
+    """rag rebuild でツールが見つからない場合のエラーハンドリング."""
+    mcp_manager = AsyncMock()
+    mcp_manager.call_tool.side_effect = MCPToolNotFoundError("rag_rebuild")
+    adapter, router = _make_router(mcp_manager=mcp_manager)
+
+    await router.process_message(_make_msg("rag rebuild index"))
+
+    assert len(adapter.sent_messages) == 2
+    assert "利用できません" in adapter.sent_messages[1][0]
 
 
 async def test_rag_without_mcp_falls_through_to_chat() -> None:


### PR DESCRIPTION
## Change type

- [x] feat: 新機能実装
- [x] docs: ドキュメント更新

## Summary

- `rag update` サブコマンド追加: BlueSky・Zenn の定期更新を一括実行（片方のみ設定でも動作）
- `rag rebuild [mode]` サブコマンド追加: RAG インデックス再構築（mode バリデーション付き、デフォルト: index）
- `.env` に `RAG_BLUESKY_HANDLE` / `RAG_ZENN_USERNAME` 環境依存値を追加
- 仕様書（rag-knowledge.md, config-management.md）を更新

## Test plan

- [x] pytest 全 55 件 pass
- [x] ruff lint 違反なし
- [x] mypy 型エラーなし
- [x] markdownlint / mermaid-lint 違反なし

## Related issues

Closes #800
Closes #801