### PR TITLE
feat(logging): 全 handler / 主要サービスにタイミングログを追加 (#835)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ RSS記事の自動収集・要約配信、チャットでの質問応答を行�
 | **ボットステータス** | 稼働環境・ホスト名・稼働時間を表示し、どのサーバーでボットが動作しているかを確認できる |
 | **Botプロセスガード** | PIDファイルによるプロセス管理で、多重起動の防止・グレースフルシャットダウン・子プロセスのクリーンアップを行う |
 | **Remote Control 起動** | Slack コマンド (`@bot rc start <repo-key>`) でホスト PC 上の指定リポジトリで `claude remote-control` を起動し、claude.ai/code 接続 URL を返す。外出先のスマホから PC 操作なしで Claude Code セッションを開始できる。許可ユーザーと対象リポジトリの allowlist 設定が必要 |
+| **ログ出力** | 全 handler・主要サービスにタイミングログを付与し、所要時間・実行段階の事後追跡を可能にする |
 
 全機能の一覧と仕様書リンクは [全体仕様概要](docs/specs/overview.md) を参照。
 
@@ -135,6 +136,7 @@ uv run mypy src
 - [RAGナレッジ](docs/specs/infrastructure/rag-knowledge.md)
 - [Bot プロセスガード](docs/specs/infrastructure/bot-process-guard.md)
 - [設定管理](docs/specs/infrastructure/config-management.md)
+- [ログ出力](docs/specs/infrastructure/logging.md)
 
 ### ワークフロー（workflows）
 

--- a/docs/specs/infrastructure/logging.md
+++ b/docs/specs/infrastructure/logging.md
@@ -29,7 +29,12 @@ bot 全体のログ出力に関する基盤と運用パターンを定義する�
 | INFO | handler の入口・完了、主要サービスの公開メソッドの入口・完了 |
 | DEBUG | 副作用を伴う処理（HTTP / DB / 外部コマンド / LLM / MCP）の前後 |
 | WARNING | 期待外の状態だが処理は継続する場合（タイムアウトでフォールバック、空応答時のフォールバック等） |
-| ERROR | 例外発生時。`logger.exception()` を用い、stack trace 付きで `ERROR` レベルに出力する |
+| ERROR | 致命的な例外で処理を中断する場合。`logger.exception()` を用い、stack trace 付きで `ERROR` レベルに出力する |
+
+例外発生時のレベル選択指針:
+
+- **致命的（処理を中断する）**: `logger.exception(...)` で `ERROR` + stack trace
+- **フォールバック可能（フォールバック処理で継続する）**: `logger.warning(...)` または `logger.debug(..., exc_info=True)` を使い分ける。stack trace が原因調査に有用なら `exc_info=True` を付ける。フォールバックが頻発する想定なら `DEBUG`、稀なら `WARNING` を選ぶ
 
 DEBUG レベルは `.env` の `DEBUG_LOG_ENABLED=true` で有効化できる（再起動が必要）。詳細は `config-management.md` を参照。
 

--- a/docs/specs/infrastructure/logging.md
+++ b/docs/specs/infrastructure/logging.md
@@ -1,0 +1,106 @@
+# ログ出力
+
+## 概要
+
+bot 全体のログ出力に関する基盤と運用パターンを定義する。Slack ハンドラ・主要サービスの観測性を統一し、再現困難な不具合の事後追跡を可能にする。
+
+## 背景
+
+`feed add` のレスポンスが本番で約 1 分かかる現象が発生したが、当時のログには handler の入口（`mention received` / `routing`）しか出ておらず、内部のどのステップで時間がかかったかをログ単独で特定できなかった。
+一方 `ChatService.respond` は `respond start` / `respond complete` の 2 段ログがあり、LLM 呼び出しの所要時間を `respond start` と `respond complete` のタイムスタンプ差分で確認できる仕組みになっていた。
+
+この差を全 handler / 主要サービスに展開し、原因調査時に「どの処理がどのタイミングで走ったか」をログだけで追跡可能にすることが本仕様の目的。
+
+## 制約
+
+- ログ出力は Python 標準の `logging` モジュールで行う。新規ロギングフレームワーク導入は行わない
+- ログファイルは py-common-lib の `SessionRotatingFileHandler` を介してセッション単位でローテートされる。詳細は同ライブラリの仕様を参照
+- 所要時間は明示計算しない。`start` ログと `complete` ログのタイムスタンプ差分から事後算出する（ロガーの asctime はミリ秒精度）
+- シークレット（API キー・認証トークン）の値はログに出力しない（`~/.claude/rules/invariants.md`「秘匿情報の出力禁止」準拠）
+- 構造化ログ（JSON 化）・外部ログ集約基盤（Loki / Datadog 等）は本仕様の対象外
+- 本仕様は既存の外部通信に対しログを付与するのみで、リクエスト数・所要時間制御（タイムアウト・レート制限・リトライ）は行わない。それらの制御は各機能の仕様書に従う
+
+## インターフェース
+
+### ログレベル方針
+
+| レベル | 用途 |
+|---|---|
+| INFO | handler の入口・完了、主要サービスの公開メソッドの入口・完了 |
+| DEBUG | 副作用を伴う処理（HTTP / DB / 外部コマンド / LLM / MCP）の前後 |
+| WARNING | 期待外の状態だが処理は継続する場合（タイムアウトでフォールバック、空応答時のフォールバック等） |
+| ERROR | 例外発生時。`logger.exception()` を用い、stack trace 付きで `ERROR` レベルに出力する |
+
+DEBUG レベルは `.env` の `DEBUG_LOG_ENABLED=true` で有効化できる（再起動が必要）。詳細は `config-management.md` を参照。
+
+### ログメッセージのフォーマット
+
+`<処理名> start: <文脈情報>` / `<処理名> complete: <結果情報>` の形式で統一する。
+
+- **処理名**: `<クラス省略の関数名>` または `<モジュールの代表処理名>`（例: `handle_feed_add`, `fetch_feed_title`, `summarize`）
+- **文脈情報**: 処理の入力を示す主要な値（URL・カテゴリ・件数等）。`key=value` 形式
+- **結果情報**: 処理の出力を示す主要な値（成功件数・エラー件数・取得件数・結果ステータス等）
+
+例（以下はロガーのメッセージ本文部分のみを示す。`asctime` / `levelname` / `name` 等のヘッダはハンドラ側で付与される）:
+
+```
+handle_feed_add start: urls=1, category=一般
+handle_feed_add complete: success=1, error=0, total=1
+```
+
+```
+fetch_feed_title start: url=https://example.com/rss
+feedparser.parse start: url=https://example.com/rss
+feedparser.parse complete: url=https://example.com/rss, entries=20
+fetch_feed_title complete: url=https://example.com/rss, title='Example Feed'
+```
+
+### 早期 return 時の complete ログ
+
+`if` 分岐や例外で早期 return する場合も、return 直前に `complete` ログを出して `start` と必ず対になるようにする。`complete` ログには `result=<状態名>` で原因を示す（例: `result=empty_urls`, `result=duplicate`, `result=timeout`）。
+
+### 例外時の扱い
+
+例外で関数が抜ける場合、既存の `logger.exception` で stack trace 付きログを出す方針を維持する。本仕様では `complete` ログを `try/finally` で必ず出すといった追加の構造化はしない（実装シンプル優先）。
+
+## コンポーネント構成
+
+呼び出しチェーン（Handler → サービス層 → 外部呼び出し）の各層が独立にログを出力する。INFO レベルで出る層と DEBUG レベルで出る層を視覚的に分離する:
+
+```mermaid
+flowchart LR
+    subgraph INFO_layer ["INFO レベル"]
+        Handler[Slack handler]
+        Service[サービス層]
+    end
+    subgraph DEBUG_layer ["DEBUG レベル"]
+        External[外部呼び出し]
+    end
+    Handler --> Service
+    Service --> External
+    Handler -.start/complete.-> LogFile[(ログファイル)]
+    Service -.start/complete.-> LogFile
+    External -.start/complete.-> LogFile
+```
+
+### 適用対象
+
+| 層 | 対象 | レベル |
+|---|---|---|
+| Slack handler | `src/messaging/router.py` の `_handle_*` 全て | INFO |
+| サービス層 | `src/services/feed_collector.py` / `src/services/summarizer.py` / `src/services/ogp_extractor.py` / `src/services/thread_history.py` / `src/services/remote_control.py` の公開メソッド | INFO |
+| スケジューラ | `src/scheduler/jobs.py` のトップレベル関数 | INFO |
+| 外部呼び出し | `feedparser.parse` / `httpx GET` / `src/llm/claude_cli.py` の `call_claude` / `src/mcp_bridge/client_manager.py` の `call_tool` / DB の主要ポイント | DEBUG |
+
+`ChatService.respond` の既存ログ（`respond start` / `respond complete` / `respond content`）はそのまま維持する（先行実装で本仕様に合致）。
+
+## 外部連携
+
+- ログファイル基盤: `py-common-lib.logging.SessionRotatingFileHandler`（外部リポジトリ）
+
+## 関連ドキュメント
+
+- `docs/specs/features/chat-response.md` — `ChatService.respond` のログパターン（本仕様の参考実装）
+- `docs/specs/infrastructure/config-management.md` — ログ関連設定値（`debug_log_enabled` / `log_level` / `log_dir` / `log_file_max_bytes`）の SSoT
+- `~/.claude/rules/invariants.md` — 秘匿情報の出力禁止
+- py-common-lib の `SessionRotatingFileHandler` 仕様（外部リポジトリ）

--- a/docs/specs/overview.md
+++ b/docs/specs/overview.md
@@ -21,6 +21,7 @@ AI Assistantは、Slack上で動作するAIアシスタントである。
 | 10 | Botプロセスガード | PIDファイルによるプロセス管理で多重起動防止・管理コマンドを提供 | [bot-process-guard.md](infrastructure/bot-process-guard.md) |
 | 11 | 設定管理 | アプリケーション設定の3層分離（シークレット・環境依存値・共通設定値） | [config-management.md](infrastructure/config-management.md) |
 | 12 | Remote Control 起動 | Slack コマンドからホスト PC 上の指定リポジトリで `claude remote-control` を起動し、接続 URL を返す | [remote-control-launch.md](features/remote-control-launch.md) |
+| 13 | ログ出力 | 全 handler / 主要サービスのタイミングログによる観測性向上 | [logging.md](infrastructure/logging.md) |
 
 ## 3. 技術スタック
 

--- a/src/llm/claude_cli.py
+++ b/src/llm/claude_cli.py
@@ -41,6 +41,7 @@ async def call_claude(
     if allowed_tools:
         cmd.extend(["--allowedTools", allowed_tools])
 
+    logger.info("call_claude start: prompt_len=%d, timeout=%d", len(prompt), timeout)
     logger.debug("Claude CLI 実行: %s", " ".join(cmd[:4]))
 
     proc = await asyncio.create_subprocess_exec(
@@ -74,4 +75,5 @@ async def call_claude(
         logger.warning(msg)
         raise RuntimeError(msg)
 
+    logger.info("call_claude complete: response_len=%d", len(response))
     return response

--- a/src/mcp_bridge/client_manager.py
+++ b/src/mcp_bridge/client_manager.py
@@ -207,7 +207,10 @@ class MCPClientManager:
             MCPToolExecutionError: ツール実行失敗時
         """
         logger.info("call_tool start: tool=%s", tool_name)
-        logger.debug("call_tool args: tool=%s, arguments=%s", tool_name, arguments)
+        # 引数値そのものは秘匿情報・個人情報を含む可能性があるため
+        # ログにはキー一覧と各値の長さのみ出力する
+        arg_summary = {k: f"len={len(str(v))}" for k, v in arguments.items()}
+        logger.debug("call_tool args: tool=%s, arg_summary=%s", tool_name, arg_summary)
         server_name = self._tool_to_server.get(tool_name)
         if server_name is None:
             raise MCPToolNotFoundError(f"ツール '{tool_name}' が見つかりません。")

--- a/src/mcp_bridge/client_manager.py
+++ b/src/mcp_bridge/client_manager.py
@@ -206,8 +206,8 @@ class MCPClientManager:
             MCPToolNotFoundError: 指定ツールが見つからない場合
             MCPToolExecutionError: ツール実行失敗時
         """
-        logger.info("call_tool: %s", tool_name)
-        logger.debug("call_tool args: %s", arguments)
+        logger.info("call_tool start: tool=%s", tool_name)
+        logger.debug("call_tool args: tool=%s, arguments=%s", tool_name, arguments)
         server_name = self._tool_to_server.get(tool_name)
         if server_name is None:
             raise MCPToolNotFoundError(f"ツール '{tool_name}' が見つかりません。")
@@ -233,7 +233,7 @@ class MCPClientManager:
             else:
                 text_parts.append(str(content_item))
         result_text = "\n".join(text_parts)
-        logger.info("call_tool completed: %s, result_length=%d", tool_name, len(result_text))
+        logger.info("call_tool complete: tool=%s, result_len=%d", tool_name, len(result_text))
         return result_text
 
     async def cleanup(self) -> None:

--- a/src/messaging/router.py
+++ b/src/messaging/router.py
@@ -143,29 +143,43 @@ async def _handle_feed_add(
     collector: FeedCollector, urls: list[str], category: str
 ) -> str:
     """フィード追加処理."""
+    logger.info("handle_feed_add start: urls=%d, category=%s", len(urls), category)
+
     if not urls:
+        logger.info("handle_feed_add complete: result=empty_urls")
         return "エラー: URLを指定してください。\n例: `@bot feed add https://example.com/rss [カテゴリ]`"
 
+    success_count = 0
+    error_count = 0
     results: list[str] = []
     for url in urls:
         try:
             name = await collector.fetch_feed_title(url)
             feed = await collector.add_feed(url, name, category)
             results.append(f"✅ {feed.url} を追加しました（名前: {feed.name}、カテゴリ: {feed.category}）")
+            success_count += 1
         except ValueError as e:
             results.append(f"❌ {url}: {e}")
+            error_count += 1
         except Exception:
             logger.exception("Failed to add feed: %s", url)
             results.append(f"❌ {url}: 追加中にエラーが発生しました")
+            error_count += 1
 
+    logger.info(
+        "handle_feed_add complete: success=%d, error=%d, total=%d",
+        success_count, error_count, len(urls),
+    )
     return "\n".join(results)
 
 
 async def _handle_feed_list(collector: FeedCollector) -> str:
     """フィード一覧表示処理."""
+    logger.info("handle_feed_list start")
     enabled, disabled = await collector.list_feeds()
 
     if not enabled and not disabled:
+        logger.info("handle_feed_list complete: enabled=0, disabled=0")
         return "フィードが登録されていません"
 
     lines: list[str] = []
@@ -181,63 +195,100 @@ async def _handle_feed_list(collector: FeedCollector) -> str:
         for feed in disabled:
             lines.append(f"• {feed.url} — {feed.name}")
 
+    logger.info(
+        "handle_feed_list complete: enabled=%d, disabled=%d",
+        len(enabled), len(disabled),
+    )
     return "\n".join(lines)
 
 
 async def _handle_feed_delete(collector: FeedCollector, urls: list[str]) -> str:
     """フィード削除処理."""
+    logger.info("handle_feed_delete start: urls=%d", len(urls))
     if not urls:
+        logger.info("handle_feed_delete complete: result=empty_urls")
         return "エラー: URLを指定してください。\n例: `@bot feed delete https://example.com/rss`"
 
+    success_count = 0
+    error_count = 0
     results: list[str] = []
     for url in urls:
         try:
             await collector.delete_feed(url)
             results.append(f"✅ {url} を削除しました")
+            success_count += 1
         except ValueError as e:
             results.append(f"❌ {url}: {e}")
+            error_count += 1
         except Exception:
             logger.exception("Failed to delete feed: %s", url)
             results.append(f"❌ {url}: 削除中にエラーが発生しました")
+            error_count += 1
 
+    logger.info(
+        "handle_feed_delete complete: success=%d, error=%d, total=%d",
+        success_count, error_count, len(urls),
+    )
     return "\n".join(results)
 
 
 async def _handle_feed_enable(collector: FeedCollector, urls: list[str]) -> str:
     """フィード有効化処理."""
+    logger.info("handle_feed_enable start: urls=%d", len(urls))
     if not urls:
+        logger.info("handle_feed_enable complete: result=empty_urls")
         return "エラー: URLを指定してください。\n例: `@bot feed enable https://example.com/rss`"
 
+    success_count = 0
+    error_count = 0
     results: list[str] = []
     for url in urls:
         try:
             await collector.enable_feed(url)
             results.append(f"✅ {url} を有効化しました")
+            success_count += 1
         except ValueError as e:
             results.append(f"❌ {url}: {e}")
+            error_count += 1
         except Exception:
             logger.exception("Failed to enable feed: %s", url)
             results.append(f"❌ {url}: 有効化中にエラーが発生しました")
+            error_count += 1
 
+    logger.info(
+        "handle_feed_enable complete: success=%d, error=%d, total=%d",
+        success_count, error_count, len(urls),
+    )
     return "\n".join(results)
 
 
 async def _handle_feed_disable(collector: FeedCollector, urls: list[str]) -> str:
     """フィード無効化処理."""
+    logger.info("handle_feed_disable start: urls=%d", len(urls))
     if not urls:
+        logger.info("handle_feed_disable complete: result=empty_urls")
         return "エラー: URLを指定してください。\n例: `@bot feed disable https://example.com/rss`"
 
+    success_count = 0
+    error_count = 0
     results: list[str] = []
     for url in urls:
         try:
             await collector.disable_feed(url)
             results.append(f"✅ {url} を無効化しました")
+            success_count += 1
         except ValueError as e:
             results.append(f"❌ {url}: {e}")
+            error_count += 1
         except Exception:
             logger.exception("Failed to disable feed: %s", url)
             results.append(f"❌ {url}: 無効化中にエラーが発生しました")
+            error_count += 1
 
+    logger.info(
+        "handle_feed_disable complete: success=%d, error=%d, total=%d",
+        success_count, error_count, len(urls),
+    )
     return "\n".join(results)
 
 
@@ -367,8 +418,10 @@ async def _handle_feed_import(
     bot_token: str,
 ) -> str:
     """CSVファイルからフィードを一括インポートする."""
+    logger.info("handle_feed_import start: files=%d", len(files) if files else 0)
     rows, error = await _download_and_parse_csv(files, bot_token)
     if error is not None:
+        logger.info("handle_feed_import complete: result=download_or_parse_error")
         return error
 
     success_count, errors = await _import_feeds_from_rows(collector, rows)
@@ -380,6 +433,10 @@ async def _handle_feed_import(
     ]
     result_lines.extend(_format_error_details(errors))
 
+    logger.info(
+        "handle_feed_import complete: success=%d, error=%d, total=%d",
+        success_count, len(errors), len(rows),
+    )
     return "\n".join(result_lines)
 
 
@@ -389,14 +446,17 @@ async def _handle_feed_replace(
     bot_token: str,
 ) -> str:
     """CSVファイルで全フィードを置換する（全削除→再登録）."""
+    logger.info("handle_feed_replace start: files=%d", len(files) if files else 0)
     rows, error = await _download_and_parse_csv(files, bot_token)
     if error is not None:
+        logger.info("handle_feed_replace complete: result=download_or_parse_error")
         return error
 
     try:
         deleted_count = await collector.delete_all_feeds()
     except Exception:
         logger.exception("Failed to delete all feeds in replace")
+        logger.info("handle_feed_replace complete: result=delete_all_failed")
         return (
             "*フィード置換エラー*\n"
             "🗑️ 既存フィードの削除中に予期せぬエラーが発生しました。\n"
@@ -407,6 +467,10 @@ async def _handle_feed_replace(
         success_count, errors = await _import_feeds_from_rows(collector, rows)
     except Exception:
         logger.exception("Failed to import feeds after delete_all in replace")
+        logger.info(
+            "handle_feed_replace complete: result=import_failed, deleted=%d",
+            deleted_count,
+        )
         return (
             "*フィード置換エラー*\n"
             f"🗑️ 削除: {deleted_count}件（既存フィード）\n"
@@ -421,6 +485,10 @@ async def _handle_feed_replace(
     ]
     result_lines.extend(_format_error_details(errors))
 
+    logger.info(
+        "handle_feed_replace complete: deleted=%d, success=%d, error=%d, total=%d",
+        deleted_count, success_count, len(errors), len(rows),
+    )
     return "\n".join(result_lines)
 
 
@@ -431,9 +499,11 @@ async def _handle_feed_export_via_port(
     channel: str,
 ) -> str:
     """全フィードをCSV形式でエクスポートする（MessagingPort経由）."""
+    logger.info("handle_feed_export start")
     feeds = await collector.get_all_feeds()
 
     if not feeds:
+        logger.info("handle_feed_export complete: result=no_feeds")
         return "エクスポートするフィードがありません。"
 
     def _sanitize_csv_field(value: str) -> str:
@@ -464,13 +534,16 @@ async def _handle_feed_export_via_port(
         error_msg = str(e)
         if "missing_scope" in error_msg or "not_allowed_token_type" in error_msg:
             logger.error("File upload failed due to missing scope: %s", e)
+            logger.info("handle_feed_export complete: result=missing_scope")
             return (
                 "エラー: ファイルのアップロードに失敗しました。\n"
                 "Slack Appに `files:write` スコープの追加が必要です。"
             )
         logger.exception("Failed to upload CSV file")
+        logger.info("handle_feed_export complete: result=upload_error")
         return f"エラー: ファイルのアップロードに失敗しました: {e}"
 
+    logger.info("handle_feed_export complete: feeds=%d", len(feeds))
     return ""
 
 
@@ -615,6 +688,10 @@ class MessageRouter:
         channel = msg.channel
 
         subcommand, urls, category = _parse_feed_command(cleaned_text)
+        logger.info(
+            "handle_feed_command start: subcommand=%s, urls=%d, category=%s",
+            subcommand, len(urls), category,
+        )
         logger.debug("feed command parsed: subcommand=%s, urls=%s, category=%s", subcommand, urls, category)
 
         if subcommand == "add":
@@ -647,12 +724,15 @@ class MessageRouter:
             )
             if response_text:
                 await self._messaging.send_message(response_text, thread_id, channel)
+            logger.info("handle_feed_command complete: subcommand=export")
             return
         elif subcommand == "collect":
             await self._handle_feed_collect(msg, cleaned_text)
+            logger.info("handle_feed_command complete: subcommand=collect")
             return
         elif subcommand == "test":
             await self._handle_feed_test(msg)
+            logger.info("handle_feed_command complete: subcommand=test")
             return
         else:
             response_text = (
@@ -671,11 +751,13 @@ class MessageRouter:
             )
 
         await self._messaging.send_message(response_text, thread_id, channel)
+        logger.info("handle_feed_command complete: subcommand=%s", subcommand)
 
     async def _handle_feed_collect(
         self, msg: IncomingMessage, cleaned_text: str
     ) -> None:
         """feed collect コマンド処理."""
+        logger.info("handle_feed_collect start")
         thread_id = msg.thread_id
         channel = msg.channel
 
@@ -703,25 +785,33 @@ class MessageRouter:
                         f"要約スキップ収集が完了しました\n収集フィード数: {feed_count}\n収集記事数: {article_count}",
                         thread_id, channel,
                     )
+                    logger.info(
+                        "handle_feed_collect complete: feeds=%d, articles=%d",
+                        feed_count, article_count,
+                    )
                 except Exception:
                     logger.exception("Failed to collect feeds with skip-summary")
                     await self._messaging.send_message(
                         "要約スキップ収集中にエラーが発生しました。",
                         thread_id, channel,
                     )
+                    logger.info("handle_feed_collect complete: result=error")
             else:
                 await self._messaging.send_message(
                     "エラー: 配信設定が不足しています。", thread_id, channel
                 )
+                logger.info("handle_feed_collect complete: result=missing_config")
         else:
             response_text = (
                 "使用方法:\n"
                 "• `@bot feed collect --skip-summary` — 要約なし一括収集"
             )
             await self._messaging.send_message(response_text, thread_id, channel)
+            logger.info("handle_feed_collect complete: result=usage_help")
 
     async def _handle_feed_test(self, msg: IncomingMessage) -> None:
         """feed test コマンド処理."""
+        logger.info("handle_feed_test start")
         thread_id = msg.thread_id
         channel = msg.channel
 
@@ -745,20 +835,24 @@ class MessageRouter:
                 await self._messaging.send_message(
                     "テスト配信が完了しました", thread_id, channel
                 )
+                logger.info("handle_feed_test complete: result=success")
             except Exception:
                 logger.exception("Failed to run feed test delivery")
                 await self._messaging.send_message(
                     "テスト配信中にエラーが発生しました。",
                     thread_id, channel,
                 )
+                logger.info("handle_feed_test complete: result=error")
         else:
             await self._messaging.send_message(
                 "エラー: 配信設定が不足しています（Slack接続が必要です）。",
                 thread_id, channel,
             )
+            logger.info("handle_feed_test complete: result=missing_config")
 
     async def _handle_deliver(self, msg: IncomingMessage) -> None:
         """deliver コマンド処理."""
+        logger.info("handle_deliver start")
         assert self._collector is not None
         assert self._session_factory is not None
         assert self._channel_id is not None
@@ -770,6 +864,7 @@ class MessageRouter:
                 "エラー: deliver コマンドは Slack 接続時のみ使用できます。",
                 thread_id, channel,
             )
+            logger.info("handle_deliver complete: result=no_slack_client")
             return
 
         from src.scheduler.jobs import daily_collect_and_deliver
@@ -787,11 +882,13 @@ class MessageRouter:
             await self._messaging.send_message(
                 "配信が完了しました", thread_id, channel
             )
+            logger.info("handle_deliver complete: result=success")
         except Exception:
             logger.exception("Failed to run manual delivery")
             await self._messaging.send_message(
                 "配信中にエラーが発生しました。", thread_id, channel
             )
+            logger.info("handle_deliver complete: result=error")
 
     async def _handle_rag_command(
         self, msg: IncomingMessage, cleaned_text: str
@@ -802,6 +899,7 @@ class MessageRouter:
         channel = msg.channel
 
         subcommand, url, raw_url_token = _parse_rag_command(cleaned_text)
+        logger.info("handle_rag_command start: subcommand=%s", subcommand)
         logger.debug("rag command parsed: subcommand=%s, url=%s", subcommand, url)
 
         if subcommand == "status":
@@ -819,14 +917,17 @@ class MessageRouter:
             )
         elif subcommand == "update":
             await self._handle_rag_update(thread_id, channel)
+            logger.info("handle_rag_command complete: subcommand=update")
             return
         elif subcommand == "rebuild":
             tokens = cleaned_text.split()
             mode = tokens[2] if len(tokens) >= 3 else "index"
             await self._handle_rag_rebuild(mode, thread_id, channel)
+            logger.info("handle_rag_command complete: subcommand=rebuild")
             return
         elif subcommand == "help":
             await self._handle_rag_help(thread_id, channel)
+            logger.info("handle_rag_command complete: subcommand=help")
             return
         else:
             response_text = (
@@ -840,6 +941,7 @@ class MessageRouter:
 
         if response_text:
             await self._messaging.send_message(response_text, thread_id, channel)
+        logger.info("handle_rag_command complete: subcommand=%s", subcommand)
 
     async def _call_rag_url_tool(
         self,
@@ -867,6 +969,7 @@ class MessageRouter:
         self, thread_id: str, channel: str,
     ) -> None:
         """BlueSky・Zenn の定期更新を一括実行する."""
+        logger.info("handle_rag_update start")
         assert self._mcp_manager is not None
 
         if not self._rag_bluesky_handle and not self._rag_zenn_username:
@@ -874,6 +977,7 @@ class MessageRouter:
                 "エラー: RAG_BLUESKY_HANDLE / RAG_ZENN_USERNAME が .env に設定されていません。",
                 thread_id, channel,
             )
+            logger.info("handle_rag_update complete: result=missing_config")
             return
 
         targets: list[tuple[str, str, dict[str, object]]] = []
@@ -904,6 +1008,7 @@ class MessageRouter:
         await self._messaging.send_message(
             "\n".join(results), thread_id, channel,
         )
+        logger.info("handle_rag_update complete: targets=%d", len(targets))
 
     _VALID_REBUILD_MODES = frozenset({"full", "convert", "index", "incremental"})
 
@@ -911,6 +1016,7 @@ class MessageRouter:
         self, mode: str, thread_id: str, channel: str,
     ) -> None:
         """RAG インデックスの再構築を実行する."""
+        logger.info("handle_rag_rebuild start: mode=%s", mode)
         assert self._mcp_manager is not None
 
         if mode not in self._VALID_REBUILD_MODES:
@@ -919,6 +1025,7 @@ class MessageRouter:
                 f"有効な mode: {', '.join(sorted(self._VALID_REBUILD_MODES))}",
                 thread_id, channel,
             )
+            logger.info("handle_rag_rebuild complete: result=invalid_mode")
             return
 
         await self._messaging.send_message(
@@ -937,11 +1044,13 @@ class MessageRouter:
             response_text = "エラー: リビルド中にエラーが発生しました。"
 
         await self._messaging.send_message(response_text, thread_id, channel)
+        logger.info("handle_rag_rebuild complete: mode=%s", mode)
 
     async def _handle_rag_help(
         self, thread_id: str, channel: str,
     ) -> None:
         """RAG MCPツール一覧を動的に取得して表示する."""
+        logger.info("handle_rag_help start")
         assert self._mcp_manager is not None
 
         try:
@@ -952,6 +1061,7 @@ class MessageRouter:
                 "エラー: RAG ツール一覧の取得に失敗しました。",
                 thread_id, channel,
             )
+            logger.info("handle_rag_help complete: result=tools_fetch_error")
             return
 
         rag_tools = [t for t in tools if t.name.startswith("rag_")]
@@ -961,6 +1071,7 @@ class MessageRouter:
                 "RAG ツールが見つかりません。MCP サーバーが起動しているか確認してください。",
                 thread_id, channel,
             )
+            logger.info("handle_rag_help complete: result=no_rag_tools")
             return
 
         lines = ["*RAG MCPツール一覧:*\n"]
@@ -972,6 +1083,7 @@ class MessageRouter:
             lines.append(f"• `{tool.name}` — {desc}")
 
         await self._messaging.send_message("\n".join(lines), thread_id, channel)
+        logger.info("handle_rag_help complete: tools=%d", len(rag_tools))
 
     async def _handle_rc_command(
         self, msg: IncomingMessage, cleaned_text: str,
@@ -980,6 +1092,7 @@ class MessageRouter:
 
         仕様: docs/specs/features/remote-control-launch.md
         """
+        logger.info("handle_rc_command start: user=%s", msg.user_id)
         assert self._remote_control_launcher is not None
         thread_id = msg.thread_id
         channel = msg.channel
@@ -992,6 +1105,7 @@ class MessageRouter:
                 "❌ このコマンドを実行する権限がありません",
                 thread_id, channel,
             )
+            logger.info("handle_rc_command complete: result=permission_denied")
             return
 
         tokens = cleaned_text.split()
@@ -999,6 +1113,7 @@ class MessageRouter:
             await self._messaging.send_message(
                 self._build_rc_usage(), thread_id, channel,
             )
+            logger.info("handle_rc_command complete: result=usage")
             return
 
         subcommand = tokens[1].lower()
@@ -1006,6 +1121,7 @@ class MessageRouter:
             await self._messaging.send_message(
                 self._build_rc_usage(), thread_id, channel,
             )
+            logger.info("handle_rc_command complete: result=invalid_subcommand")
             return
 
         if len(tokens) < 3:
@@ -1013,6 +1129,7 @@ class MessageRouter:
                 "エラー: リポジトリキーを指定してください。\n" + self._build_rc_usage(),
                 thread_id, channel,
             )
+            logger.info("handle_rc_command complete: result=missing_repo_key")
             return
 
         repo_key = tokens[2]
@@ -1021,11 +1138,13 @@ class MessageRouter:
             result = await self._remote_control_launcher.launch(repo_key)
         except RemoteControlURLTimeoutError as e:
             await self._messaging.send_message(f"⌛ {e}", thread_id, channel)
+            logger.info("handle_rc_command complete: result=url_timeout, repo_key=%s", repo_key)
             return
         except RemoteControlError as e:
             # 既知エラー（未登録 key / claude 未インストール / プロセス即時終了 等）は
             # サービス層が日本語メッセージを組み立て済みのため、そのまま転送する
             await self._messaging.send_message(f"❌ {e}", thread_id, channel)
+            logger.info("handle_rc_command complete: result=known_error, repo_key=%s", repo_key)
             return
         except Exception:
             logger.exception("Failed to launch remote control: repo_key=%s", repo_key)
@@ -1033,6 +1152,7 @@ class MessageRouter:
                 "❌ Remote Control の起動中に予期せぬエラーが発生しました。",
                 thread_id, channel,
             )
+            logger.info("handle_rc_command complete: result=unexpected_error, repo_key=%s", repo_key)
             return
 
         response = (
@@ -1042,6 +1162,10 @@ class MessageRouter:
             f"接続: {result.connect_url}"
         )
         await self._messaging.send_message(response, thread_id, channel)
+        logger.info(
+            "handle_rc_command complete: result=success, repo_key=%s, session=%s",
+            repo_key, result.session_name,
+        )
 
     def _build_rc_usage(self) -> str:
         """rc コマンドの使用方法と登録済み repo-key を返す."""

--- a/src/scheduler/jobs.py
+++ b/src/scheduler/jobs.py
@@ -286,12 +286,15 @@ async def daily_collect_and_deliver(
     Returns:
         (配信フィード数, 配信記事数) のタプル。
     """
-    logger.info("Starting daily feed collection and delivery")
+    logger.info(
+        "daily_collect_and_deliver start: channel=%s, max_articles_per_feed=%s, layout=%s, skip_summary=%s",
+        channel_id, max_articles_per_feed, layout, skip_summary,
+    )
 
     try:
         feeds_list = await collector.get_enabled_feeds()
         if not feeds_list:
-            logger.info("No enabled feeds")
+            logger.info("daily_collect_and_deliver complete: result=no_enabled_feeds")
             return (0, 0)
 
         # skip-summary時はmax_articles_per_feedを無制限にする（全件収集・配信）
@@ -391,10 +394,14 @@ async def daily_collect_and_deliver(
         if header_posted:
             await _post_footer(slack_client, channel_id)
 
-        logger.info("Delivered %d articles to %s", len(total_delivered), channel_id)
+        logger.info(
+            "daily_collect_and_deliver complete: feeds=%d, articles=%d, channel=%s",
+            delivered_feed_count, len(total_delivered), channel_id,
+        )
         return (delivered_feed_count, len(total_delivered))
     except Exception:
         logger.exception("Error in daily_collect_and_deliver job")
+        logger.info("daily_collect_and_deliver complete: result=error")
         return (0, 0)
 
 
@@ -411,6 +418,10 @@ async def feed_test_deliver(
     本番と同じ _deliver_feed_to_slack を使用し、収集ステップのみスキップする。
     仕様: docs/specs/features/feed-management.md
     """
+    logger.info(
+        "feed_test_deliver start: channel=%s, max_feeds=%d, max_articles_per_feed=%d, layout=%s",
+        channel_id, max_feeds, max_articles_per_feed, layout,
+    )
     async with session_factory() as session:
         feed_result = await session.execute(
             select(Feed)
@@ -421,7 +432,7 @@ async def feed_test_deliver(
         test_feeds = list(feed_result.scalars().all())
 
     if not test_feeds:
-        logger.info("No enabled feeds for test delivery")
+        logger.info("feed_test_deliver complete: result=no_enabled_feeds")
         return
 
     # テストヘッダー（本番同等 +（テスト））
@@ -453,4 +464,4 @@ async def feed_test_deliver(
     await _post_footer(slack_client, channel_id)
 
     # delivered フラグは更新しない（テストなので副作用なし）
-    logger.info("Test delivery completed for %d feeds", feeds_delivered)
+    logger.info("feed_test_deliver complete: feeds=%d", feeds_delivered)

--- a/src/services/feed_collector.py
+++ b/src/services/feed_collector.py
@@ -62,21 +62,22 @@ class FeedCollector:
         Args:
             skip_summary: Trueの場合、LLM要約をスキップしdescriptionを要約として保存する。
         """
+        logger.info("collect_all start: skip_summary=%s", skip_summary)
         collected: list[Article] = []
         async with self._session_factory() as session:
             feeds = await self._get_enabled_feeds(session)
 
-        logger.info("collect_all: %d feeds to process (skip_summary=%s)", len(feeds), skip_summary)
+        logger.info("collect_all progress: feeds=%d, skip_summary=%s", len(feeds), skip_summary)
         for i, feed in enumerate(feeds, 1):
             try:
-                logger.info("collect_all: [%d/%d] %s", i, len(feeds), feed.name)
+                logger.info("collect_all progress: index=%d/%d, feed=%s", i, len(feeds), feed.name)
                 articles = await self._collect_feed(feed, skip_summary=skip_summary)
                 collected.extend(articles)
             except Exception:
                 logger.exception("Failed to collect feed: %s (%s)", feed.name, feed.url)
                 continue
 
-        logger.info("collect_all: done — %d articles collected", len(collected))
+        logger.info("collect_all complete: feeds=%d, articles=%d", len(feeds), len(collected))
         return collected
 
     async def get_enabled_feeds(self) -> list[Feed]:
@@ -118,7 +119,13 @@ class FeedCollector:
                 True を返すと収集続行、False を返すと収集を中止する。
             skip_summary: Trueの場合、LLM要約をスキップしdescriptionを要約として保存する。
         """
+        logger.info("collect_feed start: feed=%s, url=%s, skip_summary=%s", feed.name, feed.url, skip_summary)
+        logger.debug("feedparser.parse start: url=%s", feed.url)
         parsed = await asyncio.to_thread(feedparser.parse, feed.url)
+        logger.debug(
+            "feedparser.parse complete: url=%s, entries=%d",
+            feed.url, len(parsed.entries),
+        )
         articles: list[Article] = []
         cutoff = datetime.now(tz=timezone.utc) - timedelta(days=self._collect_days)
 
@@ -206,6 +213,10 @@ class FeedCollector:
             await session.commit()
             articles.extend(new_articles)
 
+        logger.info(
+            "collect_feed complete: feed=%s, entries=%d, new_articles=%d",
+            feed.name, len(parsed.entries), len(articles),
+        )
         return articles
 
     async def fetch_feed_title(self, url: str) -> str:
@@ -217,13 +228,22 @@ class FeedCollector:
         Returns:
             フィード名。取得できない場合はURLをそのまま返す。
         """
+        logger.info("fetch_feed_title start: url=%s", url)
         try:
+            logger.debug("feedparser.parse start: url=%s", url)
             parsed = await asyncio.to_thread(feedparser.parse, url)
+            logger.debug(
+                "feedparser.parse complete: url=%s, entries=%d",
+                url, len(parsed.entries),
+            )
             title = str(parsed.feed.get("title", ""))
             if title:
-                return title.strip()
+                stripped = title.strip()
+                logger.info("fetch_feed_title complete: url=%s, title=%r", url, stripped)
+                return stripped
         except Exception:
             logger.warning("Failed to fetch feed title from %s", url)
+        logger.info("fetch_feed_title complete: url=%s, result=error_fallback_to_url", url)
         return url
 
     async def add_feed(self, url: str, name: str, category: str = "一般") -> Feed:
@@ -240,17 +260,24 @@ class FeedCollector:
         Raises:
             ValueError: URLが既に登録されている場合
         """
+        logger.info("add_feed start: url=%s, name=%r, category=%s", url, name, category)
         async with self._session_factory() as session:
             # 重複チェック
+            logger.debug("db select start: Feed where url=%s", url)
             result = await session.execute(select(Feed).where(Feed.url == url))
             existing = result.scalar_one_or_none()
+            logger.debug("db select complete: existing=%s", existing is not None)
             if existing:
+                logger.info("add_feed complete: result=duplicate, url=%s", url)
                 raise ValueError("既に登録されています")
 
             feed = Feed(url=url, name=name, category=category, enabled=True)
             session.add(feed)
+            logger.debug("db commit start: insert Feed url=%s", url)
             await session.commit()
             await session.refresh(feed)
+            logger.debug("db commit complete: id=%d", feed.id)
+            logger.info("add_feed complete: url=%s, id=%d", url, feed.id)
             return feed
 
     async def delete_feed(self, url: str) -> None:
@@ -262,14 +289,17 @@ class FeedCollector:
         Raises:
             ValueError: URLが見つからない場合
         """
+        logger.info("delete_feed start: url=%s", url)
         async with self._session_factory() as session:
             result = await session.execute(select(Feed).where(Feed.url == url))
             feed = result.scalar_one_or_none()
             if not feed:
+                logger.info("delete_feed complete: result=not_found, url=%s", url)
                 raise ValueError("登録されていません")
 
             await session.delete(feed)
             await session.commit()
+            logger.info("delete_feed complete: url=%s", url)
 
     async def enable_feed(self, url: str) -> None:
         """フィードを有効化する.
@@ -280,14 +310,17 @@ class FeedCollector:
         Raises:
             ValueError: URLが見つからない場合
         """
+        logger.info("enable_feed start: url=%s", url)
         async with self._session_factory() as session:
             result = await session.execute(select(Feed).where(Feed.url == url))
             feed = result.scalar_one_or_none()
             if not feed:
+                logger.info("enable_feed complete: result=not_found, url=%s", url)
                 raise ValueError("登録されていません")
 
             feed.enabled = True
             await session.commit()
+            logger.info("enable_feed complete: url=%s", url)
 
     async def disable_feed(self, url: str) -> None:
         """フィードを無効化する.
@@ -298,14 +331,17 @@ class FeedCollector:
         Raises:
             ValueError: URLが見つからない場合
         """
+        logger.info("disable_feed start: url=%s", url)
         async with self._session_factory() as session:
             result = await session.execute(select(Feed).where(Feed.url == url))
             feed = result.scalar_one_or_none()
             if not feed:
+                logger.info("disable_feed complete: result=not_found, url=%s", url)
                 raise ValueError("登録されていません")
 
             feed.enabled = False
             await session.commit()
+            logger.info("disable_feed complete: url=%s", url)
 
     async def list_feeds(self) -> tuple[list[Feed], list[Feed]]:
         """全フィードを有効/無効で分類して取得する.
@@ -313,12 +349,17 @@ class FeedCollector:
         Returns:
             (有効フィードリスト, 無効フィードリスト) のタプル
         """
+        logger.info("list_feeds start")
         async with self._session_factory() as session:
             result = await session.execute(select(Feed).order_by(Feed.url.asc()))
             all_feeds = list(result.scalars().all())
 
         enabled = [f for f in all_feeds if f.enabled]
         disabled = [f for f in all_feeds if not f.enabled]
+        logger.info(
+            "list_feeds complete: enabled=%d, disabled=%d",
+            len(enabled), len(disabled),
+        )
         return (enabled, disabled)
 
     async def delete_all_feeds(self) -> int:
@@ -327,6 +368,7 @@ class FeedCollector:
         Returns:
             削除されたフィード数
         """
+        logger.info("delete_all_feeds start")
         async with self._session_factory() as session:
             result = await session.execute(select(Feed))
             feeds = list(result.scalars().all())
@@ -334,6 +376,7 @@ class FeedCollector:
             for feed in feeds:
                 await session.delete(feed)
             await session.commit()
+            logger.info("delete_all_feeds complete: count=%d", count)
             return count
 
     async def get_all_feeds(self) -> list[Feed]:
@@ -342,6 +385,9 @@ class FeedCollector:
         Returns:
             全Feedオブジェクトのリスト
         """
+        logger.info("get_all_feeds start")
         async with self._session_factory() as session:
             result = await session.execute(select(Feed).order_by(Feed.url.asc()))
-            return list(result.scalars().all())
+            feeds = list(result.scalars().all())
+        logger.info("get_all_feeds complete: count=%d", len(feeds))
+        return feeds

--- a/src/services/feed_collector.py
+++ b/src/services/feed_collector.py
@@ -229,6 +229,7 @@ class FeedCollector:
             フィード名。取得できない場合はURLをそのまま返す。
         """
         logger.info("fetch_feed_title start: url=%s", url)
+        fallback_reason = "no_title"
         try:
             logger.debug("feedparser.parse start: url=%s", url)
             parsed = await asyncio.to_thread(feedparser.parse, url)
@@ -243,7 +244,11 @@ class FeedCollector:
                 return stripped
         except Exception:
             logger.warning("Failed to fetch feed title from %s", url)
-        logger.info("fetch_feed_title complete: url=%s, result=error_fallback_to_url", url)
+            fallback_reason = "error"
+        logger.info(
+            "fetch_feed_title complete: url=%s, result=%s_fallback_to_url",
+            url, fallback_reason,
+        )
         return url
 
     async def add_feed(self, url: str, name: str, category: str = "一般") -> Feed:

--- a/src/services/ogp_extractor.py
+++ b/src/services/ogp_extractor.py
@@ -47,18 +47,25 @@ class OgpExtractor:
         2. なければ記事URLにGETしてog:imageを抽出
         3. 失敗時はNone
         """
+        logger.info("extract_image_url start: url=%s", url)
         # 1. RSSエントリから取得を試みる
         if entry:
             image = self._extract_from_entry(entry)
             if image:
+                logger.info("extract_image_url complete: url=%s, source=entry", url)
                 return unescape(image)
 
         # 2. 記事URLからOGPタグを取得
         try:
             result = await self._fetch_og_image(url)
+            if result:
+                logger.info("extract_image_url complete: url=%s, source=og:image", url)
+            else:
+                logger.info("extract_image_url complete: url=%s, source=none", url)
             return unescape(result) if result else None
         except Exception:
             logger.debug("Failed to fetch OGP image for %s", url, exc_info=True)
+            logger.info("extract_image_url complete: url=%s, source=error", url)
             return None
 
     def _extract_from_entry(self, entry: dict[str, Any]) -> str | None:
@@ -101,8 +108,10 @@ class OgpExtractor:
 
     async def _fetch_og_image(self, url: str) -> str | None:
         """記事URLにアクセスしてog:imageメタタグを抽出する."""
+        logger.debug("ogp http GET start: url=%s", url)
         async with ConstrainedClient(request_timeout=self._timeout) as client:
             resp = await client.get(url)
+            logger.debug("ogp http GET complete: url=%s, status=%d", url, resp.status_code)
             if resp.status_code in (301, 302, 303, 307, 308):
                 logger.warning(
                     "Redirect detected (SSRF protection): %s -> %s",

--- a/src/services/remote_control.py
+++ b/src/services/remote_control.py
@@ -89,6 +89,7 @@ class RemoteControlLauncher:
 
     async def launch(self, repo_key: str) -> RemoteControlLaunchResult:
         """指定 repo-key で claude remote-control を起動し、接続 URL を返す."""
+        logger.info("remote_control launch start: repo_key=%s", repo_key)
         if repo_key not in self._repositories:
             registered = ", ".join(sorted(self._repositories.keys())) or "(なし)"
             msg = f"未登録のリポジトリキーです: {repo_key}\n登録済み: {registered}"
@@ -150,7 +151,7 @@ class RemoteControlLauncher:
                     pass
 
         logger.info(
-            "remote-control launched: pid=%s, repo_key=%s, session=%s, log=%s",
+            "remote_control subprocess complete: pid=%s, repo_key=%s, session=%s, log=%s",
             proc.pid, repo_key, session_name, log_path,
         )
 
@@ -161,6 +162,10 @@ class RemoteControlLauncher:
         wait_task = asyncio.create_task(proc.wait())
         wait_task.add_done_callback(
             lambda _t: self._active_pids.discard(proc.pid),
+        )
+        logger.info(
+            "remote_control launch complete: repo_key=%s, session=%s, pid=%s",
+            repo_key, session_name, proc.pid,
         )
         return RemoteControlLaunchResult(
             session_name=session_name,

--- a/src/services/summarizer.py
+++ b/src/services/summarizer.py
@@ -57,12 +57,15 @@ class Summarizer:
             description: 記事の概要。空文字の場合は「なし」として扱う。
             lang: ログ記録用の言語識別子（デフォルト: ""）。
         """
+        logger.info("summarize start: url=%s, lang=%s, desc_len=%d", url, lang, len(description))
         prompt = SUMMARIZE_PROMPT.format(title=title, url=url, description=description or "なし")
         try:
+            logger.debug("llm.complete start: url=%s", url)
             response = await self._llm.complete(
                 [Message(role="user", content=prompt)],
                 reasoning_effort=self._reasoning_effort,
             )
+            logger.debug("llm.complete complete: url=%s", url)
             content = response.content.strip()
             if not content:
                 logger.warning(
@@ -70,10 +73,13 @@ class Summarizer:
                     url,
                     lang,
                 )
+                logger.info("summarize complete: url=%s, result=empty_fallback_to_title", url)
                 return title
+            logger.info("summarize complete: url=%s, summary_len=%d", url, len(content))
             return content
         except Exception:
             logger.exception(
                 "Failed to summarize article: url=%s, lang=%s", url, lang
             )
+            logger.info("summarize complete: url=%s, result=error_fallback_to_title", url)
             return title

--- a/src/services/thread_history.py
+++ b/src/services/thread_history.py
@@ -74,22 +74,39 @@ class ThreadHistoryService:
         Returns:
             Message のリスト。取得失敗時は None（呼び出し元でフォールバック判定）。
         """
+        logger.info(
+            "fetch_thread_messages start: channel=%s, thread_ts=%s",
+            channel, thread_ts,
+        )
         try:
+            logger.debug("slack conversations_replies start: channel=%s, thread_ts=%s", channel, thread_ts)
             result = await self._client.conversations_replies(
                 channel=channel,
                 ts=thread_ts,
                 limit=self._limit,
             )
             raw_messages: list[dict[str, Any]] = result.get("messages", [])
+            logger.debug(
+                "slack conversations_replies complete: channel=%s, thread_ts=%s, raw_count=%d",
+                channel, thread_ts, len(raw_messages),
+            )
         except Exception:
             logger.exception(
                 "Failed to fetch thread replies: channel=%s, thread_ts=%s",
                 channel,
                 thread_ts,
             )
+            logger.info(
+                "fetch_thread_messages complete: channel=%s, thread_ts=%s, result=error",
+                channel, thread_ts,
+            )
             return None
 
         if not raw_messages:
+            logger.info(
+                "fetch_thread_messages complete: channel=%s, thread_ts=%s, count=0",
+                channel, thread_ts,
+            )
             return []
 
         # 今回のトリガーメッセージを除外（ChatService 側で追加されるため）
@@ -131,4 +148,8 @@ class ThreadHistoryService:
 
             messages.append(Message(role=role, content=content))
 
+        logger.info(
+            "fetch_thread_messages complete: channel=%s, thread_ts=%s, count=%d",
+            channel, thread_ts, len(messages),
+        )
         return messages


### PR DESCRIPTION
## Change type

- [x] ★ feat: 新機能実装
- [x] docs: ドキュメント更新

## Summary

- 全 Slack ハンドラ（`router.py` の `_handle_*`）の入口・完了に INFO レベルの start/complete ログを追加
- 主要サービス（`feed_collector` / `summarizer` / `ogp_extractor` / `thread_history` / `remote_control` / `scheduler/jobs`）の公開メソッドに INFO レベルの start/complete ログを追加
- 外部呼び出し（`feedparser.parse` / `httpx GET` / `call_claude` / MCP `call_tool` / DB の主要ポイント）の前後に DEBUG レベルログを追加
- ログメッセージは `<処理名> start: <文脈>` / `<処理名> complete: <結果>` 形式で統一
- 観測性ガイドラインを `docs/specs/infrastructure/logging.md` として新設、`overview.md` / `README.md` にリンク追加
- `feed add` 1 分問題の調査時にログ不足で原因特定が困難だった事象を、以後はタイムスタンプ差分で各処理段階の所要時間を追跡できる状態にする

## Test plan

- [x] `uv run pytest`（393 passed）
- [x] `uv run ruff check .`（All checks passed）
- [x] `uv run mypy src`（Success: no issues found in 37 source files）
- [x] `npx markdownlint-cli2`（24 files, 0 errors）
- [x] mermaid 構文 / GitHub 互換チェック
- [x] CLI ワンショット (`uv run python -m src.cli --message "feed add ..."`) で `handle_feed_command start/complete` `handle_feed_add start/complete` `fetch_feed_title start/complete` `add_feed start/complete` 等の階層ログを確認
- [x] worktree で bot を起動し Slack 経由 `feed add` 投稿、本番ログに INFO レベルでタイミングログが記録されることを手動確認（10:51:27→10:51:28、各ステップの所要時間がタイムスタンプ差分で算出可能）

## Related issues

Closes #835