### PR TITLE
docs(config-management): 設定テーブルをスタイルガイド 6.11 の3列形式に統一 (#803)

### DIFF
--- a/config/config.toml
+++ b/config/config.toml
@@ -8,5 +8,7 @@ feed_summarize_timeout = 180
 feed_collect_days = 7
 thread_history_limit = 20
 rag_show_sources = true
+rag_bluesky_max_posts = 100
+rag_zenn_max_articles = 10
 claude_allowed_tools = "mcp__rag-knowledge-production__*,WebSearch,WebFetch"
 claude_timeout = 120

--- a/docs/specs/features/feed-management.md
+++ b/docs/specs/features/feed-management.md
@@ -29,13 +29,13 @@ RSSフィードから学習関連記事を自動収集し、LLMで要約した�
 
 ### 設定値
 
-| 環境変数 | 説明 |
-| --- | --- |
-| `FEED_ARTICLES_PER_FEED` | フィードあたりの最大表示件数 |
-| `FEED_CARD_LAYOUT` | 配信カードの表示形式（`horizontal` / `vertical`） |
-| `FEED_SUMMARIZE_TIMEOUT` | 1記事あたりの要約タイムアウト秒数。超過時はそのフィードの収集を中止 |
-| `FEED_COLLECT_DAYS` | 収集対象の日数。`published_at` がこの日数より古い記事はスキップ。`published_at` が NULL の記事はスキップしない |
-| `SLACK_NEWS_CHANNEL_ID` | 配信先チャンネルID |
+| 項目名 | 層 | 設計意図 |
+|---|---|---|
+| `feed_articles_per_feed` | 共通設定値 | フィードごとの配信記事数を制限しチャンネルの可読性を維持する |
+| `feed_card_layout` | 共通設定値 | フィードカードの表示形式をプロジェクトとして統一する |
+| `feed_summarize_timeout` | 共通設定値 | 1記事あたりの要約タイムアウトを設けて無応答時の待機を防止する。超過時はそのフィードの収集を中止 |
+| `feed_collect_days` | 共通設定値 | 収集対象の日数を制限し処理量を抑制する。`published_at` がこの日数より古い記事はスキップ。`published_at` が NULL の記事はスキップしない |
+| `slack_news_channel_id` | 環境依存値 | フィード配信先チャンネル ID は Slack ワークスペースごとに異なる |
 
 ### 配信カードレイアウト
 
@@ -72,9 +72,9 @@ RSSフィードから学習関連記事を自動収集し、LLMで要約した�
 | URL重複 | 収集済みの URL はスキップ |
 | 要約生成 | description あり → 概要に基づいて要約。なし/不足 → タイトルから推測して要約 |
 | 要約の品質制約 | 「情報が不足」「把握できません」等の非要約応答は禁止 |
-| 要約タイムアウト | `FEED_SUMMARIZE_TIMEOUT` 超過時はそのフィードの収集を中止 |
+| 要約タイムアウト | `feed_summarize_timeout` 超過時はそのフィードの収集を中止 |
 | OGP画像 | 取得可能な場合のみ保存 |
-| 収集日数 | `published_at` が `FEED_COLLECT_DAYS` より古い記事はスキップ |
+| 収集日数 | `published_at` が `feed_collect_days` より古い記事はスキップ |
 
 ### 毎朝自動配信
 

--- a/docs/specs/infrastructure/config-management.md
+++ b/docs/specs/infrastructure/config-management.md
@@ -60,8 +60,10 @@ feed_card_layout = "horizontal"
 feed_summarize_timeout = 180
 feed_collect_days = 7
 thread_history_limit = 20
-rag_show_sources = false
-claude_allowed_tools = "mcp__rag-knowledge-production__*"
+rag_show_sources = true
+rag_bluesky_max_posts = 100
+rag_zenn_max_articles = 10
+claude_allowed_tools = "mcp__rag-knowledge-production__*,WebSearch,WebFetch"
 claude_timeout = 120
 ```
 
@@ -73,77 +75,58 @@ TOML はフラット構造（セクションなし）とし、キー名は `Sett
 
 漏洩時に直接被害が発生する認証情報。OS のセキュアストレージ（keyring）で管理する。
 
-| 設定項目 | keyring キー名 | 説明 |
+| 項目名 | 層 | 設計意図 |
 |---|---|---|
-| `slack_bot_token` | `SLACK_BOT_TOKEN` | Slack Bot トークン |
-| `slack_signing_secret` | `SLACK_SIGNING_SECRET` | Slack 署名シークレット |
-| `slack_app_token` | `SLACK_APP_TOKEN` | Slack App トークン（Socket Mode 用） |
-| `openai_api_key` | `OPENAI_API_KEY` | OpenAI API キー |
-| `anthropic_api_key` | `ANTHROPIC_API_KEY` | Anthropic API キー |
+| `slack_bot_token` | シークレット | Slack API 認証に使用。漏洩でアカウント乗っ取りのリスクがある |
+| `slack_signing_secret` | シークレット | Slack リクエスト署名の検証に使用。漏洩でなりすましのリスクがある |
+| `slack_app_token` | シークレット | Socket Mode 接続の認証に使用。漏洩でアカウント乗っ取りのリスクがある |
+| `openai_api_key` | シークレット | OpenAI API の認証に使用。漏洩で不正利用・課金被害のリスクがある |
+| `anthropic_api_key` | シークレット | Anthropic API の認証に使用。漏洩で不正利用・課金被害のリスクがある |
 
 #### 環境依存値層（.env）
 
 デプロイ先・マシンごとに異なる値。`.env` ファイルで管理する。
 
-| 設定項目 | 環境変数名 | デフォルト | 説明 |
-|---|---|---|---|
-| `lmstudio_base_url` | `LMSTUDIO_BASE_URL` | — | LM Studio の接続先 URL |
-| `database_url` | `DATABASE_URL` | — | データベース接続文字列 |
-| `slack_news_channel_id` | `SLACK_NEWS_CHANNEL_ID` | `""`（空文字列） | フィード配信先チャンネル ID |
-| `slack_auto_reply_channels` | `SLACK_AUTO_REPLY_CHANNELS` | `""`（空文字列） | 自動返信チャンネル ID（カンマ区切り） |
-| `env_name` | `ENV_NAME` | `""`（空文字列） | 環境名（ステータス表示用） |
-| `mcp_enabled` | `MCP_ENABLED` | `false` | MCP 機能の有効/無効 |
-| `mcp_servers_config` | `MCP_SERVERS_CONFIG` | `config/mcp_servers.json` | MCP サーバー設定ファイルパス |
-| `log_level` | `LOG_LEVEL` | `INFO` | ログ出力レベル |
-| `rag_bluesky_handle` | `RAG_BLUESKY_HANDLE` | `""`（空文字列） | RAG 定期更新対象の BlueSky ハンドル |
-| `rag_zenn_username` | `RAG_ZENN_USERNAME` | `""`（空文字列） | RAG 定期更新対象の Zenn ユーザー名 |
-| `online_llm_provider` | `ONLINE_LLM_PROVIDER` | — | オンライン LLM プロバイダー（`openai` / `anthropic`） |
-| `chat_llm_provider` | `CHAT_LLM_PROVIDER` | — | チャット応答の LLM 選択（`local` / `online` / `claude`） |
-| `profiler_llm_provider` | `PROFILER_LLM_PROVIDER` | — | ユーザー情報抽出の LLM 選択（`local` / `online`） |
-| `topic_llm_provider` | `TOPIC_LLM_PROVIDER` | — | トピック提案の LLM 選択（`local` / `online`） |
-| `summarizer_llm_provider` | `SUMMARIZER_LLM_PROVIDER` | — | 記事要約の LLM 選択（`local` / `online`） |
+| 項目名 | 層 | 設計意図 |
+|---|---|---|
+| `lmstudio_base_url` | 環境依存値 | ローカル LLM サーバーのホスト・ポートはマシンごとに異なる |
+| `database_url` | 環境依存値 | DB ファイルパスはデプロイ先ごとに異なる |
+| `slack_news_channel_id` | 環境依存値 | フィード配信先チャンネル ID は Slack ワークスペースごとに異なる |
+| `slack_auto_reply_channels` | 環境依存値 | 自動返信対象チャンネルはワークスペースごとに異なる |
+| `env_name` | 環境依存値 | ステータス表示用の環境識別子はデプロイ先ごとに異なる |
+| `mcp_enabled` | 環境依存値 | MCP サーバーの有無はデプロイ環境に依存する |
+| `mcp_servers_config` | 環境依存値 | MCP サーバー設定ファイルの配置パスはデプロイ先ごとに異なりうる |
+| `log_level` | 環境依存値 | 本番・開発でログ出力レベルを変える必要がある |
+| `rag_bluesky_handle` | 環境依存値 | RAG 定期更新の対象 BlueSky アカウントはデプロイ環境ごとに異なりうる |
+| `rag_zenn_username` | 環境依存値 | RAG 定期更新の対象 Zenn アカウントはデプロイ環境ごとに異なりうる |
+| `online_llm_provider` | 環境依存値 | オンライン利用時の API プロバイダーを切り替える |
+| `chat_llm_provider` | 環境依存値 | 利用する LLM をローカル・オンライン・Claude CLI で切り替える |
+| `profiler_llm_provider` | 環境依存値 | 同上（ローカルとオンラインの切り替え） |
+| `topic_llm_provider` | 環境依存値 | 同上 |
+| `summarizer_llm_provider` | 環境依存値 | 同上 |
 
 #### 共通設定値層（config.toml）
 
 プロジェクトとして統一管理するパラメータ。`config/config.toml` で git 管理する。デフォルト値は持たない（config.toml に全値を明示する）。
 
-| 設定項目 | config.toml キー名 | 許容範囲 | 説明 |
-|---|---|---|---|
-| `openai_model` | `openai_model` | — | OpenAI モデル名 |
-| `anthropic_model` | `anthropic_model` | — | Anthropic モデル名 |
-| `lmstudio_model` | `lmstudio_model` | — | LM Studio モデル名 |
-| `timezone` | `timezone` | IANA タイムゾーン | アプリケーションのタイムゾーン |
-| `feed_articles_per_feed` | `feed_articles_per_feed` | 1 以上の整数 | フィードごとの配信記事数上限 |
-| `feed_card_layout` | `feed_card_layout` | `vertical` / `horizontal` | フィードカードのレイアウト |
-| `feed_summarize_timeout` | `feed_summarize_timeout` | 0 以上の整数（秒、0=無制限） | 要約タイムアウト |
-| `feed_collect_days` | `feed_collect_days` | 1 以上の整数 | 収集対象の日数 |
-| `thread_history_limit` | `thread_history_limit` | 1〜100 | スレッド履歴取得の最大件数 |
-| `rag_show_sources` | `rag_show_sources` | `true` / `false` | RAG 参照元 URL 表示（デバッグ用） |
-| `claude_allowed_tools` | `claude_allowed_tools` | MCP ツールパターン文字列 | `chat_llm_provider=claude` の場合のみ必須。許可する MCP ツール（`--allowedTools` に渡す値） |
-| `claude_timeout` | `claude_timeout` | 1 以上の整数（秒） | `chat_llm_provider=claude` の場合のみ必須。Claude CLI プロセスタイムアウト |
+| 項目名 | 層 | 設計意図 |
+|---|---|---|
+| `openai_model` | 共通設定値 | プロジェクトとして使用する OpenAI モデルを統一管理する |
+| `anthropic_model` | 共通設定値 | プロジェクトとして使用する Anthropic モデルを統一管理する |
+| `lmstudio_model` | 共通設定値 | プロジェクトとして使用するローカル LLM モデルを統一管理する |
+| `timezone` | 共通設定値 | タイムゾーンはプロジェクト共通の運用方針であり環境ごとに変える必要がない |
+| `feed_articles_per_feed` | 共通設定値 | フィードごとの配信記事数を制限しチャンネルの可読性を維持する |
+| `feed_card_layout` | 共通設定値 | フィードカードの表示形式をプロジェクトとして統一する |
+| `feed_summarize_timeout` | 共通設定値 | LLM 要約処理のタイムアウトを設けて無応答時の待機を防止する |
+| `feed_collect_days` | 共通設定値 | 収集対象の日数を制限し処理量を抑制する |
+| `thread_history_limit` | 共通設定値 | スレッド履歴の取得件数を制限しコンテキストサイズを制御する |
+| `rag_show_sources` | 共通設定値 | RAG 参照元 URL の表示可否をデバッグ目的で制御する |
+| `rag_bluesky_max_posts` | 共通設定値 | BlueSky 定期更新でクロールする投稿数の上限を制御する |
+| `rag_zenn_max_articles` | 共通設定値 | Zenn 定期更新でクロールする記事数の上限を制御する |
+| `claude_allowed_tools` | 共通設定値 | Claude CLI モードで許可する MCP ツールを制御する |
+| `claude_timeout` | 共通設定値 | Claude CLI プロセスのタイムアウトを設けて無応答時の待機を防止する |
 
 `claude_allowed_tools` と `claude_timeout` は条件付き必須項目である。`chat_llm_provider=claude` の場合は必須とし、いずれかが未設定なら起動時エラーとする。`chat_llm_provider=local` / `online` の場合は任意とし、設定されていてもアプリケーションは参照しない。
-
-#### 分類判断の根拠
-
-| 設定項目 | 分類 | 根拠 |
-|---|---|---|
-| `SLACK_BOT_TOKEN` 等 | シークレット | 認証トークン。漏洩でアカウント乗っ取りのリスク |
-| `OPENAI_API_KEY` 等 | シークレット | API キー。漏洩で不正利用・課金被害のリスク |
-| `LMSTUDIO_BASE_URL` | 環境依存値 | ローカル LLM のホスト・ポートはマシンごとに異なる |
-| `DATABASE_URL` | 環境依存値 | DB ファイルパスはデプロイ先ごとに異なる |
-| `SLACK_NEWS_CHANNEL_ID` | 環境依存値 | チャンネル ID は Slack ワークスペースごとに異なる |
-| `ENV_NAME` | 環境依存値 | 環境識別子はデプロイ先ごとに異なる |
-| `MCP_ENABLED` | 環境依存値 | MCP サーバーの有無はデプロイ環境に依存 |
-| `LOG_LEVEL` | 環境依存値 | 本番・開発でログレベルを変えるため |
-| `RAG_BLUESKY_HANDLE` | 環境依存値 | 取得対象アカウントはデプロイ環境ごとに異なりうる |
-| `RAG_ZENN_USERNAME` | 環境依存値 | 取得対象アカウントはデプロイ環境ごとに異なりうる |
-| LLM プロバイダー選択 | 環境依存値 | ローカル LLM（LM Studio）の有無はマシンごとに異なる |
-| `TIMEZONE` | 共通設定値 | タイムゾーンはプロジェクト共通の運用方針であり環境ごとに変える必要がない |
-| モデル名 | 共通設定値 | プロジェクトとして使用するモデルの統一管理 |
-| Feed パラメータ | 共通設定値 | チューニングパラメータ。プロジェクト共通の値を git 管理する |
-| `THREAD_HISTORY_LIMIT` | 共通設定値 | アプリケーション動作パラメータ。プロジェクト共通 |
-| Claude CLI 設定 | 共通設定値 | Claude CLI モードの動作パラメータ。プロジェクト共通 |
 
 ## コンポーネント構成
 

--- a/docs/specs/infrastructure/rag-knowledge.md
+++ b/docs/specs/infrastructure/rag-knowledge.md
@@ -39,8 +39,8 @@ MCP ツールの定義・振る舞いは [rag-knowledge 仕様書](https://githu
 
 `rag update` は以下を順次実行する:
 
-1. `rag_crawl_bluesky` — `.env` の `RAG_BLUESKY_HANDLE` を対象に `rag_bluesky_max_posts` 件取得
-2. `rag_crawl_zenn` — `.env` の `RAG_ZENN_USERNAME` を対象に `rag_zenn_max_articles` 件取得
+1. `rag_crawl_bluesky` — `.env` の `RAG_BLUESKY_HANDLE` を対象に `rag_bluesky_max_posts`（`config.toml`）件取得
+2. `rag_crawl_zenn` — `.env` の `RAG_ZENN_USERNAME` を対象に `rag_zenn_max_articles`（`config.toml`）件取得
 
 定期実行は Slack のワークフロー/スケジュール機能から呼び出す想定。Bot 側は呼ばれたら実行するのみ。
 

--- a/docs/specs/infrastructure/rag-knowledge.md
+++ b/docs/specs/infrastructure/rag-knowledge.md
@@ -39,8 +39,8 @@ MCP ツールの定義・振る舞いは [rag-knowledge 仕様書](https://githu
 
 `rag update` は以下を順次実行する:
 
-1. `rag_crawl_bluesky` — `.env` の `RAG_BLUESKY_HANDLE` を対象に最大 100 件取得
-2. `rag_crawl_zenn` — `.env` の `RAG_ZENN_USERNAME` を対象に最大 10 件取得
+1. `rag_crawl_bluesky` — `.env` の `RAG_BLUESKY_HANDLE` を対象に `rag_bluesky_max_posts` 件取得
+2. `rag_crawl_zenn` — `.env` の `RAG_ZENN_USERNAME` を対象に `rag_zenn_max_articles` 件取得
 
 定期実行は Slack のワークフロー/スケジュール機能から呼び出す想定。Bot 側は呼ばれたら実行するのみ。
 

--- a/src/cli.py
+++ b/src/cli.py
@@ -189,6 +189,8 @@ async def _setup(
         bot_start_time=bot_start_time,
         rag_bluesky_handle=settings.rag_bluesky_handle,
         rag_zenn_username=settings.rag_zenn_username,
+        rag_bluesky_max_posts=settings.rag_bluesky_max_posts,
+        rag_zenn_max_articles=settings.rag_zenn_max_articles,
     )
 
     return router, cli_adapter, mcp_manager

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -128,6 +128,8 @@ class Settings(BaseModel):
 
     # RAG
     rag_show_sources: bool
+    rag_bluesky_max_posts: int = Field(ge=1)  # 定期更新でクロールする BlueSky 投稿数の上限
+    rag_zenn_max_articles: int = Field(ge=1)  # 定期更新でクロールする Zenn 記事数の上限
 
     # Claude CLI（chat_llm_provider="claude" の場合に使用。未指定時はデフォルト値を利用）
     claude_allowed_tools: str = ""

--- a/src/main.py
+++ b/src/main.py
@@ -224,6 +224,8 @@ async def main() -> None:
             slack_client=slack_client,
             rag_bluesky_handle=settings.rag_bluesky_handle,
             rag_zenn_username=settings.rag_zenn_username,
+            rag_bluesky_max_posts=settings.rag_bluesky_max_posts,
+            rag_zenn_max_articles=settings.rag_zenn_max_articles,
         )
 
         register_handlers(

--- a/src/messaging/router.py
+++ b/src/messaging/router.py
@@ -501,6 +501,8 @@ class MessageRouter:
         slack_client: AsyncWebClient | None = None,
         rag_bluesky_handle: str = "",
         rag_zenn_username: str = "",
+        rag_bluesky_max_posts: int = 100,
+        rag_zenn_max_articles: int = 10,
     ) -> None:
         self._messaging = messaging
         self._chat_service = chat_service
@@ -519,6 +521,8 @@ class MessageRouter:
         self._slack_client = slack_client
         self._rag_bluesky_handle = rag_bluesky_handle
         self._rag_zenn_username = rag_zenn_username
+        self._rag_bluesky_max_posts = rag_bluesky_max_posts
+        self._rag_zenn_max_articles = rag_zenn_max_articles
 
     async def process_message(self, msg: IncomingMessage) -> None:
         """受信メッセージをキーワードルーティングし、適切なサービスに委譲する."""
@@ -930,11 +934,11 @@ class MessageRouter:
         targets: list[tuple[str, str, dict[str, object]]] = []
         if self._rag_bluesky_handle:
             targets.append(("BlueSky", "rag_crawl_bluesky", {
-                "handle": self._rag_bluesky_handle, "max_posts": 100,
+                "handle": self._rag_bluesky_handle, "max_posts": self._rag_bluesky_max_posts,
             }))
         if self._rag_zenn_username:
             targets.append(("Zenn", "rag_crawl_zenn", {
-                "username": self._rag_zenn_username, "max_articles": 10,
+                "username": self._rag_zenn_username, "max_articles": self._rag_zenn_max_articles,
             }))
 
         await self._messaging.send_message(

--- a/tests/settings_defaults.py
+++ b/tests/settings_defaults.py
@@ -35,6 +35,8 @@ TEST_SETTINGS_DEFAULTS: dict[str, object] = {
     "feed_collect_days": 7,
     "thread_history_limit": 20,
     "rag_show_sources": False,
+    "rag_bluesky_max_posts": 100,
+    "rag_zenn_max_articles": 10,
     "claude_allowed_tools": "",
     "claude_timeout": 120,
 }

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -55,8 +55,12 @@ def test_get_settings_loads_from_env_and_toml() -> None:
     """get_settings() が .env と config.toml から統合して読み込める."""
     from src.config.settings import get_settings
 
-    settings = get_settings()
-    # .env から
+    # .env の代わりに git 管理されている .env.example を使用
+    get_settings.cache_clear()
+    with patch.object(_EnvLoader, "model_config", {**_EnvLoader.model_config, "env_file": ".env.example"}):
+        settings = get_settings()
+    get_settings.cache_clear()
+    # .env.example から
     assert settings.lmstudio_base_url
     assert settings.online_llm_provider in ("openai", "anthropic")
     # config.toml から

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -8,6 +8,7 @@ import pytest
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
+from src.config.settings import _EnvLoader
 from src.db.models import Article, Base, Conversation, Feed, UserProfile
 from src.db import session as session_mod
 
@@ -74,7 +75,12 @@ async def test_conversation(session: AsyncSession) -> None:
 
 async def test_init_db_and_get_session(monkeypatch: pytest.MonkeyPatch) -> None:
     """init_db/get_session 経由でテーブル作成とセッション取得ができる."""
+    # .env.example をベースに読み込み、DATABASE_URL のみテスト用にオーバーライド
     monkeypatch.setenv("DATABASE_URL", "sqlite+aiosqlite:///:memory:")
+    monkeypatch.setattr(
+        _EnvLoader, "model_config",
+        {**_EnvLoader.model_config, "env_file": ".env.example"},
+    )
 
     # グローバル状態をリセット
     session_mod._engine = None

--- a/tests/test_message_router.py
+++ b/tests/test_message_router.py
@@ -91,6 +91,8 @@ def _make_router(
         bot_start_time=bot_start_time,
         rag_bluesky_handle=rag_bluesky_handle,
         rag_zenn_username=rag_zenn_username,
+        rag_bluesky_max_posts=100,
+        rag_zenn_max_articles=10,
     )
     return adapter, router
 

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -581,6 +581,8 @@ async def test_manual_deliver_command_passes_layout_from_router() -> None:
         channel_id=channel_id,
         feed_card_layout="vertical",
         slack_client=slack_client,
+        rag_bluesky_max_posts=100,
+        rag_zenn_max_articles=10,
     )
 
     msg = IncomingMessage(

--- a/tests/test_user_profiler.py
+++ b/tests/test_user_profiler.py
@@ -219,6 +219,8 @@ async def test_profile_keyword_triggers_get_profile() -> None:
         messaging=messaging,
         chat_service=chat_service,
         user_profiler=user_profiler,
+        rag_bluesky_max_posts=100,
+        rag_zenn_max_articles=10,
     )
 
     msg = IncomingMessage(


### PR DESCRIPTION
## Change type

- [ ] feat: 新機能実装
- [ ] fix: バグ修正
- [x] docs: ドキュメント更新 ★
- [ ] docs(pre-impl): 設計書先行更新（実装は後続フェーズ）
- [x] refactor: リファクタリング
- [ ] ci: CI/CD改善
- [x] test: テスト追加・修正

## Summary

- config-management.md の設定テーブルをスタイルガイド 6.11 の3列形式（項目名/層/設計意図）に移行
- 分類判断の根拠テーブルを各項目の設計意図列に統合して削除
- feed-management.md の設定テーブルも3列形式に移行（環境変数名の誤記も修正）
- rag-knowledge.md のハードコード値を設定項目名の参照に変更
- `rag_bluesky_max_posts` / `rag_zenn_max_articles` を config.toml の共通設定値として追加（router.py のハードコード値を設定値化）
- テストの `.env` ファイル依存を `.env.example` 参照に修正

## Test plan

- [x] pytest 378 passed
- [x] ruff check: 違反なし
- [x] mypy: 型エラーなし

## Related issues

Closes #803