### PR TITLE
feat(remote-control-launch): Slack 起動を bypassPermissions 化＋REMOTE_SLACK_SESSION マーカーを子プロセスに注入 (#839)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,6 +42,6 @@ SUMMARIZER_LLM_PROVIDER=local
 REMOTE_CONTROL_ALLOWED_USERS=U0123456789,U9876543210
 # 起動可能リポジトリ: <key>=<絶対パス> をカンマ区切り
 # 例: REMOTE_CONTROL_REPOSITORIES=ai-assistant=C:/path/to/ai-assistant,agent-commons=C:/path/to/agent-commons
-REMOTE_CONTROL_REPOSITORIES=ai-assistant=C:/path/to/ai-assistant,agent-commons=C:/path/to/agent-commons
+REMOTE_CONTROL_REPOSITORIES=ai-assistant=C:/path/to/ai-assistant,agent-commons=C:/path/to/agent-commons,rag-knowledge=C:/path/to/rag-knowledge,shared-workflows=C:/path/to/shared-workflows,py-common-lib=C:/path/to/py-common-lib,becky3.github.io=C:/path/to/becky3.github.io,article-writer=C:/path/to/article-writer,unity-mcp-lab=C:/path/to/unity-mcp-lab,my-life=C:/path/to/my-life
 # 起動ログ出力先（未指定時は .tmp/remote-control/）
 REMOTE_CONTROL_LOG_DIR=C:/path/to/remote-control-logs

--- a/docs/specs/features/remote-control-launch.md
+++ b/docs/specs/features/remote-control-launch.md
@@ -15,6 +15,8 @@ Slack コマンドにより、ホスト PC 上で `claude remote-control` プロ
 
 - **二重 allowlist 方式**: 認可ユーザー allowlist と repo-key allowlist の両方を通過した場合のみ起動可能。任意のパス・任意のユーザーでの起動は拒否する。Slack 経由で任意プロセスを起動可能になることを防ぐため
 - **起動コマンドはリスト引数で渡す**: `subprocess` の `shell=False` でリスト引数を渡し、コマンドインジェクションを防止する
+- **`bypassPermissions` モードで起動する**: Slack 経由で起動したセッションは Yes/No 系の権限確認に応答する動線がないため、`--permission-mode bypassPermissions` を固定で付与する。二重 allowlist 方式が前提として機能することで本モードが正当な利用に限定される
+- **子プロセス環境に `REMOTE_SLACK_SESSION=1` を注入する**: 起動した Claude セッション側がリモート環境を検出し、確認動線を切替えるためのマーカー（bot プロセスの環境変数を継承した上で追加）。検出後の振る舞い差替えルールは agent-commons 側（becky3/agent-commons#358）で管理する
 - **`claude` CLI v2.1.51+ を運用前提とする**: Remote Control 機能はこのバージョン以降で利用可能。本機能の実装は `claude` 実行ファイルの **存在確認のみ**を行い、版数検証は運用で担保する（ホスト PC の `claude` インストール時に版数を満たすこと）。未インストール時は PATH エラーを返す。版数不一致時の検出は本機能のスコープ外
 - **ホスト OS 前提**: Windows 11（本プロジェクトの主要運用環境）。subprocess のデタッチ起動方式は OS ごとに分岐する
 - **claude にログイン済みであること**: ホスト PC で `claude auth` 等によるログインが完了していない場合、起動した remote-control プロセスは接続できない。ログイン状態は本機能の前提条件として運用で担保する
@@ -43,7 +45,7 @@ Slack コマンドにより、ホスト PC 上で `claude remote-control` プロ
 2. repo allowlist に `<repo-key>` が含まれるか検証する。含まれない場合は登録済み key 一覧を含むエラーを返して終了する
 3. allowlist の対応パスが実在ディレクトリであることを検証する。存在しない場合は構成エラーを返して終了する
 4. `claude` 実行ファイルが PATH 上で解決できることを検証する。解決できない場合は前提エラーを返して終了する
-5. `<repo-key>` を含むセッション名（例: `slack-<repo-key>-<unix-timestamp>`）を組み立て、`claude remote-control --name <session_name>` をデタッチ起動する。標準出力・標準エラーは起動ログファイル（`<log_dir>/<session_name>.log`）に書き出す
+5. セッション名（例: `slack-<repo-key>-<unix-timestamp>`）を組み立て、上記制約に従って `claude remote-control` をデタッチ起動する。stdout/stderr は `<log_dir>/<session_name>.log` に書き出す
 6. ログファイルを最大 15 秒間ポーリングし、`https://claude.ai/code?environment=env_...` 形式の URL を抽出する。タイムアウト時はタイムアウトエラーを返す
 7. 抽出した URL を Slack に返信する
 

--- a/src/services/remote_control.py
+++ b/src/services/remote_control.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import re
 import shutil
 import subprocess
@@ -114,6 +115,16 @@ class RemoteControlLauncher:
 
         # log_file の Python 側バッファリング指定は子プロセスの書き込みには無関係
         # （fd 経由で直接 OS に書き込まれるため）。テキストモードは UTF-8 受け取りの意図表明のみ
+        # Slack 経由のリモートセッションでは「ドキュメント確認依頼時の自動オープン」
+        # （~/.claude/rules/invariants.md）が機能しないため、Claude 側が確認動線を
+        # 切替えるためのマーカーを bot 環境継承時に追加する。同名キーがあれば本値で確定する
+        child_env = {**os.environ, "REMOTE_SLACK_SESSION": "1"}
+        # bypassPermissions: Slack 起動のセッションは Yes/No 確認に応答できないため許可確認を回避する
+        launch_args: tuple[str, ...] = (
+            claude_bin, "remote-control",
+            "--name", session_name,
+            "--permission-mode", "bypassPermissions",
+        )
         log_file = log_path.open("w", encoding="utf-8")
         launch_failed = False
         try:
@@ -122,19 +133,21 @@ class RemoteControlLauncher:
                     subprocess, "CREATE_NEW_PROCESS_GROUP", 0,
                 ) | getattr(subprocess, "DETACHED_PROCESS", 0)
                 proc = await asyncio.create_subprocess_exec(
-                    claude_bin, "remote-control", "--name", session_name,
+                    *launch_args,
                     cwd=str(repo_path),
                     stdout=log_file.fileno(),
                     stderr=subprocess.STDOUT,
                     creationflags=creationflags,
+                    env=child_env,
                 )
             else:
                 proc = await asyncio.create_subprocess_exec(
-                    claude_bin, "remote-control", "--name", session_name,
+                    *launch_args,
                     cwd=str(repo_path),
                     stdout=log_file.fileno(),
                     stderr=subprocess.STDOUT,
                     start_new_session=True,
+                    env=child_env,
                 )
         except Exception:
             launch_failed = True

