### PR TITLE
feat(config-management): ログ出力の充実 (#824)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -25,6 +25,8 @@ MCP_RAG_URL=http://127.0.0.1:8081/mcp
 
 # Logging
 LOG_LEVEL=INFO
+DEBUG_LOG_ENABLED=false
+LOG_DIR=
 
 # RAG 定期更新アカウント（rag update コマンドで使用）
 RAG_BLUESKY_HANDLE=user.bsky.social

--- a/config/config.toml
+++ b/config/config.toml
@@ -13,3 +13,4 @@ rag_bluesky_max_posts = 100
 rag_zenn_max_articles = 10
 claude_allowed_tools = "mcp__rag-knowledge-production__*,WebSearch,WebFetch"
 claude_timeout = 120
+log_file_max_bytes = 10485760

--- a/docs/specs/infrastructure/config-management.md
+++ b/docs/specs/infrastructure/config-management.md
@@ -65,6 +65,7 @@ rag_bluesky_max_posts = 100
 rag_zenn_max_articles = 10
 claude_allowed_tools = "mcp__rag-knowledge-production__*,WebSearch,WebFetch"
 claude_timeout = 120
+log_file_max_bytes = 10485760
 ```
 
 TOML はフラット構造（セクションなし）とし、キー名は `Settings` クラスのフィールド名と一致させる。
@@ -98,6 +99,8 @@ TOML はフラット構造（セクションなし）とし、キー名は `Sett
 | `mcp_rag_transport` | 環境依存値 | MCP サーバーの接続方式はデプロイ環境に依存する |
 | `mcp_rag_url` | 環境依存値 | MCP サーバーのエンドポイント URL はデプロイ先ごとに異なる |
 | `log_level` | 環境依存値 | 本番・開発でログ出力レベルを変える必要がある |
+| `debug_log_enabled` | 環境依存値 | 開発・調査時にデバッグレベルのログ出力を有効にする |
+| `log_dir` | 環境依存値 | ログファイルの出力先ディレクトリをデプロイ先ごとに指定する |
 | `rag_bluesky_handle` | 環境依存値 | RAG 定期更新の対象 BlueSky アカウントはデプロイ環境ごとに異なりうる |
 | `rag_zenn_username` | 環境依存値 | RAG 定期更新の対象 Zenn アカウントはデプロイ環境ごとに異なりうる |
 | `online_llm_provider` | 環境依存値 | オンライン利用時の API プロバイダーを切り替える |
@@ -124,6 +127,7 @@ TOML はフラット構造（セクションなし）とし、キー名は `Sett
 | `rag_zenn_max_articles` | 共通設定値 | Zenn 定期更新でクロールする記事数の上限を制御する |
 | `claude_allowed_tools` | 共通設定値 | Claude CLI モードで許可する MCP ツールを制御する |
 | `claude_timeout` | 共通設定値 | Claude CLI プロセスのタイムアウトを設けて無応答時の待機を防止する |
+| `log_file_max_bytes` | 共通設定値 | ログファイル1つあたりの最大サイズを制御する（超過時にセッション単位で新ファイルへ切り替え、旧ファイルは保持） |
 
 `claude_allowed_tools` と `claude_timeout` は条件付き必須項目である。`chat_llm_provider=claude` の場合は必須とし、いずれかが未設定なら起動時エラーとする。`chat_llm_provider=local` / `online` の場合は任意とし、設定されていてもアプリケーションは参照しない。
 

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -57,6 +57,8 @@ class _EnvLoader(BaseSettings):
 
     # Logging
     log_level: str = "INFO"
+    debug_log_enabled: bool = False
+    log_dir: str = ""
 
     # RAG 定期更新アカウント（rag update コマンドで使用）
     rag_bluesky_handle: str = ""
@@ -93,6 +95,8 @@ class Settings(BaseModel):
     mcp_rag_transport: str
     mcp_rag_url: str
     log_level: str
+    debug_log_enabled: bool
+    log_dir: str
     rag_bluesky_handle: str
     rag_zenn_username: str
     online_llm_provider: Literal["openai", "anthropic"]
@@ -133,6 +137,9 @@ class Settings(BaseModel):
     # Claude CLI（chat_llm_provider="claude" の場合に使用。未指定時はデフォルト値を利用）
     claude_allowed_tools: str = ""
     claude_timeout: int = Field(default=120, ge=1)
+
+    # Logging（ログファイルのローテーション設定）
+    log_file_max_bytes: int = Field(ge=1)  # ログファイル1つあたりの最大サイズ
 
 
 def _load_toml_config() -> dict[str, Any]:

--- a/src/llm/factory.py
+++ b/src/llm/factory.py
@@ -4,6 +4,7 @@
 
 from __future__ import annotations
 
+import logging
 from typing import Literal
 
 from py_common_lib.secrets import get_secret
@@ -13,6 +14,8 @@ from src.llm.anthropic_provider import AnthropicProvider
 from src.llm.base import LLMProvider
 from src.llm.lmstudio_provider import LMStudioProvider
 from src.llm.openai_provider import OpenAIProvider
+
+logger = logging.getLogger(__name__)
 
 
 def create_online_provider(settings: Settings) -> LLMProvider:
@@ -50,5 +53,9 @@ def get_provider_for_service(
         対応するLLMプロバイダー
     """
     if service_llm_setting == "online":
-        return create_online_provider(settings)
-    return create_local_provider(settings)
+        provider = create_online_provider(settings)
+        logger.info("LLM provider selected: %s (online/%s)", type(provider).__name__, settings.online_llm_provider)
+        return provider
+    provider = create_local_provider(settings)
+    logger.info("LLM provider selected: %s (local)", type(provider).__name__)
+    return provider

--- a/src/main.py
+++ b/src/main.py
@@ -7,13 +7,16 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import sys
 from datetime import datetime
+from pathlib import Path
 from typing import TYPE_CHECKING
 from zoneinfo import ZoneInfo
 
+from py_common_lib.logging import SessionRotatingFileHandler
 from py_common_lib.secrets import SecretNotFoundError, get_secret
 
-from src.config.settings import SERVICE_NAME, get_settings, load_assistant_config
+from src.config.settings import SERVICE_NAME, Settings, get_settings, load_assistant_config
 from src.process_guard import (
     BOT_READY_SIGNAL,
     check_already_running,
@@ -27,13 +30,44 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+_LOG_FORMAT = "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 
+
+def _configure_logging(settings: Settings) -> None:
+    """ログ設定を構築する（フォーマット統一・ファイル出力・デバッグ切替）."""
+    # debug_log_enabled=True の場合は log_level 設定を上書きして DEBUG にする
+    log_level: int | str = logging.DEBUG if settings.debug_log_enabled else settings.log_level
+    formatter = logging.Formatter(_LOG_FORMAT)
+
+    root = logging.getLogger()
+    root.setLevel(log_level)
+
+    if not root.handlers:
+        stream_handler = logging.StreamHandler(sys.stderr)
+        stream_handler.setFormatter(formatter)
+        root.addHandler(stream_handler)
+    else:
+        for handler in root.handlers:
+            handler.setFormatter(formatter)
+
+    log_dir = settings.log_dir
+    if log_dir and not any(isinstance(h, SessionRotatingFileHandler) for h in root.handlers):
+        log_path = Path(log_dir)
+        log_path.mkdir(parents=True, exist_ok=True)
+        file_handler = SessionRotatingFileHandler(
+            log_dir=log_path,
+            prefix="bot",
+            started_at=datetime.now(),
+            max_bytes=settings.log_file_max_bytes,
+        )
+        file_handler.setFormatter(formatter)
+        root.addHandler(file_handler)
 
 
 async def main() -> None:
     # ログ設定（プロセスガードのログ出力に必要なため最初に実行）
     settings = get_settings()
-    logging.basicConfig(level=settings.log_level)
+    _configure_logging(settings)
 
     # 重複起動検知: 既に動いていたら警告して終了
     check_already_running()

--- a/src/mcp_bridge/client_manager.py
+++ b/src/mcp_bridge/client_manager.py
@@ -206,6 +206,8 @@ class MCPClientManager:
             MCPToolNotFoundError: 指定ツールが見つからない場合
             MCPToolExecutionError: ツール実行失敗時
         """
+        logger.info("call_tool: %s", tool_name)
+        logger.debug("call_tool args: %s", arguments)
         server_name = self._tool_to_server.get(tool_name)
         if server_name is None:
             raise MCPToolNotFoundError(f"ツール '{tool_name}' が見つかりません。")
@@ -230,7 +232,9 @@ class MCPClientManager:
                 text_parts.append(content_item.text)
             else:
                 text_parts.append(str(content_item))
-        return "\n".join(text_parts)
+        result_text = "\n".join(text_parts)
+        logger.info("call_tool completed: %s, result_length=%d", tool_name, len(result_text))
+        return result_text
 
     async def cleanup(self) -> None:
         """全接続をクリーンアップする."""

--- a/src/messaging/router.py
+++ b/src/messaging/router.py
@@ -516,12 +516,15 @@ class MessageRouter:
     async def process_message(self, msg: IncomingMessage) -> None:
         """受信メッセージをキーワードルーティングし、適切なサービスに委譲する."""
         cleaned_text = _strip_reminder_prefix(msg.text)
+        if cleaned_text != msg.text:
+            logger.debug("strip_reminder_prefix: %r -> %r", msg.text, cleaned_text)
         user_id = msg.user_id
         thread_id = msg.thread_id
         channel = msg.channel
 
         # ステータスコマンド (F5)
         if cleaned_text.lower().strip() in _STATUS_KEYWORDS:
+            logger.info("routing: text=%r -> handler=status", cleaned_text[:200])
             response_text = _build_status_message(
                 self._timezone, self._env_name, self._bot_start_time
             )
@@ -533,6 +536,7 @@ class MessageRouter:
         if self._collector is not None and any(
             re.match(rf"^{re.escape(kw)}\b", lower_text) for kw in _FEED_KEYWORDS
         ):
+            logger.info("routing: text=%r -> handler=feed", cleaned_text[:200])
             await self._handle_feed_command(msg, cleaned_text, lower_text)
             return
 
@@ -540,6 +544,7 @@ class MessageRouter:
         if self._mcp_manager is not None and any(
             re.match(rf"^{re.escape(kw)}\b", lower_text) for kw in _RAG_KEYWORDS
         ):
+            logger.info("routing: text=%r -> handler=rag", cleaned_text[:200])
             await self._handle_rag_command(msg, cleaned_text)
             return
 
@@ -553,10 +558,12 @@ class MessageRouter:
                 for kw in _DELIVER_KEYWORDS
             )
         ):
+            logger.info("routing: text=%r -> handler=deliver", cleaned_text[:200])
             await self._handle_deliver(msg)
             return
 
         # デフォルト: ChatService で応答
+        logger.info("routing: text=%r -> handler=chat", cleaned_text[:200])
         try:
             response = await self._chat_service.respond(
                 user_id=user_id,
@@ -583,6 +590,7 @@ class MessageRouter:
         channel = msg.channel
 
         subcommand, urls, category = _parse_feed_command(cleaned_text)
+        logger.debug("feed command parsed: subcommand=%s, urls=%s, category=%s", subcommand, urls, category)
 
         if subcommand == "add":
             response_text = await _handle_feed_add(self._collector, urls, category)
@@ -769,6 +777,7 @@ class MessageRouter:
         channel = msg.channel
 
         subcommand, url, raw_url_token = _parse_rag_command(cleaned_text)
+        logger.debug("rag command parsed: subcommand=%s, url=%s", subcommand, url)
 
         if subcommand == "status":
             try:

--- a/src/messaging/slack_adapter.py
+++ b/src/messaging/slack_adapter.py
@@ -5,10 +5,13 @@
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING
 
 from src.llm.base import Message
 from src.messaging.port import MessagingPort
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from slack_sdk.web.async_client import AsyncWebClient
@@ -36,6 +39,7 @@ class SlackAdapter(MessagingPort):
 
     async def send_message(self, text: str, thread_id: str, channel: str) -> None:
         """Slack にメッセージを投稿する."""
+        logger.debug("send_message: channel=%s, length=%d", channel, len(text))
         await self._client.chat_postMessage(
             channel=channel, text=text, thread_ts=thread_id,
         )
@@ -49,6 +53,7 @@ class SlackAdapter(MessagingPort):
         comment: str,
     ) -> None:
         """Slack にファイルをアップロードする."""
+        logger.info("upload_file: channel=%s, filename=%s, size=%d", channel, filename, len(content))
         await self._client.files_upload_v2(
             channel=channel,
             thread_ts=thread_id,

--- a/src/services/chat.py
+++ b/src/services/chat.py
@@ -452,7 +452,7 @@ class ChatService:
     ) -> str:
         """ユーザーメッセージとアシスタント応答をDBに保存し、応答テキストを返す."""
         logger.info("respond complete: user=%s, response_length=%d", user_id, len(assistant_text))
-        logger.debug("respond content: %s", assistant_text)
+        logger.info("respond content: %s", assistant_text)
 
         session.add(Conversation(
             slack_user_id=user_id,

--- a/src/services/chat.py
+++ b/src/services/chat.py
@@ -134,6 +134,8 @@ class ChatService:
         current_ts: str = "",
     ) -> str:
         """ユーザーメッセージに対する応答を生成し、履歴を保存する."""
+        mode = "claude" if self._claude_mode else "llm"
+        logger.info("respond start: user=%s, mode=%s, text=%r", user_id, mode, text[:200])
         async with self._session_factory() as session:
             # スレッド内かつ thread_history_fetcher が利用可能な場合は外部から取得
             history: list[Message] | None = None
@@ -449,6 +451,8 @@ class ChatService:
         rag_sources: list[RagSource] | None = None,
     ) -> str:
         """ユーザーメッセージとアシスタント応答をDBに保存し、応答テキストを返す."""
+        logger.info("respond complete: user=%s, response_length=%d", user_id, len(assistant_text))
+
         session.add(Conversation(
             slack_user_id=user_id,
             thread_ts=thread_ts,

--- a/src/services/chat.py
+++ b/src/services/chat.py
@@ -452,6 +452,7 @@ class ChatService:
     ) -> str:
         """ユーザーメッセージとアシスタント応答をDBに保存し、応答テキストを返す."""
         logger.info("respond complete: user=%s, response_length=%d", user_id, len(assistant_text))
+        logger.debug("respond content: %s", assistant_text)
 
         session.add(Conversation(
             slack_user_id=user_id,

--- a/src/slack/handlers.py
+++ b/src/slack/handlers.py
@@ -7,6 +7,7 @@
 
 from __future__ import annotations
 
+import logging
 import re
 from typing import TYPE_CHECKING
 
@@ -17,12 +18,17 @@ from src.messaging.port import IncomingMessage
 if TYPE_CHECKING:
     from src.messaging.router import MessageRouter
 
+logger = logging.getLogger(__name__)
+
 _MENTION_PATTERN = re.compile(r"<@[A-Za-z0-9]+(?:\|[^>]+)?>\s*")
 
 
 def strip_mention(text: str) -> str:
     """メンション部分 (<@U...> または <@U...|name>) を除去する."""
-    return _MENTION_PATTERN.sub("", text).strip()
+    result = _MENTION_PATTERN.sub("", text).strip()
+    if result != text:
+        logger.debug("strip_mention: %r -> %r", text, result)
+    return result
 
 
 def register_handlers(
@@ -42,8 +48,14 @@ def register_handlers(
         files: list[dict[str, object]] | None = event.get("files")
         channel: str = event.get("channel", "")
 
+        logger.info(
+            "mention received: user=%s, channel=%s, raw_text=%r",
+            user_id, channel, text[:200],
+        )
+
         cleaned_text = strip_mention(text)
         if not cleaned_text:
+            logger.debug("mention ignored: empty text after strip_mention")
             return
 
         msg = IncomingMessage(
@@ -71,9 +83,11 @@ def register_handlers(
             return
 
         if event.get("bot_id"):
+            logger.debug("message filtered: bot_id present")
             return
 
         if event.get("subtype"):
+            logger.debug("message filtered: subtype=%s", event.get("subtype"))
             return
 
         channel: str = event.get("channel", "")
@@ -83,10 +97,12 @@ def register_handlers(
         text: str = event.get("text", "")
 
         if _MENTION_PATTERN.search(text):
+            logger.debug("message filtered: contains mention (handled by app_mention)")
             return
 
         user_id: str = event.get("user", "")
         if not user_id:
+            logger.debug("message filtered: no user_id")
             return
 
         raw_thread_ts: str | None = event.get("thread_ts")
@@ -96,7 +112,13 @@ def register_handlers(
 
         cleaned_text = text.strip()
         if not cleaned_text:
+            logger.debug("message filtered: empty text")
             return
+
+        logger.info(
+            "auto-reply message: user=%s, channel=%s, text=%r",
+            user_id, channel, cleaned_text[:200],
+        )
 
         msg = IncomingMessage(
             user_id=user_id,

--- a/tests/settings_defaults.py
+++ b/tests/settings_defaults.py
@@ -18,6 +18,8 @@ TEST_SETTINGS_DEFAULTS: dict[str, object] = {
     "mcp_rag_transport": "http",
     "mcp_rag_url": "",
     "log_level": "INFO",
+    "debug_log_enabled": False,
+    "log_dir": "",
     "rag_bluesky_handle": "",
     "rag_zenn_username": "",
     "online_llm_provider": "openai",
@@ -39,4 +41,5 @@ TEST_SETTINGS_DEFAULTS: dict[str, object] = {
     "feed_summarize_reasoning_effort": "none",
     "claude_allowed_tools": "",
     "claude_timeout": 120,
+    "log_file_max_bytes": 10485760,
 }

--- a/uv.lock
+++ b/uv.lock
@@ -1353,7 +1353,7 @@ wheels = [
 [[package]]
 name = "py-common-lib"
 version = "0.1.0"
-source = { git = "https://github.com/becky3/py-common-lib#65ce072c1c052269ace49495c6b4bec58efc9a10" }
+source = { git = "https://github.com/becky3/py-common-lib#080e2bbc0352af6482e000b6f1c1cbba8072406a" }
 dependencies = [
     { name = "httpx" },
     { name = "keyring" },


### PR DESCRIPTION
## Change type

- [x] feat: 新機能実装
- [x] docs: ドキュメント更新

## Summary

- ログ基盤整備: フォーマット統一（`%(asctime)s - %(name)s - %(levelname)s - %(message)s`）、`SessionRotatingFileHandler`（py-common-lib 共通化）によるファイル出力、`DEBUG_LOG_ENABLED` による切替
- メッセージ受信ログ: `handlers.py` に mention/auto-reply 受信時の raw テキスト、`strip_mention` の入出力、フィルタリング理由を記録
- ルーティングログ: `router.py` にコマンド判定結果（feed/rag/deliver/chat）、コマンドパース結果を記録
- 主要処理パスログ: `chat.py`（respond 開始/完了）、`factory.py`（LLM プロバイダー選択）、`slack_adapter.py`（送信/アップロード）、`client_manager.py`（MCP ツール呼び出し）
- 設定追加: `.env` に `DEBUG_LOG_ENABLED` / `LOG_DIR`、`config.toml` に `log_file_max_bytes`
- 仕様書更新: `config-management.md` の環境依存値・共通設定値テーブルに新設定を追記

## Test plan

- [x] pytest 367 passed
- [x] ruff check clean
- [x] mypy clean

## Related issues

Closes #824