### PR TITLE
fix(config-management): .env.example の空欄キーに汎用ダミー値を設定 (#837)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,7 @@
 
 # Slack
 SLACK_NEWS_CHANNEL_ID=C0123456789
-SLACK_AUTO_REPLY_CHANNELS=
+SLACK_AUTO_REPLY_CHANNELS=C1111111111,C2222222222
 
 # LM Studio 接続
 LMSTUDIO_BASE_URL=http://localhost:1234
@@ -16,7 +16,7 @@ LMSTUDIO_BASE_URL=http://localhost:1234
 DATABASE_URL=sqlite+aiosqlite:///./ai_assistant.db
 
 # Environment Name (optional, displayed in @bot status)
-ENV_NAME=
+ENV_NAME=Local
 
 # MCP (Model Context Protocol)
 MCP_ENABLED=false
@@ -26,7 +26,7 @@ MCP_RAG_URL=http://127.0.0.1:8081/mcp
 # Logging
 LOG_LEVEL=INFO
 DEBUG_LOG_ENABLED=false
-LOG_DIR=
+LOG_DIR=C:/path/to/logs
 
 # RAG 定期更新アカウント（rag update コマンドで使用）
 RAG_BLUESKY_HANDLE=user.bsky.social
@@ -39,9 +39,9 @@ SUMMARIZER_LLM_PROVIDER=local
 
 # Remote Control 起動（rc start コマンド）
 # 認可ユーザー: Slack user_id をカンマ区切り。空の場合は本機能は無効
-REMOTE_CONTROL_ALLOWED_USERS=
+REMOTE_CONTROL_ALLOWED_USERS=U0123456789,U9876543210
 # 起動可能リポジトリ: <key>=<絶対パス> をカンマ区切り
-# 例: REMOTE_CONTROL_REPOSITORIES=ai-assistant=/path/to/ai-assistant,agent-commons=/path/to/agent-commons
-REMOTE_CONTROL_REPOSITORIES=
+# 例: REMOTE_CONTROL_REPOSITORIES=ai-assistant=C:/path/to/ai-assistant,agent-commons=C:/path/to/agent-commons
+REMOTE_CONTROL_REPOSITORIES=ai-assistant=C:/path/to/ai-assistant,agent-commons=C:/path/to/agent-commons
 # 起動ログ出力先（未指定時は .tmp/remote-control/）
-REMOTE_CONTROL_LOG_DIR=
+REMOTE_CONTROL_LOG_DIR=C:/path/to/remote-control-logs

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 from pathlib import Path
 from unittest.mock import patch
 
@@ -51,9 +52,19 @@ def test_settings_no_defaults_for_toml_fields() -> None:
             )
 
 
-def test_get_settings_loads_from_env_and_toml() -> None:
+def test_get_settings_loads_from_env_and_toml(monkeypatch: pytest.MonkeyPatch) -> None:
     """get_settings() が .env と config.toml から統合して読み込める."""
     from src.config.settings import get_settings
+
+    # .env.example は主要動作環境 (Windows) 形式の絶対パス (C:/...) を持つ。
+    # Linux/macOS では Path("C:/...").is_absolute() が False を返し
+    # _validate_remote_control_repositories の絶対パス判定で弾かれるため、
+    # POSIX 互換の絶対パスにオーバーライドする。
+    if sys.platform != "win32":
+        monkeypatch.setenv(
+            "REMOTE_CONTROL_REPOSITORIES",
+            "ai-assistant=/path/to/ai-assistant,agent-commons=/path/to/agent-commons",
+        )
 
     # .env の代わりに git 管理されている .env.example を使用
     get_settings.cache_clear()
@@ -65,6 +76,32 @@ def test_get_settings_loads_from_env_and_toml() -> None:
     assert settings.online_llm_provider in ("openai", "anthropic")
     # config.toml から
     assert settings.openai_model