--- a/tests/test_remote_control.py
+++ b/tests/test_remote_control.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -155,3 +155,52 @@ async def test_extract_url_handles_missing_log_file_initially(tmp_path: Path) ->
     await write_task
 
     assert url == "https://claude.ai/code?environment=env_01XYZ789"
+
+
+# --- 起動引数・環境変数の検証 (Issue #839) ---
+
+
+@pytest.mark.parametrize("platform", ["win32", "linux"])
+async def test_launch_passes_bypass_permissions_and_marker_env(
+    tmp_path: Path, platform: str,
+) -> None:
+    """Win/POSIX 両分岐で起動引数に --permission-mode bypassPermissions が含まれ、
+    子プロセス env に REMOTE_SLACK_SESSION=1 が注入され、親環境の PATH が継承される.
+    """
+    launcher = _make_launcher(
+        repositories={"foo": str(tmp_path)},
+        log_dir=tmp_path / "logs",
+    )
+
+    fake_proc = MagicMock()
+    fake_proc.pid = 12345
+    fake_proc.wait = AsyncMock(return_value=0)
+    fake_proc.returncode = None
+
+    with patch(
+        "src.services.remote_control.asyncio.create_subprocess_exec",
+        new=AsyncMock(return_value=fake_proc),
+    ) as mock_exec, patch(
+        "src.services.remote_control.shutil.which",
+        return_value="/usr/bin/claude",
+    ), patch(
+        "src.services.remote_control.sys.platform", platform,
+    ), patch.object(
+        launcher,
+        "_extract_url",
+        new=AsyncMock(return_value="https://claude.ai/code?environment=env_01TEST"),
+    ), patch.dict(
+        "src.services.remote_control.os.environ",
+        {"PATH": "/usr/bin"},
+        clear=False,
+    ):
+        await launcher.launch("foo")
+
+    args, kwargs = mock_exec.call_args
+    assert "--permission-mode" in args
+    perm_idx = args.index("--permission-mode")
+    assert args[perm_idx + 1] == "bypassPermissions"
+    assert "--name" in args  # 既存仕様: セッション名指定は維持
+    env = kwargs["env"]
+    assert env["REMOTE_SLACK_SESSION"] == "1"
+    assert env["PATH"] == "/usr/bin"  # 親環境の継承を確認


### PR DESCRIPTION
## Change type

- [x] feat: 新機能実装 ★

## Summary

- `claude remote-control` 起動コマンドに `--permission-mode bypassPermissions` を追加し、Slack 経由で起動したセッションが Yes/No 確認待ちで停止しないようにした
- 子プロセス環境に `REMOTE_SLACK_SESSION=1` を注入（`os.environ` 継承 + マーカー追加）。Claude 側がリモートセッション環境を検出できるマーカーとして機能（検出後の振る舞い差替えルールは becky3/agent-commons#358 で対応予定）
- 仕様書 `docs/specs/features/remote-control-launch.md` に上記 2 点を制約・振る舞い両セクションに追記
- `.env.example` の `REMOTE_CONTROL_REPOSITORIES` 例を 2 件から 9 件に拡張（よく作業するリポジトリを追加）
- 起動引数と env マーカーの含有を検証する単体テストを Win/POSIX 両分岐で追加（parametrize）

## Test plan

- [x] `uv run pytest`（396 passed）
- [x] `uv run ruff check .` clean
- [x] `uv run mypy src` clean
- [x] markdownlint clean
- [x] code-reviewer / doc-reviewer 実施＋指摘対応済み（/triage で要相談 3 件を確定）

## Related issues

Closes #839
Related: becky3/agent-commons#358