### PR TITLE
fix: Slack Reminder 経由のコマンドが認識されない問題を修正 (#823)

### DIFF
--- a/src/messaging/router.py
+++ b/src/messaging/router.py
@@ -44,9 +44,9 @@ def _strip_reminder_prefix(text: str) -> str:
     """Slack Reminder のプレフィックスと末尾ピリオドを除去する."""
     lstripped = text.lstrip()
     stripped = _REMINDER_PREFIX.sub("", lstripped)
-    if stripped != lstripped:
-        stripped = stripped.rstrip(".")
-    return stripped
+    if stripped == lstripped:
+        return text
+    return stripped.rstrip(".")
 
 
 def _parse_rag_command(text: str) -> tuple[str, str, str]:

--- a/src/messaging/router.py
+++ b/src/messaging/router.py
@@ -37,6 +37,17 @@ _FEED_KEYWORDS = ("feed",)
 _RAG_KEYWORDS = ("rag",)
 _STATUS_KEYWORDS = ("status", "info")
 
+_REMINDER_PREFIX = re.compile(r"^reminder:\s+", re.IGNORECASE)
+
+
+def _strip_reminder_prefix(text: str) -> str:
+    """Slack Reminder のプレフィックスと末尾ピリオドを除去する."""
+    lstripped = text.lstrip()
+    stripped = _REMINDER_PREFIX.sub("", lstripped)
+    if stripped != lstripped:
+        stripped = stripped.rstrip(".")
+    return stripped
+
 
 def _parse_rag_command(text: str) -> tuple[str, str, str]:
     """ragコマンドを解析する."""
@@ -504,7 +515,7 @@ class MessageRouter:
 
     async def process_message(self, msg: IncomingMessage) -> None:
         """受信メッセージをキーワードルーティングし、適切なサービスに委譲する."""
-        cleaned_text = msg.text
+        cleaned_text = _strip_reminder_prefix(msg.text)
         user_id = msg.user_id
         thread_id = msg.thread_id
         channel = msg.channel
@@ -537,7 +548,10 @@ class MessageRouter:
             self._collector is not None
             and self._session_factory is not None
             and self._channel_id is not None
-            and any(kw in cleaned_text.lower() for kw in _DELIVER_KEYWORDS)
+            and any(
+                re.match(rf"^{re.escape(kw)}\b", lower_text)
+                for kw in _DELIVER_KEYWORDS
+            )
         ):
             await self._handle_deliver(msg)
             return

--- a/src/slack/handlers.py
+++ b/src/slack/handlers.py
@@ -17,10 +17,12 @@ from src.messaging.port import IncomingMessage
 if TYPE_CHECKING:
     from src.messaging.router import MessageRouter
 
+_MENTION_PATTERN = re.compile(r"<@[A-Za-z0-9]+(?:\|[^>]+)?>\s*")
+
 
 def strip_mention(text: str) -> str:
-    """メンション部分 (<@U...>) を除去する."""
-    return re.sub(r"<@[A-Za-z0-9]+>\s*", "", text).strip()
+    """メンション部分 (<@U...> または <@U...|name>) を除去する."""
+    return _MENTION_PATTERN.sub("", text).strip()
 
 
 def register_handlers(
@@ -80,7 +82,7 @@ def register_handlers(
 
         text: str = event.get("text", "")
 
-        if re.search(r"<@[A-Za-z0-9]+>\s*", text):
+        if _MENTION_PATTERN.search(text):
             return
 
         user_id: str = event.get("user", "")

--- a/tests/test_message_router.py
+++ b/tests/test_message_router.py
@@ -16,6 +16,7 @@ from src.messaging.router import (
     _build_status_message,
     _format_uptime,
     _parse_rag_command,
+    _strip_reminder_prefix,
 )
 
 
@@ -519,3 +520,69 @@ async def test_rag_without_mcp_falls_through_to_chat() -> None:
 
     assert len(adapter.sent_messages) == 1
     chat_service.respond.assert_called_once()
+
+
+# --- _strip_reminder_prefix テスト ---
+
+
+def test_strip_reminder_prefix_removes_prefix_and_trailing_dot() -> None:
+    """Slack Reminder プレフィックスと末尾ピリオドが除去される."""
+    assert _strip_reminder_prefix("Reminder: deliver.") == "deliver"
+
+
+def test_strip_reminder_prefix_case_insensitive() -> None:
+    """大文字小文字を問わず除去される."""
+    assert _strip_reminder_prefix("reminder: rag update.") == "rag update"
+
+
+def test_strip_reminder_prefix_no_prefix() -> None:
+    """プレフィックスがなければそのまま返す（末尾ピリオドも残る）."""
+    assert _strip_reminder_prefix("rag update.") == "rag update."
+
+
+def test_strip_reminder_prefix_no_trailing_dot() -> None:
+    """Reminder プレフィックスありでも末尾ピリオドがなければそのまま."""
+    assert _strip_reminder_prefix("Reminder: rag update") == "rag update"
+
+
+def test_strip_reminder_prefix_leading_whitespace() -> None:
+    """先頭空白 + Reminder プレフィックスが除去される."""
+    assert _strip_reminder_prefix("  Reminder: feed list.") == "feed list"
+
+
+def test_strip_reminder_prefix_no_space_after_colon() -> None:
+    """Reminder: の後に空白なしの場合はプレフィックス除去しない."""
+    assert _strip_reminder_prefix("Reminder:deliver") == "Reminder:deliver"
+
+
+# --- Reminder プレフィックス経由のルーティングテスト ---
+
+
+async def test_reminder_rag_update_routes_to_rag_command() -> None:
+    """Reminder 経由の rag update がコマンドとして認識される (#823)."""
+    mcp_manager = AsyncMock()
+    mcp_manager.call_tool.return_value = "取り込み完了"
+    adapter, router = _make_router(
+        mcp_manager=mcp_manager,
+        rag_bluesky_handle="user.bsky.social",
+    )
+
+    await router.process_message(_make_msg("Reminder: rag update."))
+
+    assert len(adapter.sent_messages) == 2
+    mcp_manager.call_tool.assert_called_once()
+
+
+async def test_reminder_deliver_routes_to_deliver() -> None:
+    """Reminder 経由の deliver が deliver ハンドラに到達する."""
+    collector = AsyncMock()
+    session_factory = AsyncMock()
+    adapter, router = _make_router(
+        collector=collector,
+        session_factory=session_factory,
+    )
+
+    await router.process_message(_make_msg("Reminder: deliver."))
+
+    assert len(adapter.sent_messages) == 1
+    assert "Slack 接続時のみ" in adapter.sent_messages[0][0]

--- a/tests/test_message_router.py
+++ b/tests/test_message_router.py
@@ -536,8 +536,9 @@ def test_strip_reminder_prefix_case_insensitive() -> None:
 
 
 def test_strip_reminder_prefix_no_prefix() -> None:
-    """プレフィックスがなければそのまま返す（末尾ピリオドも残る）."""
+    """プレフィックスがなければそのまま返す（先頭空白・末尾ピリオドも残る）."""
     assert _strip_reminder_prefix("rag update.") == "rag update."
+    assert _strip_reminder_prefix("  rag update") == "  rag update"
 
 
 def test_strip_reminder_prefix_no_trailing_dot() -> None:

--- a/tests/test_slack_handlers.py
+++ b/tests/test_slack_handlers.py
@@ -16,6 +16,12 @@ def test_strip_mention_removes_bot_id() -> None:
     assert strip_mention("<@U1234ABC>") == ""
 
 
+def test_strip_mention_with_display_name() -> None:
+    """表示名付きメンション (<@U...|name>) を除去する."""
+    assert strip_mention("<@U0AC49HLCUB|daisy> rag update.") == "rag update."
+    assert strip_mention("Reminder: <@U0AC49HLCUB|daisy> rag update.") == "Reminder: rag update."
+
+
 def test_strip_mention_multiple() -> None:
     """複数メンションがあっても全て除去する."""
     assert strip_mention("<@U111> <@U222> test") == "test"
@@ -188,6 +194,18 @@ async def test_auto_reply_ignores_mention_messages() -> None:
 
     say = AsyncMock()
     event = {"user": "U123", "text": "<@UBOT> hello", "channel": "C_AUTO", "ts": "123.456"}
+    await handlers["message"](event=event, say=say)
+
+    router.process_message.assert_not_called()
+
+
+async def test_auto_reply_ignores_mention_with_display_name() -> None:
+    """表示名付きメンション (<@U...|name>) も app_mention 扱いでスキップ."""
+    router = AsyncMock()
+    handlers = _setup_handlers_with_auto_reply(router, ["C_AUTO"])
+
+    say = AsyncMock()
+    event = {"user": "U123", "text": "<@UBOT|botname> hello", "channel": "C_AUTO", "ts": "123.456"}
     await handlers["message"](event=event, say=say)
 
     router.process_message.assert_not_called()


### PR DESCRIPTION
## Change type

- [x] fix: バグ修正 ★
- [x] test: テスト追加・修正

## Summary

- `strip_mention` を `<@U...|name>` 形式（Slack Reminder が使用）に対応させ、`_MENTION_PATTERN` として定数化
- `_strip_reminder_prefix()` を追加し、ルーティング前に Reminder プレフィックスと末尾ピリオドを除去
- deliver のマッチ方式を部分一致 (`kw in text`) から先頭一致 (`re.match`) に統一
- Slack 実機で Reminder 経由の `rag update` が正常動作することを検証済み

## Test plan

- [x] pytest 58件 pass
- [x] ruff / mypy クリア
- [x] Slack Reminder 経由の rag update 実機検証

## Related issues

Closes #823