+
+
+def test_env_example_has_no_empty_values() -> None:
+    """`.env.example` の全 KEY=value 行で value が非空であること.
+
+    Issue #837: `.env.example` は新規セットアップ時のテンプレートとして
+    各キーで「何を入れるか」「どんなフォーマットか」を読み取れる必要がある。
+    将来キー追加時に空欄プレースホルダーが混入することを防ぐためのガードレール。
+    """
+    env_example_path = Path(".env.example")
+    assert env_example_path.is_file(), ".env.example が見つかりません"
+
+    empty_keys = []
+    for raw in env_example_path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        if not value.strip():
+            empty_keys.append(key.strip())
+
+    assert not empty_keys, (
+        f".env.example の以下のキーが空欄です（フォーマット例の汎用ダミー値を設定してください）: {empty_keys}"
+    )
 
 
 def test_toml_config_loads() -> None:

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import sys
 from collections.abc import AsyncGenerator
 
 import pytest
@@ -66,6 +67,15 @@ async def test_init_db_and_get_session(monkeypatch: pytest.MonkeyPatch) -> None:
     """init_db/get_session 経由でテーブル作成とセッション取得ができる."""
     # .env.example をベースに読み込み、DATABASE_URL のみテスト用にオーバーライド
     monkeypatch.setenv("DATABASE_URL", "sqlite+aiosqlite:///:memory:")
+    # .env.example は主要動作環境 (Windows) 形式の絶対パス (C:/...) を持つ。
+    # Linux/macOS では Path("C:/...").is_absolute() が False を返し
+    # _validate_remote_control_repositories の絶対パス判定で弾かれるため、
+    # POSIX 互換の絶対パスにオーバーライドする。
+    if sys.platform != "win32":
+        monkeypatch.setenv(
+            "REMOTE_CONTROL_REPOSITORIES",
+            "ai-assistant=/path/to/ai-assistant,agent-commons=/path/to/agent-commons",
+        )
     monkeypatch.setattr(
         _EnvLoader, "model_config",
         {**_EnvLoader.model_config, "env_file": ".env.example"},


### PR DESCRIPTION
## Change type

- [x] fix: バグ修正 ★

## Summary

- `.env.example` の値が空欄だった 6 キーに汎用ダミー値を設定し、新規セットアップ時にフォーマットが読み取れるようにする
  - `SLACK_AUTO_REPLY_CHANNELS=C1111111111,C2222222222`（既存 `SLACK_NEWS_CHANNEL_ID` と区別がつくダミー）
  - `ENV_NAME=Local`
  - `LOG_DIR=C:/path/to/logs`
  - `REMOTE_CONTROL_ALLOWED_USERS=U0123456789,U9876543210`
  - `REMOTE_CONTROL_REPOSITORIES=ai-assistant=C:/path/to/ai-assistant,agent-commons=C:/path/to/agent-commons`
  - `REMOTE_CONTROL_LOG_DIR=C:/path/to/remote-control-logs`
- パス系は Windows 形式（`C:/path/to/...`）を採用。`Path("/path/to/x").is_absolute()` が Windows で False を返し、`_validate_remote_control_repositories` の絶対パス判定で起動失敗するため
- 既存の `REMOTE_CONTROL_REPOSITORIES` 例コメント（line 44）も値と整合するよう Windows 形式に追従
- 既存環境の実値（実チャンネル ID・実ユーザー ID・LAN 内 IP 等）はコピーせず、すべて汎用プレースホルダーで構成

## Test plan

- [x] 既存の品質チェック（pytest 19 passed / ruff / mypy）に回帰がないことを確認
- [x] code-reviewer 指摘 2 件を triage で対応済み（Win 形式採用 / SLACK_AUTO_REPLY_CHANNELS の重複 ID 解消）
- [x] 計画ファイル（aidlc-archive/837/plan-work/issue-837.md）の完了基準すべて満たすことを確認

## Related issues

Closes #837