### PR TITLE
feat(feed-management): LLM要約時のreasoning制御とモデル変更 (#816)

### DIFF
--- a/config/config.toml
+++ b/config/config.toml
@@ -1,10 +1,11 @@
 openai_model = "gpt-4o-mini"
 anthropic_model = "claude-3-5-sonnet-20241022"
-lmstudio_model = "qwen/qwen3-next-80b"
+lmstudio_model = "google/gemma-4-26b-a4b"
 timezone = "Asia/Tokyo"
 feed_articles_per_feed = 50
 feed_card_layout = "horizontal"
 feed_summarize_timeout = 180
+feed_summarize_reasoning_effort = "none"
 feed_collect_days = 7
 thread_history_limit = 20
 rag_show_sources = true

--- a/docs/specs/features/feed-management.md
+++ b/docs/specs/features/feed-management.md
@@ -34,6 +34,7 @@ RSSフィードから学習関連記事を自動収集し、LLMで要約した�
 | `feed_articles_per_feed` | 共通設定値 | フィードごとの配信記事数を制限しチャンネルの可読性を維持する |
 | `feed_card_layout` | 共通設定値 | フィードカードの表示形式をプロジェクトとして統一する |
 | `feed_summarize_timeout` | 共通設定値 | 1記事あたりの要約タイムアウトを設けて無応答時の待機を防止する。超過時はそのフィードの収集を中止 |
+| `feed_summarize_reasoning_effort` | 共通設定値 | 要約時の LLM 推論深度を制御する。reasoning 対応モデルで不要な思考を抑制し処理速度を改善する |
 | `feed_collect_days` | 共通設定値 | 収集対象の日数を制限し処理量を抑制する。`published_at` がこの日数より古い記事はスキップ。`published_at` が NULL の記事はスキップしない |
 | `slack_news_channel_id` | 環境依存値 | フィード配信先チャンネル ID は Slack ワークスペースごとに異なる |
 

--- a/scripts/test_summarize_speed.py
+++ b/scripts/test_summarize_speed.py
@@ -1,0 +1,143 @@
+"""Feed要約の速度・品質計測スクリプト.
+
+reasoning_effort あり/なしの比較ができる。
+
+使い方:
+    # config.toml の設定値で実行
+    uv run python scripts/test_summarize_speed.py
+
+    # reasoning_effort を明示指定（none / low / medium / high）
+    uv run python scripts/test_summarize_speed.py none
+    uv run python scripts/test_summarize_speed.py high
+
+    # あり/なし比較モード
+    uv run python scripts/test_summarize_speed.py --compare
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import time
+
+from src.compat import configure_stdio_encoding
+
+from src.config.settings import get_settings
+from src.llm.factory import create_local_provider
+from src.services.summarizer import Summarizer
+
+# テスト用の記事データ（実際のRSS記事を模擬）
+TEST_ARTICLES = [
+    {
+        "title": "Python 3.13 introduces new features for async programming",
+        "url": "https://example.com/python-3.13",
+        "description": (
+            "Python 3.13 brings significant improvements to async programming, "
+            "including TaskGroup enhancements, better error handling in asyncio, "
+            "and new APIs for structured concurrency."
+        ),
+    },
+    {
+        "title": "Understanding Vector Databases for AI Applications",
+        "url": "https://example.com/vector-db",
+        "description": (
+            "This article explains how vector databases work, their role in AI "
+            "applications like RAG, and compares popular options such as ChromaDB, "
+            "Pinecone, and Weaviate."
+        ),
+    },
+    {
+        "title": "Best Practices for Building Slack Bots with Python",
+        "url": "https://example.com/slack-bots",
+        "description": (
+            "A comprehensive guide on building production-ready Slack bots using "
+            "Python and slack-bolt, covering event handling, rate limiting, and "
+            "deployment strategies."
+        ),
+    },
+]
+
+
+async def run_test(reasoning_effort: str | None) -> list[tuple[str, str, float]]:
+    """指定した reasoning_effort で要約を実行し、結果を返す."""
+    settings = get_settings()
+    llm = create_local_provider(settings)
+    summarizer = Summarizer(llm=llm, reasoning_effort=reasoning_effort)
+
+    available = await llm.is_available()
+    if not available:
+        print("ERROR: LM Studio is not available")
+        sys.exit(1)
+
+    results: list[tuple[str, str, float]] = []
+    for article in TEST_ARTICLES:
+        start = time.perf_counter()
+        summary = await summarizer.summarize(
+            title=article["title"],
+            url=article["url"],
+            description=article["description"],
+        )
+        elapsed = time.perf_counter() - start
+        results.append((article["title"], summary, elapsed))
+    return results
+
+
+def print_results(label: str, results: list[tuple[str, str, float]]) -> None:
+    """結果を表示する."""
+    print(f"\n{'=' * 70}")
+    print(f"  {label}")
+    print(f"{'=' * 70}")
+    total = 0.0
+    for i, (title, summary, elapsed) in enumerate(results, 1):
+        total += elapsed
+        print(f"\n[{i}] {elapsed:.1f}s — {title[:60]}")
+        print(f"    {summary}")
+    avg = total / len(results)
+    print(f"\n  Total: {total:.1f}s | Avg: {avg:.1f}s/article")
+
+
+async def main() -> None:
+    settings = get_settings()
+    print(f"Model: {settings.lmstudio_model}")
+    print(f"LM Studio URL: {settings.lmstudio_base_url}")
+
+    args = sys.argv[1:]
+
+    if "--compare" in args:
+        # 比較モード: reasoning あり(デフォルト=None) と なし(none) を比較
+        print("\n--- Compare mode: default vs none ---")
+
+        results_default = await run_test(reasoning_effort=None)
+        print_results("reasoning_effort = (default/未指定)", results_default)
+
+        results_none = await run_test(reasoning_effort="none")
+        print_results("reasoning_effort = none", results_none)
+
+        # サマリー比較
+        total_default = sum(e for _, _, e in results_default)
+        total_none = sum(e for _, _, e in results_none)
+        speedup = total_default / total_none if total_none > 0 else 0
+        print(f"\n{'=' * 70}")
+        print(f"  Speedup: {speedup:.1f}x faster with reasoning_effort=none")
+        print(f"  ({total_default:.1f}s -> {total_none:.1f}s)")
+        print(f"{'=' * 70}")
+    else:
+        # 単発モード
+        valid_efforts = {"none", "low", "medium", "high"}
+        if args:
+            if args[0] not in valid_efforts:
+                print(f"ERROR: invalid reasoning_effort '{args[0]}'")
+                print(f"Valid values: {', '.join(sorted(valid_efforts))}")
+                sys.exit(1)
+            effort: str | None = args[0]
+        else:
+            effort = settings.feed_summarize_reasoning_effort
+        print(f"reasoning_effort: {effort}")
+
+        results = await run_test(reasoning_effort=effort)
+        print_results(f"reasoning_effort = {effort}", results)
+
+
+if __name__ == "__main__":
+    configure_stdio_encoding()
+    asyncio.run(main())

--- a/src/cli.py
+++ b/src/cli.py
@@ -134,7 +134,10 @@ async def _setup(
         session_factory=session_factory,
     )
 
-    summarizer = Summarizer(llm=summarizer_llm)
+    summarizer = Summarizer(
+        llm=summarizer_llm,
+        reasoning_effort=settings.feed_summarize_reasoning_effort,
+    )
     ogp_extractor = OgpExtractor()
     feed_collector = FeedCollector(
         session_factory=session_factory,

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -123,6 +123,7 @@ class Settings(BaseModel):
     feed_articles_per_feed: int = Field(ge=1)
     feed_card_layout: Literal["vertical", "horizontal"]
     feed_summarize_timeout: int = Field(ge=0)
+    feed_summarize_reasoning_effort: Literal["none", "low", "medium", "high"]
     feed_collect_days: int = Field(ge=1)
 
     # Thread

--- a/src/llm/anthropic_provider.py
+++ b/src/llm/anthropic_provider.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import logging
+from typing import Literal
 
 from anthropic import AsyncAnthropic
 from anthropic.types import MessageParam, TextBlockParam, ToolParam, ToolUseBlockParam
@@ -74,7 +75,12 @@ class AnthropicProvider(LLMProvider):
         self._client = AsyncAnthropic(api_key=api_key)
         self._model = model
 
-    async def complete(self, messages: list[Message]) -> LLMResponse:
+    async def complete(
+        self,
+        messages: list[Message],
+        *,
+        reasoning_effort: Literal["none", "low", "medium", "high"] | None = None,
+    ) -> LLMResponse:
         system_prompt, chat_messages = _build_anthropic_messages(messages)
 
         response = await self._client.messages.create(

--- a/src/llm/base.py
+++ b/src/llm/base.py
@@ -61,7 +61,12 @@ class LLMProvider(abc.ABC):
     """全LLMプロバイダーの共通インターフェース."""
 
     @abc.abstractmethod
-    async def complete(self, messages: list[Message]) -> LLMResponse:
+    async def complete(
+        self,
+        messages: list[Message],
+        *,
+        reasoning_effort: Literal["none", "low", "medium", "high"] | None = None,
+    ) -> LLMResponse:
         """メッセージリストを受け取り、応答を返す."""
 
     async def complete_with_tools(

--- a/src/llm/lmstudio_provider.py
+++ b/src/llm/lmstudio_provider.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import json
 import logging
+from typing import Any, Literal
 
 from openai import AsyncOpenAI
 from openai.types.chat import (
@@ -81,10 +82,19 @@ class LMStudioProvider(LLMProvider):
         self._client = AsyncOpenAI(base_url=normalized, api_key="lm-studio")
         self._model = model
 
-    async def complete(self, messages: list[Message]) -> LLMResponse:
+    async def complete(
+        self,
+        messages: list[Message],
+        *,
+        reasoning_effort: Literal["none", "low", "medium", "high"] | None = None,
+    ) -> LLMResponse:
+        extra_kwargs: dict[str, Any] = {}
+        if reasoning_effort is not None:
+            extra_kwargs["reasoning_effort"] = reasoning_effort
         response = await self._client.chat.completions.create(
             model=self._model,
             messages=[_to_openai_message(m) for m in messages],
+            **extra_kwargs,
         )
         choice = response.choices[0]
         usage = {}

--- a/src/llm/openai_provider.py
+++ b/src/llm/openai_provider.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import json
 import logging
+from typing import Literal
 
 from openai import AsyncOpenAI
 from openai.types.chat import (
@@ -75,7 +76,12 @@ class OpenAIProvider(LLMProvider):
         self._client = AsyncOpenAI(api_key=api_key)
         self._model = model
 
-    async def complete(self, messages: list[Message]) -> LLMResponse:
+    async def complete(
+        self,
+        messages: list[Message],
+        *,
+        reasoning_effort: Literal["none", "low", "medium", "high"] | None = None,
+    ) -> LLMResponse:
         response = await self._client.chat.completions.create(
             model=self._model,
             messages=[_to_openai_message(m) for m in messages],

--- a/src/main.py
+++ b/src/main.py
@@ -162,7 +162,10 @@ async def main() -> None:
         )
 
         # 要約・収集サービス
-        summarizer = Summarizer(llm=summarizer_llm)
+        summarizer = Summarizer(
+            llm=summarizer_llm,
+            reasoning_effort=settings.feed_summarize_reasoning_effort,
+        )
         ogp_extractor = OgpExtractor()
         feed_collector = FeedCollector(
             session_factory=session_factory,

--- a/src/services/summarizer.py
+++ b/src/services/summarizer.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import logging
+from typing import Literal
 
 from src.llm.base import LLMProvider, Message
 
@@ -36,8 +37,14 @@ class Summarizer:
     仕様: docs/specs/features/feed-management.md
     """
 
-    def __init__(self, llm: LLMProvider) -> None:
+    def __init__(
+        self,
+        llm: LLMProvider,
+        *,
+        reasoning_effort: Literal["none", "low", "medium", "high"] | None,
+    ) -> None:
         self._llm = llm
+        self._reasoning_effort = reasoning_effort
 
     async def summarize(
         self, title: str, url: str, description: str = "", lang: str = ""
@@ -52,9 +59,10 @@ class Summarizer:
         """
         prompt = SUMMARIZE_PROMPT.format(title=title, url=url, description=description or "なし")
         try:
-            response = await self._llm.complete([
-                Message(role="user", content=prompt),
-            ])
+            response = await self._llm.complete(
+                [Message(role="user", content=prompt)],
+                reasoning_effort=self._reasoning_effort,
+            )
             content = response.content.strip()
             if not content:
                 logger.warning(

--- a/tests/settings_defaults.py
+++ b/tests/settings_defaults.py
@@ -38,6 +38,7 @@ TEST_SETTINGS_DEFAULTS: dict[str, object] = {
     "rag_show_sources": False,
     "rag_bluesky_max_posts": 100,
     "rag_zenn_max_articles": 10,
+    "feed_summarize_reasoning_effort": "none",
     "claude_allowed_tools": "",
     "claude_timeout": 120,
 }

--- a/tests/test_summarizer.py
+++ b/tests/test_summarizer.py
@@ -35,7 +35,7 @@ async def test_prompt_no_inference_when_description_exists() -> None:
 async def test_summarize_with_no_description(mock_llm: AsyncMock) -> None:
     """概要なしの場合、descriptionが「なし」としてプロンプトに渡される."""
     mock_llm.complete.return_value = LLMResponse(content="タイトルから推測した要約")
-    summarizer = Summarizer(llm=mock_llm)
+    summarizer = Summarizer(llm=mock_llm, reasoning_effort=None)
 
     result = await summarizer.summarize("Python 3.13の新機能", "https://example.com/article")
 
@@ -50,7 +50,7 @@ async def test_summarize_with_no_description(mock_llm: AsyncMock) -> None:
 async def test_summarize_with_description(mock_llm: AsyncMock) -> None:
     """概要ありの場合、descriptionがそのままプロンプトに渡される."""
     mock_llm.complete.return_value = LLMResponse(content="概要に基づく要約")
-    summarizer = Summarizer(llm=mock_llm)
+    summarizer = Summarizer(llm=mock_llm, reasoning_effort=None)
 
     result = await summarizer.summarize(
         "Python 3.13の新機能",
@@ -67,7 +67,7 @@ async def test_summarize_with_description(mock_llm: AsyncMock) -> None:
 async def test_summarize_empty_description_treated_as_none(mock_llm: AsyncMock) -> None:
     """空文字列の概要は「なし」として扱われる."""
     mock_llm.complete.return_value = LLMResponse(content="推測された要約")
-    summarizer = Summarizer(llm=mock_llm)
+    summarizer = Summarizer(llm=mock_llm, reasoning_effort=None)
 
     await summarizer.summarize("記事タイトル", "https://example.com/article", "")
 
@@ -79,7 +79,7 @@ async def test_summarize_empty_description_treated_as_none(mock_llm: AsyncMock) 
 async def test_summarize_fallback_to_title_on_empty_response(mock_llm: AsyncMock) -> None:
     """LLMが空の応答を返した場合、タイトルをフォールバックとして返す."""
     mock_llm.complete.return_value = LLMResponse(content="")
-    summarizer = Summarizer(llm=mock_llm)
+    summarizer = Summarizer(llm=mock_llm, reasoning_effort=None)
 
     result = await summarizer.summarize("フォールバックテスト", "https://example.com/article")
 
@@ -89,7 +89,7 @@ async def test_summarize_fallback_to_title_on_empty_response(mock_llm: AsyncMock
 async def test_summarize_fallback_to_title_on_exception(mock_llm: AsyncMock) -> None:
     """LLM呼び出しが例外を投げた場合、タイトルをフォールバックとして返す."""
     mock_llm.complete.side_effect = RuntimeError("LLM error")
-    summarizer = Summarizer(llm=mock_llm)
+    summarizer = Summarizer(llm=mock_llm, reasoning_effort=None)
 
     result = await summarizer.summarize("エラーテスト", "https://example.com/article")
 
@@ -101,7 +101,7 @@ async def test_exception_log_contains_url_and_lang(
 ) -> None:
     """例外時のログにURLとlang情報が含まれる."""
     mock_llm.complete.side_effect = RuntimeError("LLM error")
-    summarizer = Summarizer(llm=mock_llm)
+    summarizer = Summarizer(llm=mock_llm, reasoning_effort=None)
 
     await summarizer.summarize(
         "テスト記事", "https://example.com/article", lang="ja"
@@ -116,7 +116,7 @@ async def test_empty_response_log_contains_url_and_lang(
 ) -> None:
     """空応答時のログにURLとlang情報が含まれる."""
     mock_llm.complete.return_value = LLMResponse(content="")
-    summarizer = Summarizer(llm=mock_llm)
+    summarizer = Summarizer(llm=mock_llm, reasoning_effort=None)
 
     await summarizer.summarize(
         "テスト記事", "https://example.com/article", lang="en"


### PR DESCRIPTION
## Change type

- [x] feat: 新機能実装
- [x] docs: ドキュメント更新

## Summary

- `LLMProvider.complete()` に `reasoning_effort` オプショナルパラメータを追加
- `LMStudioProvider` で `reasoning_effort` を LM Studio API に渡す実装
- `config.toml` に `feed_summarize_reasoning_effort = "none"` を追加し `Settings` に反映
- `Summarizer` が `reasoning_effort` を受け取り `complete()` に伝搬
- `main.py` / `cli.py` の `Summarizer` 初期化で設定値を渡す
- `lmstudio_model` を `google/gemma-4-26b-a4b` に変更
- 仕様書 `feed-management.md` の設定値テーブルに追記
- 要約速度計測スクリプト `scripts/test_summarize_speed.py` を追加

### 計測結果（gemma-4-26b-a4b, 3記事）

| 条件 | 合計 | 平均/記事 |
|------|------|----------|
| reasoning 有効（変更前） | 61.7秒 | 20.6秒 |
| `reasoning_effort = "none"` | 12.2秒 | 4.1秒 |

要約品質に差はなく、約4.6倍の高速化を確認。

## Test plan

- [x] pytest 43件パス
- [x] ruff lint パス
- [x] mypy 型チェックパス
- [x] 実機で reasoning_effort あり/なしの速度・品質比較を実施

## Related issues

Closes #816