### PR TITLE
feat(article-publishing): Slack コマンド article write-hatena 実装 (#841)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,3 +45,8 @@ REMOTE_CONTROL_ALLOWED_USERS=U0123456789,U9876543210
 REMOTE_CONTROL_REPOSITORIES=ai-assistant=C:/path/to/ai-assistant,agent-commons=C:/path/to/agent-commons,rag-knowledge=C:/path/to/rag-knowledge,shared-workflows=C:/path/to/shared-workflows,py-common-lib=C:/path/to/py-common-lib,becky3.github.io=C:/path/to/becky3.github.io,article-writer=C:/path/to/article-writer,unity-mcp-lab=C:/path/to/unity-mcp-lab,my-life=C:/path/to/my-life
 # 起動ログ出力先（未指定時は .tmp/remote-control/）
 REMOTE_CONTROL_LOG_DIR=C:/path/to/remote-control-logs
+
+# 記事自動投稿（@bot article write-hatena コマンドで使用）
+# article-writer リポジトリの絶対パス。空または未設定の場合は本機能は無効
+# 認可ユーザーは REMOTE_CONTROL_ALLOWED_USERS を流用する
+ARTICLE_WRITER_REPO_PATH=C:/path/to/article-writer

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ RSS記事の自動収集・要約配信、チャットでの質問応答を行�
 | **Botプロセスガード** | PIDファイルによるプロセス管理で、多重起動の防止・グレースフルシャットダウン・子プロセスのクリーンアップを行う |
 | **Remote Control 起動** | Slack コマンド (`@bot rc start <repo-key>`) でホスト PC 上の指定リポジトリで `claude remote-control` を起動し、claude.ai/code 接続 URL を返す。外出先のスマホから PC 操作なしで Claude Code セッションを開始できる。許可ユーザーと対象リポジトリの allowlist 設定が必要 |
 | **ログ出力** | 全 handler・主要サービスにタイミングログを付与し、所要時間・実行段階の事後追跡を可能にする |
+| **記事自動投稿** | Slack コマンド (`@bot article write-hatena`) または Slack reminder からホスト PC 上の article-writer リポジトリで `/auto-publish-diary` スキルを起動し、Hatena への日記下書き登録・PR 作成・マージまでを無人実行。結果（下書き URL・PR URL）を Slack に通知する |
 
 全機能の一覧と仕様書リンクは [全体仕様概要](docs/specs/overview.md) を参照。
 
@@ -129,6 +130,7 @@ uv run mypy src
 - [Slack mrkdwn形式対応](docs/specs/features/slack-formatting.md)
 - [CLIアダプター](docs/specs/features/cli-adapter.md)
 - [Remote Control 起動](docs/specs/features/remote-control-launch.md)
+- [記事自動投稿](docs/specs/features/article-publishing.md)
 
 ### 基盤仕様（infrastructure）
 

--- a/config/config.toml
+++ b/config/config.toml
@@ -15,3 +15,4 @@ claude_allowed_tools = "mcp__rag-knowledge-production__*,WebSearch,WebFetch"
 claude_timeout = 120
 log_file_max_bytes = 10485760
 remote_control_url_timeout = 15
+article_publish_timeout = 1200

--- a/docs/specs/features/article-publishing.md
+++ b/docs/specs/features/article-publishing.md
@@ -1,0 +1,160 @@
+# 記事自動投稿（article-writer 連携）
+
+## 概要
+
+Slack コマンドにより、ホスト PC 上の article-writer リポジトリで `claude -p '/auto-publish-diary'` を起動し、日記記事の生成 → Hatena 下書き登録 → PR 作成 → 即マージ → worktree クリーンアップまでを無人実行する機能。
+実行結果（成功時の下書き URL・PR URL、失敗時の残置 worktree パス）を Slack に通知する。
+
+主用途は Slack reminder からの定時自動投稿。手動運用負荷を下げ、日記投稿の安定継続を実現する。
+
+## 背景
+
+- article-writer 側に `/auto-publish-diary` スキルが新設された（article-writer PR #70 / Issue #68）。記事生成 → Hatena 下書き登録 → PR 作成 → 即マージ → worktree クリーンアップを一括する無人実行ワンショットスキル
+- スキル本体は単独で動作するが、毎日定時に無人実行するには起動トリガーが必要
+- Slack reminder は標準機能でメッセージ定時投稿が可能。reminder からのトリガーを受け取り `claude -p` をホスト PC 上で起動する受信側が ai-assistant 側に未実装
+
+## 制約
+
+- **二重 allowlist 方式**: 認可ユーザー allowlist の通過とリポジトリパス設定の存在の両方を確認した上で起動する。任意ユーザーでの起動は拒否する。Slack 経由で任意プロセスを起動可能になることを防ぐため
+- **既存 Remote Control allowlist を共用**: 認可ユーザーは Remote Control 機能の `REMOTE_CONTROL_ALLOWED_USERS` を流用する。本機能と Remote Control 起動の許可ユーザーが運用上一致しており、env を増やさないため
+- **起動コマンドはリスト引数で渡す**: `subprocess` の `shell=False` でリスト引数を渡し、コマンドインジェクションを防止する
+- **スキル名はハードコード**: 起動対象のスキルは `/auto-publish-diary` 固定。外部入力（Slack コマンド本文）からスキル名を組み立てない
+- **`--dangerously-skip-permissions` モードで起動する**: `claude -p` は git ネットワーク操作（`git fetch` / `git pull` / `git push`）・`gh pr create` / `gh pr merge` の permission をデフォルトで拒否する。`/auto-publish-diary` はこれらを多用するため `--dangerously-skip-permissions` で全許可する。緩和策として (1) allowlist で実行ユーザー制限、(2) `cwd` を `ARTICLE_WRITER_REPO_PATH` 固定、(3) スキル名固定、(4) `Path.is_absolute()` 検証で相対パス指定を排除、の 4 段防御で対処する
+- **対象リポジトリのパスは絶対パスのみ許可**: `ARTICLE_WRITER_REPO_PATH` は絶対パスで指定する。意図しないディレクトリでの起動を防ぐため
+- **同時実行制御は提供しない**: 多重起動の防止は本機能のスコープ外。Slack reminder の運用では基本的に 1 日 1 回のみ起動される前提
+- **失敗時の worktree 残置の自動掃除は提供しない**: `/auto-publish-diary` は失敗時に worktree を残置する設計（state 保持のため）。残置 worktree の定期掃除は本機能のスコープ外で、運用上の手動掃除でカバーする
+- **トリガー（Slack reminder の登録）は本機能のスコープ外**: Slack 標準機能で reminder を登録する。コード変更なし
+- **対象スキルの SSoT は article-writer 側**: `/auto-publish-diary` の出力契約（最終行 JSON のフィールド構成・終了コード）は article-writer 側の仕様に従う。本機能は出力契約のうち本機能が依存するフィールドのみを参照する
+
+## 操作一覧
+
+| 操作 | トリガー | 概要 |
+|---|---|---|
+| Hatena への日記自動投稿 | `article write-hatena` キーワード | article-writer 側の `/auto-publish-diary` スキルを起動し、結果を Slack に通知する |
+
+- メンション付き・自動返信チャンネルの両方で動作する
+- Slack reminder からの定時投稿も同じトリガーキーワードで動作する（reminder プレフィックスは既存ルーターが除去する）
+
+## 各操作の仕様
+
+### Hatena への日記自動投稿
+
+**トリガー**: メッセージが `article write-hatena` の形式（先頭が `article`、サブコマンドが `write-hatena`）
+
+サブコマンド名は **大文字小文字を区別する**（既存の `feed` / `rag` / `rc` コマンドと同じく、小文字一致を必須とする）。
+
+**振る舞い**:
+
+1. 認可ユーザー allowlist（`REMOTE_CONTROL_ALLOWED_USERS`）にメッセージ送信者の Slack `user_id` が含まれるか検証する。含まれない場合は権限エラーを返して終了する
+2. `ARTICLE_WRITER_REPO_PATH` が設定されているか検証する。空または未設定の場合は機能無効メッセージを返して終了する
+3. 設定された絶対パスが実在ディレクトリであることを検証する。存在しない場合は構成エラーを返して終了する
+4. `claude` 実行ファイルが PATH 上で解決できることを検証する。解決できない場合は前提エラーを返して終了する
+5. Slack に「投稿処理を開始します」メッセージを返す（実行時間が長いため処理開始を明示する）
+6. `claude -p '/auto-publish-diary' --dangerously-skip-permissions --output-format text` を `cwd=ARTICLE_WRITER_REPO_PATH` で起動する。stdout / stderr を捕捉し、終了コードを取得する
+7. プロセスがタイムアウト時間内に終了しない場合は kill し、タイムアウトエラーを Slack に返す
+8. 終了コードが 0 の場合は stdout 最終行を JSON としてパースし、結果フィールド（`status` / `article_path` / `draft_url` / `pr_url` / `worktree_removed` / `worktree_path`）を Slack 通知に整形する
+9. 終了コードが非 0 または JSON パースに失敗した場合はエラーを Slack に返す。失敗時の JSON に `worktree_path` が含まれる場合は併せて通知する
+
+**出力**:
+
+成功時（`status="ok"`）:
+
+```
+✅ 日記の自動投稿に成功しました
+記事: articles/hatena/2026-02-10-diary.md
+下書き: https://example.hatenablog.com/entry/2026/05/20/152523
+PR: https://github.com/becky3/article-writer/pull/71
+```
+
+権限拒否時:
+
+```
+❌ このコマンドを実行する権限がありません
+```
+
+機能無効時（`ARTICLE_WRITER_REPO_PATH` 未設定）:
+
+```
+記事自動投稿機能は現在無効です。管理者に設定を依頼してください。
+```
+
+タイムアウト時:
+
+```
+⌛ 記事の自動投稿がタイムアウトしました（{N}分）。article-writer 側の worktree が残置されている可能性があります。
+```
+
+失敗時（終了コード非 0、JSON 解析成功）:
+
+```
+❌ 日記の自動投稿に失敗しました
+理由: {失敗 JSON の reason フィールド等}
+残置 worktree: {worktree_path}
+```
+
+JSON 解析失敗時:
+
+```
+❌ 日記の自動投稿に失敗しました（実行結果の解析に失敗）
+exit code: {終了コード}
+stdout 末尾: {直近の数行}
+```
+
+公開チャンネルでの実行を想定し、Slack 返信には絶対パス全文・シークレット値を含めない。`worktree_path` は article-writer リポジトリ内の相対パス前提で通知し、絶対パスの場合は最後のセグメントのみ表示する。詳細な絶対パスはサーバーログにのみ出力する。
+
+### サブコマンドの拡張余地
+
+`article write-zenn` 等の追加は別 Issue で扱う。本機能のスコープは `article write-hatena` のみ。
+
+## 設定
+
+設定値は3層分離方針（[`config-management.md`](../infrastructure/config-management.md)）に従う。
+
+| 項目名 | 層 | 設計意図 |
+|---|---|---|
+| `ARTICLE_WRITER_REPO_PATH` | 環境依存値 | article-writer リポジトリの絶対パス。空または未設定の場合は本機能は無効化される。絶対パス必須（意図しないディレクトリでの起動防止） |
+| `REMOTE_CONTROL_ALLOWED_USERS` | 環境依存値 | 本機能でも認可ユーザー allowlist として流用する（Remote Control 機能と共用）。詳細は [`remote-control-launch.md`](remote-control-launch.md) の同名項目を参照 |
+| `article_publish_timeout` | 共通設定値 | `claude -p` 起動のタイムアウト秒数。`/auto-publish-diary` の実機 QA 実測 ~13 分を踏まえて余裕を持たせる |
+
+具体値の制約は pydantic Field 定義（`src/config/settings.py`）が SSoT。仕様書では設計意図のみを記述する。
+
+## コンポーネント構成
+
+```mermaid
+graph LR
+    A[Slack reminder] --> B[Slack メッセージ]
+    B --> C[MessageRouter]
+    C -->|article キーワード判定| D[article コマンドハンドラ]
+    D --> E[認可検証]
+    D --> F[ArticleWriterPublisher]
+    F --> G[claude -p /auto-publish-diary]
+    G --> H[stdout 最終行 JSON]
+    H --> I[Slack 応答]
+    E --> I
+```
+
+| コンポーネント | 役割 |
+|---|---|
+| MessageRouter | `article` キーワードで本ハンドラへルーティング |
+| article コマンドハンドラ | サブコマンド `write-hatena` の引数解析・エラー応答整形 |
+| 認可検証 | `REMOTE_CONTROL_ALLOWED_USERS` allowlist チェック |
+| ArticleWriterPublisher | `claude -p '/auto-publish-diary'` の subprocess 起動・stdout 最終行 JSON パース・結果整形 |
+
+## エッジケース
+
+| ケース | 振る舞い |
+|---|---|
+| `ARTICLE_WRITER_REPO_PATH` が空または未設定 | 本機能は無効。「機能は現在無効です」とのメッセージを返す（fail-closed） |
+| `REMOTE_CONTROL_ALLOWED_USERS` が空 | 認可ユーザーがいない状態のため、全ユーザーからのコマンドが権限エラーで拒否される |
+| 同時実行（実行中にもう一度コマンドが送信される） | 本機能は多重起動を制御しない。subprocess が並列に起動される（article-writer 側で worktree 名が衝突する可能性あり、運用で回避する） |
+| `claude` プロセスが即時終了（exit code 非 0 + JSON 出力なし） | エラーメッセージに終了コードと stdout 末尾を含めて返す |
+| stdout 最終行が JSON でない | JSON 解析失敗エラーを返す。`worktree_path` は通知できないため、ユーザーはサーバーログを確認する |
+| タイムアウト | 子プロセスを kill し、タイムアウトエラーを返す。worktree が残置されている可能性を明示する |
+
+## 関連ドキュメント
+
+- [remote-control-launch](remote-control-launch.md): allowlist 共用元・既存 subprocess パターンの参考
+- [cli-adapter](cli-adapter.md): メッセージルーティング基盤
+- [auto-reply](auto-reply.md): 自動返信チャンネルでのコマンド動作
+- [config-management](../infrastructure/config-management.md): 設定の3層分離方針
+- article-writer リポジトリ `/auto-publish-diary` スキル（article-writer PR #70 / Issue #68）

--- a/docs/specs/features/article-publishing.md
+++ b/docs/specs/features/article-publishing.md
@@ -19,12 +19,22 @@ Slack コマンドにより、ホスト PC 上の article-writer リポジトリ
 - **既存 Remote Control allowlist を共用**: 認可ユーザーは Remote Control 機能の `REMOTE_CONTROL_ALLOWED_USERS` を流用する。本機能と Remote Control 起動の許可ユーザーが運用上一致しており、env を増やさないため
 - **起動コマンドはリスト引数で渡す**: `subprocess` の `shell=False` でリスト引数を渡し、コマンドインジェクションを防止する
 - **スキル名はハードコード**: 起動対象のスキルは `/auto-publish-diary` 固定。外部入力（Slack コマンド本文）からスキル名を組み立てない
-- **`--dangerously-skip-permissions` モードで起動する**: `claude -p` は git ネットワーク操作（`git fetch` / `git pull` / `git push`）・`gh pr create` / `gh pr merge` の permission をデフォルトで拒否する。`/auto-publish-diary` はこれらを多用するため `--dangerously-skip-permissions` で全許可する。緩和策として (1) allowlist で実行ユーザー制限、(2) `cwd` を `ARTICLE_WRITER_REPO_PATH` 固定、(3) スキル名固定、(4) `Path.is_absolute()` 検証で相対パス指定を排除、の 4 段防御で対処する
+- **`--dangerously-skip-permissions` モードで起動する**: `claude -p` は git ネットワーク操作（`git fetch` / `git pull` / `git push`）・`gh pr create` / `gh pr merge` の permission をデフォルトで拒否する。
+  `/auto-publish-diary` はこれらを多用するため `--dangerously-skip-permissions` で全許可する。緩和策として以下の 4 段防御で対処する:
+  - allowlist による実行ユーザー制限
+  - `cwd` を `ARTICLE_WRITER_REPO_PATH` に固定
+  - スキル名（`/auto-publish-diary`）の固定（外部入力からスキル名を組み立てない）
+  - 設定パスの `Path.is_absolute()` 検証による相対パス指定の排除
 - **対象リポジトリのパスは絶対パスのみ許可**: `ARTICLE_WRITER_REPO_PATH` は絶対パスで指定する。意図しないディレクトリでの起動を防ぐため
 - **同時実行制御は提供しない**: 多重起動の防止は本機能のスコープ外。Slack reminder の運用では基本的に 1 日 1 回のみ起動される前提
+- **リトライしない**: 子プロセス起動の失敗・タイムアウト・レスポンスファイル解析失敗いずれもリトライせず、即座にエラーを Slack に返す。再実行は運用判断で手動再投入する
+- **操作全体のタイムアウトは設定値で制御する**: `article_publish_timeout` は設定値（種別: 設定値、許容範囲は pydantic Field が SSoT）。タイムアウト経過時は子プロセスを kill する
 - **失敗時の worktree 残置の自動掃除は提供しない**: `/auto-publish-diary` は失敗時に worktree を残置する設計（state 保持のため）。残置 worktree の定期掃除は本機能のスコープ外で、運用上の手動掃除でカバーする
 - **トリガー（Slack reminder の登録）は本機能のスコープ外**: Slack 標準機能で reminder を登録する。コード変更なし
-- **対象スキルの SSoT は article-writer 側**: `/auto-publish-diary` の出力契約（最終行 JSON のフィールド構成・終了コード）は article-writer 側の仕様に従う。本機能は出力契約のうち本機能が依存するフィールドのみを参照する
+- **対象スキルの SSoT は article-writer 側**: `/auto-publish-diary` の出力契約（レスポンスファイルのフィールド構成・終了コード・書き込み先パス）は article-writer 側の仕様に従う。本機能は出力契約のうち本機能が依存するフィールドのみを参照する
+- **結果はレスポンスファイルから取得する**: `claude -p --output-format text` は Claude の最終応答テキストのみを返す（subprocess 内の `echo` 出力を中継しない）ため、stdout からの構造化データ取得は不定。
+  `/auto-publish-diary` は親リポ直下の `.tmp/auto-publish-diary/result.json` に成否情報を書き出す契約とし、本機能はこのファイルを読む。
+  stdout はエラー時のログ表示用にのみ使用する
 
 ## 操作一覧
 
@@ -41,29 +51,42 @@ Slack コマンドにより、ホスト PC 上の article-writer リポジトリ
 
 **トリガー**: メッセージが `article write-hatena` の形式（先頭が `article`、サブコマンドが `write-hatena`）
 
-サブコマンド名は **大文字小文字を区別する**（既存の `feed` / `rag` / `rc` コマンドと同じく、小文字一致を必須とする）。
+サブコマンド名は小文字に正規化してから比較する（既存の `feed` / `rag` / `rc` コマンドと同パターン）。
 
 **振る舞い**:
 
 1. 認可ユーザー allowlist（`REMOTE_CONTROL_ALLOWED_USERS`）にメッセージ送信者の Slack `user_id` が含まれるか検証する。含まれない場合は権限エラーを返して終了する
 2. `ARTICLE_WRITER_REPO_PATH` が設定されているか検証する。空または未設定の場合は機能無効メッセージを返して終了する
-3. 設定された絶対パスが実在ディレクトリであることを検証する。存在しない場合は構成エラーを返して終了する
-4. `claude` 実行ファイルが PATH 上で解決できることを検証する。解決できない場合は前提エラーを返して終了する
-5. Slack に「投稿処理を開始します」メッセージを返す（実行時間が長いため処理開始を明示する）
+3. Slack に「投稿処理を開始します」メッセージを返す（実行時間が長いため処理開始を明示する）
+4. 設定された絶対パスが実在ディレクトリであることを検証する。存在しない場合は構成エラーを Slack に返して終了する
+5. `claude` 実行ファイルが PATH 上で解決できることを検証する。解決できない場合は前提エラーを Slack に返して終了する
 6. `claude -p '/auto-publish-diary' --dangerously-skip-permissions --output-format text` を `cwd=ARTICLE_WRITER_REPO_PATH` で起動する。stdout / stderr を捕捉し、終了コードを取得する
 7. プロセスがタイムアウト時間内に終了しない場合は kill し、タイムアウトエラーを Slack に返す
-8. 終了コードが 0 の場合は stdout 最終行を JSON としてパースし、結果フィールド（`status` / `article_path` / `draft_url` / `pr_url` / `worktree_removed` / `worktree_path`）を Slack 通知に整形する
-9. 終了コードが非 0 または JSON パースに失敗した場合はエラーを Slack に返す。失敗時の JSON に `worktree_path` が含まれる場合は併せて通知する
+8. 親リポ直下のレスポンスファイル `<ARTICLE_WRITER_REPO_PATH>/.tmp/auto-publish-diary/result.json` を読み込み、JSON としてパースする。ファイル不在・読み取り失敗・JSON 解析失敗・dict 以外の値の場合は実行結果解析エラーを Slack に返す
+9. 終了コードが 0 + JSON 解析成功の場合は結果フィールド（`status` / `article_path` / `draft_url` / `pr_url` / `worktree_removed` / `worktree_path`）を Slack 通知に整形する
+10. 終了コードが非 0 + JSON 解析成功の場合は失敗結果として Slack に返す。失敗時の JSON に `worktree_path` が含まれる場合は併せて通知する
+
+ステップ 4・5 が処理開始メッセージの後にあるのは、ホスト固有の前提（ディレクトリ実在・`claude` 実行ファイル PATH 解決）の検証を `ArticleWriterPublisher` サービス層に集約し、router 側を薄く保つ設計上の判断による。構成エラー時は「開始」「失敗」の 2 メッセージがユーザーに届くが、処理は正しく中断される。
 
 **出力**:
 
-成功時（`status="ok"`）:
+成功時（`status="ok"` / `worktree_removed=true`）:
 
 ```
 ✅ 日記の自動投稿に成功しました
-記事: articles/hatena/2026-02-10-diary.md
+記事: articles/hatena/2026-05-20-diary.md
 下書き: https://example.hatenablog.com/entry/2026/05/20/152523
 PR: https://github.com/becky3/article-writer/pull/71
+```
+
+成功時（`status="ok"` / `worktree_removed=false`、cleanup のみ失敗）:
+
+```
+✅ 日記の自動投稿に成功しました（worktree 削除のみ失敗）
+記事: articles/hatena/2026-05-20-diary.md
+下書き: https://example.hatenablog.com/entry/2026/05/20/152523
+PR: https://github.com/becky3/article-writer/pull/71
+残置 worktree: article-writer-wt-auto-20260520
 ```
 
 権限拒否時:
@@ -84,18 +107,21 @@ PR: https://github.com/becky3/article-writer/pull/71
 ⌛ 記事の自動投稿がタイムアウトしました（{N}分）。article-writer 側の worktree が残置されている可能性があります。
 ```
 
-失敗時（終了コード非 0、JSON 解析成功）:
+失敗時（終了コード非 0、レスポンスファイル解析成功）:
 
 ```
 ❌ 日記の自動投稿に失敗しました
-理由: {失敗 JSON の reason フィールド等}
+exit code: {終了コード}
+失敗 Phase: {failed_phase}
+理由: {error フィールド}
 残置 worktree: {worktree_path}
 ```
 
-JSON 解析失敗時:
+実行結果の解析失敗時（レスポンスファイル不在・JSON 解析失敗等）:
 
 ```
 ❌ 日記の自動投稿に失敗しました（実行結果の解析に失敗）
+理由: {失敗理由（ファイル不在 / 読み取り失敗 / JSON 解析失敗 / 型不一致）}
 exit code: {終了コード}
 stdout 末尾: {直近の数行}
 ```
@@ -128,9 +154,10 @@ graph LR
     D --> E[認可検証]
     D --> F[ArticleWriterPublisher]
     F --> G[claude -p /auto-publish-diary]
-    G --> H[stdout 最終行 JSON]
-    H --> I[Slack 応答]
-    E --> I
+    G --> H[result.json 書き込み]
+    H --> I[ArticleWriterPublisher 読み取り]
+    I --> J[Slack 応答]
+    E --> J
 ```
 
 | コンポーネント | 役割 |
@@ -138,7 +165,8 @@ graph LR
 | MessageRouter | `article` キーワードで本ハンドラへルーティング |
 | article コマンドハンドラ | サブコマンド `write-hatena` の引数解析・エラー応答整形 |
 | 認可検証 | `REMOTE_CONTROL_ALLOWED_USERS` allowlist チェック |
-| ArticleWriterPublisher | `claude -p '/auto-publish-diary'` の subprocess 起動・stdout 最終行 JSON パース・結果整形 |
+| ArticleWriterPublisher | `claude -p '/auto-publish-diary'` の subprocess 起動・親リポ直下 `.tmp/auto-publish-diary/result.json` の読み取り・結果整形 |
+| result.json | スキル側が親リポ直下に書き出すレスポンスファイル。SSoT は article-writer 側スキル仕様 |
 
 ## エッジケース
 
@@ -146,9 +174,9 @@ graph LR
 |---|---|
 | `ARTICLE_WRITER_REPO_PATH` が空または未設定 | 本機能は無効。「機能は現在無効です」とのメッセージを返す（fail-closed） |
 | `REMOTE_CONTROL_ALLOWED_USERS` が空 | 認可ユーザーがいない状態のため、全ユーザーからのコマンドが権限エラーで拒否される |
-| 同時実行（実行中にもう一度コマンドが送信される） | 本機能は多重起動を制御しない。subprocess が並列に起動される（article-writer 側で worktree 名が衝突する可能性あり、運用で回避する） |
-| `claude` プロセスが即時終了（exit code 非 0 + JSON 出力なし） | エラーメッセージに終了コードと stdout 末尾を含めて返す |
-| stdout 最終行が JSON でない | JSON 解析失敗エラーを返す。`worktree_path` は通知できないため、ユーザーはサーバーログを確認する |
+| 同時実行（実行中にもう一度コマンドが送信される） | 制約セクション「同時実行制御は提供しない」を参照 |
+| `claude` プロセスが即時終了（result.json 未生成） | 実行結果解析エラーを Slack に返す（exit code と stdout 末尾を含む） |
+| result.json が読み取れない / JSON として不正 / dict でない | 実行結果解析エラーを Slack に返す。`worktree_path` は取得できないため、ユーザーはサーバーログを確認する |
 | タイムアウト | 子プロセスを kill し、タイムアウトエラーを返す。worktree が残置されている可能性を明示する |
 
 ## 関連ドキュメント
@@ -157,4 +185,5 @@ graph LR
 - [cli-adapter](cli-adapter.md): メッセージルーティング基盤
 - [auto-reply](auto-reply.md): 自動返信チャンネルでのコマンド動作
 - [config-management](../infrastructure/config-management.md): 設定の3層分離方針
-- article-writer リポジトリ `/auto-publish-diary` スキル（article-writer PR #70 / Issue #68）
+- article-writer リポジトリ `/auto-publish-diary` スキル: [PR #70](https://github.com/becky3/article-writer/pull/70) / [Issue #68](https://github.com/becky3/article-writer/issues/68)（スキル本体の出力契約・実行フローはこちらが SSoT）
+- article-writer [Issue #75](https://github.com/becky3/article-writer/issues/75): 出力契約を stdout JSON からレスポンスファイル方式に変更する Issue（本機能の前提）

--- a/docs/specs/overview.md
+++ b/docs/specs/overview.md
@@ -22,6 +22,7 @@ AI Assistantは、Slack上で動作するAIアシスタントである。
 | 11 | 設定管理 | アプリケーション設定の3層分離（シークレット・環境依存値・共通設定値） | [config-management.md](infrastructure/config-management.md) |
 | 12 | Remote Control 起動 | Slack コマンドからホスト PC 上の指定リポジトリで `claude remote-control` を起動し、接続 URL を返す | [remote-control-launch.md](features/remote-control-launch.md) |
 | 13 | ログ出力 | 全 handler / 主要サービスのタイミングログによる観測性向上 | [logging.md](infrastructure/logging.md) |
+| 14 | 記事自動投稿 | Slack コマンドから article-writer リポジトリで `/auto-publish-diary` スキルを起動し、結果を Slack に通知 | [article-publishing.md](features/article-publishing.md) |
 
 ## 3. 技術スタック
 

--- a/src/cli.py
+++ b/src/cli.py
@@ -155,6 +155,7 @@ async def _setup(
         rag_zenn_max_articles=settings.rag_zenn_max_articles,
         remote_control_launcher=None,
         remote_control_allowed_users=[],
+        article_writer_publisher=None,
     )
 
     return router, cli_adapter, mcp_manager

--- a/src/config/settings.py
+++ b/src/config/settings.py
@@ -80,6 +80,9 @@ class _EnvLoader(BaseSettings):
     remote_control_repositories: str = ""
     remote_control_log_dir: str = ""
 
+    # 記事自動投稿（article-writer リポジトリの絶対パス。空文字なら機能無効）
+    article_writer_repo_path: str = ""
+
 
 # .env 管理フィールド名の集合（重複検出に使用）
 _ENV_FIELD_NAMES = frozenset(_EnvLoader.model_fields.keys())
@@ -116,6 +119,7 @@ class Settings(BaseModel):
     remote_control_allowed_users: str
     remote_control_repositories: str
     remote_control_log_dir: str
+    article_writer_repo_path: str
 
     def get_auto_reply_channels(self) -> list[str]:
         """自動返信チャンネルのリストを返す（カンマ区切りを解析）."""
@@ -177,12 +181,36 @@ class Settings(BaseModel):
     # 上限はサーバー応答性の悪化（長時間ポーリング）を防ぐためのハードリミット
     remote_control_url_timeout: int = Field(ge=1, le=300)
 
+    # 記事自動投稿（共通設定値）
+    # claude -p '/auto-publish-diary' のタイムアウト秒数。
+    # 上限は実機 QA 実測 ~13 分を踏まえ、極端な長時間ハングを防ぐためのハードリミット
+    article_publish_timeout: int = Field(ge=60, le=3600)
+
     @field_validator("remote_control_repositories")
     @classmethod
     def _validate_remote_control_repositories(cls, value: str) -> str:
         """起動時に文法検証する（パース成功すれば値はそのまま採用）."""
         _parse_remote_control_repositories(value)
         return value
+
+    @field_validator("article_writer_repo_path")
+    @classmethod
+    def _validate_article_writer_repo_path(cls, value: str) -> str:
+        """起動時に絶対パスのみ許容する（fail-fast）.
+
+        `--dangerously-skip-permissions` 起動の安全性ガードレールとして、
+        相対パス指定による意図しないディレクトリでの起動を排除する。
+        """
+        stripped = value.strip()
+        if not stripped:
+            return ""
+        if not Path(stripped).is_absolute():
+            msg = (
+                "ARTICLE_WRITER_REPO_PATH は絶対パスで指定してください: "
+                f"'{stripped}'"
+            )
+            raise ValueError(msg)
+        return stripped
 
 
 def _parse_remote_control_repositories(value: str) -> dict[str, str]:

--- a/src/main.py
+++ b/src/main.py
@@ -78,6 +78,7 @@ async def main() -> None:
     from src.mcp_bridge.client_manager import MCPClientManager, build_mcp_server_configs
     from src.messaging.router import MessageRouter
     from src.messaging.slack_adapter import SlackAdapter
+    from src.services.article_publisher import ArticleWriterPublisher
     from src.services.chat import ChatService
     from src.services.feed_collector import FeedCollector
     from src.services.ogp_extractor import OgpExtractor
@@ -221,6 +222,24 @@ async def main() -> None:
                 "Remote Control 起動は無効（REMOTE_CONTROL_ALLOWED_USERS / REMOTE_CONTROL_REPOSITORIES のいずれかが未設定）",
             )
 
+        # 記事自動投稿サービス（ARTICLE_WRITER_REPO_PATH 設定がある場合のみ有効化）
+        # 空白のみの値は settings 側の field_validator で空文字に正規化済み
+        if settings.article_writer_repo_path:
+            article_writer_publisher = ArticleWriterPublisher(
+                repo_path=Path(settings.article_writer_repo_path),
+                timeout=settings.article_publish_timeout,
+            )
+            logger.info(
+                "記事自動投稿を有効化: repo_path=%s, timeout=%ds",
+                settings.article_writer_repo_path,
+                settings.article_publish_timeout,
+            )
+        else:
+            article_writer_publisher = None
+            logger.info(
+                "記事自動投稿は無効（ARTICLE_WRITER_REPO_PATH が未設定）",
+            )
+
         # MessageRouter (F9)
         router = MessageRouter(
             messaging=slack_adapter,
@@ -242,6 +261,7 @@ async def main() -> None:
             rag_zenn_max_articles=settings.rag_zenn_max_articles,
             remote_control_launcher=remote_control_launcher,
             remote_control_allowed_users=rc_allowed_users,
+            article_writer_publisher=article_writer_publisher,
         )
 
         register_handlers(

--- a/src/messaging/router.py
+++ b/src/messaging/router.py
@@ -21,6 +21,14 @@ from py_common_lib.httpx import ConstrainedClient
 
 from src.mcp_bridge.client_manager import MCPToolNotFoundError
 from src.messaging.port import IncomingMessage, MessagingPort
+from src.services.article_publisher import (
+    ArticlePublishError,
+    ArticlePublishFailure,
+    ArticlePublishResponseFileError,
+    ArticlePublishResult,
+    ArticlePublishTimeoutError,
+    ArticleWriterPublisher,
+)
 from src.services.chat import ChatService
 from src.services.remote_control import (
     RemoteControlError,
@@ -37,6 +45,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+_ARTICLE_KEYWORDS = ("article",)
 _DELIVER_KEYWORDS = ("deliver",)
 _FEED_KEYWORDS = ("feed",)
 _RAG_KEYWORDS = ("rag",)
@@ -575,6 +584,7 @@ class MessageRouter:
         rag_zenn_max_articles: int,
         remote_control_launcher: RemoteControlLauncher | None,
         remote_control_allowed_users: list[str],
+        article_writer_publisher: ArticleWriterPublisher | None,
     ) -> None:
         self._messaging = messaging
         self._chat_service = chat_service
@@ -595,6 +605,7 @@ class MessageRouter:
         self._rag_zenn_max_articles = rag_zenn_max_articles
         self._remote_control_launcher = remote_control_launcher
         self._remote_control_allowed_users = remote_control_allowed_users
+        self._article_writer_publisher = article_writer_publisher
 
     async def process_message(self, msg: IncomingMessage) -> None:
         """受信メッセージをキーワードルーティングし、適切なサービスに委譲する."""
@@ -629,6 +640,14 @@ class MessageRouter:
         ):
             logger.info("routing: text=%r -> handler=rag", cleaned_text[:200])
             await self._handle_rag_command(msg, cleaned_text)
+            return
+
+        # article コマンド (記事自動投稿)
+        if any(
+            re.match(rf"^{re.escape(kw)}\b", lower_text) for kw in _ARTICLE_KEYWORDS
+        ):
+            logger.info("routing: text=%r -> handler=article", cleaned_text[:200])
+            await self._handle_article_command(msg, cleaned_text)
             return
 
         # rc コマンド (Remote Control 起動)
@@ -1177,4 +1196,181 @@ class MessageRouter:
             "• `@bot rc start <repo-key>` — 指定リポジトリで Claude Code Remote Control を起動\n"
             f"登録済み: {registered}"
         )
+
+    async def _handle_article_command(
+        self, msg: IncomingMessage, cleaned_text: str,
+    ) -> None:
+        """article コマンドのルーティング（記事自動投稿）.
+
+        仕様: docs/specs/features/article-publishing.md
+        """
+        logger.info("handle_article_command start: user=%s", msg.user_id)
+        thread_id = msg.thread_id
+        channel = msg.channel
+
+        if self._article_writer_publisher is None:
+            await self._messaging.send_message(
+                "記事自動投稿機能は現在無効です。管理者に設定を依頼してください。",
+                thread_id, channel,
+            )
+            logger.info("handle_article_command complete: result=disabled")
+            return
+
+        if msg.user_id not in self._remote_control_allowed_users:
+            logger.warning(
+                "article command denied: user=%s not in allowlist", msg.user_id,
+            )
+            await self._messaging.send_message(
+                "❌ このコマンドを実行する権限がありません",
+                thread_id, channel,
+            )
+            logger.info("handle_article_command complete: result=permission_denied")
+            return
+
+        tokens = cleaned_text.split()
+        if len(tokens) < 2:
+            await self._messaging.send_message(
+                _build_article_usage(), thread_id, channel,
+            )
+            logger.info("handle_article_command complete: result=usage")
+            return
+
+        subcommand = tokens[1].lower()
+        if subcommand != "write-hatena":
+            await self._messaging.send_message(
+                _build_article_usage(), thread_id, channel,
+            )
+            logger.info(
+                "handle_article_command complete: result=invalid_subcommand",
+            )
+            return
+
+        await self._handle_article_write_hatena(thread_id, channel)
+
+    async def _handle_article_write_hatena(
+        self, thread_id: str, channel: str,
+    ) -> None:
+        """`article write-hatena` の本体: ArticleWriterPublisher を起動して結果を Slack 通知."""
+        assert self._article_writer_publisher is not None
+        publisher = self._article_writer_publisher
+
+        await self._messaging.send_message(
+            "📝 日記の自動投稿処理を開始します...", thread_id, channel,
+        )
+
+        try:
+            outcome = await publisher.publish_diary()
+        except ArticlePublishTimeoutError as e:
+            timeout_minutes = max(1, publisher.timeout // 60)
+            await self._messaging.send_message(
+                f"⌛ 記事の自動投稿がタイムアウトしました（{timeout_minutes}分）。"
+                "article-writer 側の worktree が残置されている可能性があります。",
+                thread_id, channel,
+            )
+            logger.info("handle_article_write_hatena complete: result=timeout, err=%s", e)
+            return
+        except ArticlePublishResponseFileError as e:
+            await self._messaging.send_message(
+                _format_article_response_file_error(e), thread_id, channel,
+            )
+            logger.info(
+                "handle_article_write_hatena complete: result=response_file_error",
+            )
+            return
+        except ArticlePublishError as e:
+            await self._messaging.send_message(
+                f"❌ 日記の自動投稿に失敗しました\n理由: {e}",
+                thread_id, channel,
+            )
+            logger.info(
+                "handle_article_write_hatena complete: result=publish_error",
+            )
+            return
+        except Exception:
+            logger.exception("Failed to publish diary")
+            await self._messaging.send_message(
+                "❌ 日記の自動投稿中に予期せぬエラーが発生しました。",
+                thread_id, channel,
+            )
+            logger.info(
+                "handle_article_write_hatena complete: result=unexpected_error",
+            )
+            return
+
+        if isinstance(outcome, ArticlePublishFailure):
+            response = _format_article_failure(outcome)
+        else:
+            response = _format_article_success(outcome)
+
+        await self._messaging.send_message(response, thread_id, channel)
+        logger.info(
+            "handle_article_write_hatena complete: result=success_or_known_failure",
+        )
+
+
+def _build_article_usage() -> str:
+    """article コマンドの使用方法を返す."""
+    return (
+        "使用方法:\n"
+        "• `@bot article write-hatena` — article-writer で `/auto-publish-diary` を起動"
+    )
+
+
+def _format_article_success(result: ArticlePublishResult) -> str:
+    """成功時の Slack メッセージを組み立てる."""
+    header = (
+        "✅ 日記の自動投稿に成功しました"
+        if result.worktree_removed
+        else "✅ 日記の自動投稿に成功しました（worktree 削除のみ失敗）"
+    )
+    lines = [header]
+    if result.article_path:
+        lines.append(f"記事: {result.article_path}")
+    if result.draft_url:
+        lines.append(f"下書き: {result.draft_url}")
+    if result.pr_url:
+        lines.append(f"PR: {result.pr_url}")
+    if result.status and result.status != "ok":
+        lines.append(f"status: {result.status}")
+    if not result.worktree_removed and result.worktree_path:
+        lines.append(f"残置 worktree: {_safe_worktree_label(result.worktree_path)}")
+    return "\n".join(lines)
+
+
+def _format_article_response_file_error(err: ArticlePublishResponseFileError) -> str:
+    """レスポンスファイル不在・解析失敗時の Slack メッセージを組み立てる（仕様書「出力 / 実行結果の解析失敗時」準拠）."""
+    return (
+        "❌ 日記の自動投稿に失敗しました（実行結果の解析に失敗）\n"
+        f"理由: {err.reason}\n"
+        f"exit code: {err.exit_code}\n"
+        f"stdout 末尾: {err.stdout_tail}"
+    )
+
+
+def _format_article_failure(failure: ArticlePublishFailure) -> str:
+    """失敗時の Slack メッセージを組み立てる（article-writer の result.json スキーマ準拠）."""
+    raw = failure.raw_json
+    lines = [
+        "❌ 日記の自動投稿に失敗しました",
+        f"exit code: {failure.exit_code}",
+    ]
+    failed_phase = raw.get("failed_phase")
+    if isinstance(failed_phase, str) and failed_phase:
+        lines.append(f"失敗 Phase: {failed_phase}")
+    error_text = raw.get("error")
+    if isinstance(error_text, str) and error_text:
+        lines.append(f"理由: {error_text}")
+    worktree_path = raw.get("worktree_path")
+    if isinstance(worktree_path, str) and worktree_path:
+        lines.append(f"残置 worktree: {_safe_worktree_label(worktree_path)}")
+    return "\n".join(lines)
+
+
+def _safe_worktree_label(worktree_path: str) -> str:
+    """worktree パスを Slack 通知向けに整形する（絶対パスは最後のセグメントのみ表示）."""
+    path = worktree_path.replace("\\", "/")
+    if path.startswith("/") or (len(path) >= 2 and path[1] == ":"):
+        # 絶対パスの場合は末尾セグメントのみ
+        return path.rsplit("/", 1)[-1] or worktree_path
+    return worktree_path
 

--- a/src/services/article_publisher.py
+++ b/src/services/article_publisher.py
@@ -1,0 +1,243 @@
+"""記事自動投稿サービス
+仕様: docs/specs/features/article-publishing.md
+
+article-writer リポジトリで `claude -p '/auto-publish-diary'` を起動し、
+親リポ直下のレスポンスファイル（`.tmp/auto-publish-diary/result.json`）を結果 dataclass にパースする。
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import shutil
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# article-writer 側 `/auto-publish-diary` スキル名（ハードコード固定。外部入力から組み立てない）
+_AUTO_PUBLISH_DIARY_SKILL = "/auto-publish-diary"
+
+# レスポンスファイルの親リポ相対パス（article-writer 側スキルとの SSoT 結合）
+# 親リポ固定の理由: worktree は Phase 4 で削除されるため、worktree 内に置くと cleanup で消える
+RESULT_FILE_RELATIVE = Path(".tmp") / "auto-publish-diary" / "result.json"
+
+
+class ArticlePublishError(Exception):
+    """記事自動投稿の共通エラー."""
+
+
+class ArticlePublishBinaryNotFoundError(ArticlePublishError):
+    """claude 実行ファイルが PATH 上に存在しない."""
+
+
+class ArticlePublishRepositoryNotFoundError(ArticlePublishError):
+    """ARTICLE_WRITER_REPO_PATH のパスがディレクトリとして存在しない."""
+
+
+class ArticlePublishTimeoutError(ArticlePublishError):
+    """claude -p の実行がタイムアウトした."""
+
+
+class ArticlePublishResponseFileError(ArticlePublishError):
+    """レスポンスファイルが読めない・解析できない（仕様書「実行結果の解析失敗時」出力に対応）.
+
+    Slack 通知用に終了コードと診断情報を構造化して保持する。
+    """
+
+    def __init__(
+        self,
+        reason: str,
+        exit_code: int,
+        stdout_tail: str,
+        result_path: Path,
+    ) -> None:
+        super().__init__(reason)
+        self.reason = reason
+        self.exit_code = exit_code
+        self.stdout_tail = stdout_tail
+        self.result_path = result_path
+
+
+@dataclass(frozen=True)
+class ArticlePublishResult:
+    """起動成功時の結果（result.json のうち本機能が依存するフィールド）."""
+
+    status: str
+    article_path: str | None
+    draft_url: str | None
+    pr_url: str | None
+    worktree_removed: bool
+    worktree_path: str | None
+
+
+@dataclass(frozen=True)
+class ArticlePublishFailure:
+    """終了コード非 0 + result.json 解析に成功した失敗結果."""
+
+    exit_code: int
+    raw_json: dict[str, object]
+
+
+class ArticleWriterPublisher:
+    """`claude -p '/auto-publish-diary'` を起動して結果を返すサービス.
+
+    仕様: docs/specs/features/article-publishing.md
+    """
+
+    def __init__(self, repo_path: Path, timeout: int) -> None:
+        self._repo_path = repo_path
+        self._timeout = timeout
+
+    @property
+    def repo_path(self) -> Path:
+        """設定された article-writer リポジトリパス."""
+        return self._repo_path
+
+    @property
+    def timeout(self) -> int:
+        """設定されたタイムアウト秒数."""
+        return self._timeout
+
+    @property
+    def result_path(self) -> Path:
+        """レスポンスファイルの絶対パス."""
+        return self._repo_path / RESULT_FILE_RELATIVE
+
+    async def publish_diary(self) -> ArticlePublishResult | ArticlePublishFailure:
+        """`/auto-publish-diary` を起動し、結果を返す.
+
+        Returns:
+            終了コード 0 + result.json 解析成功時: ArticlePublishResult
+            終了コード非 0 + result.json 解析成功時: ArticlePublishFailure
+
+        Raises:
+            ArticlePublishRepositoryNotFoundError: repo_path が実在しない
+            ArticlePublishBinaryNotFoundError: claude が PATH 上に無い
+            ArticlePublishTimeoutError: タイムアウト
+            ArticlePublishResponseFileError: result.json 不在 / 解析失敗
+        """
+        logger.info("article_publish start: repo_path=%s", self._repo_path)
+        if not self._repo_path.is_dir():
+            msg = f"ARTICLE_WRITER_REPO_PATH のディレクトリが存在しません: {self._repo_path}"
+            raise ArticlePublishRepositoryNotFoundError(msg)
+
+        claude_bin = shutil.which("claude")
+        if claude_bin is None:
+            msg = "claude コマンドが PATH 上に見つかりません。Claude Code CLI をインストールしてください。"
+            raise ArticlePublishBinaryNotFoundError(msg)
+
+        cmd = (
+            claude_bin, "-p", _AUTO_PUBLISH_DIARY_SKILL,
+            "--dangerously-skip-permissions",
+            "--output-format", "text",
+        )
+
+        proc = await asyncio.create_subprocess_exec(
+            *cmd,
+            cwd=str(self._repo_path),
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+
+        try:
+            stdout, stderr = await asyncio.wait_for(
+                proc.communicate(), timeout=self._timeout,
+            )
+        except asyncio.TimeoutError:
+            proc.kill()
+            await proc.wait()
+            msg = f"claude -p '/auto-publish-diary' がタイムアウトしました（{self._timeout}秒）"
+            logger.error(msg)
+            raise ArticlePublishTimeoutError(msg) from None
+
+        stdout_text = stdout.decode("utf-8", errors="replace")
+        stderr_text = stderr.decode("utf-8", errors="replace").strip()
+        exit_code = proc.returncode if proc.returncode is not None else -1
+
+        logger.info(
+            "article_publish subprocess complete: exit_code=%d, stdout_len=%d",
+            exit_code, len(stdout_text),
+        )
+
+        tail = _tail_lines(stdout_text, 10)
+        result_path = self.result_path
+
+        if not result_path.is_file():
+            reason = (
+                f"レスポンスファイルが見つかりません: {RESULT_FILE_RELATIVE.as_posix()}"
+            )
+            logger.error(
+                "article_publish response file missing: %s, exit_code=%d, stderr=%r",
+                result_path, exit_code, stderr_text[:200],
+            )
+            raise ArticlePublishResponseFileError(
+                reason=reason, exit_code=exit_code, stdout_tail=tail,
+                result_path=result_path,
+            )
+
+        try:
+            raw_text = result_path.read_text(encoding="utf-8")
+        except OSError as e:
+            reason = f"レスポンスファイルの読み取りに失敗しました: {e}"
+            logger.error("article_publish response file read failed: %s", reason)
+            raise ArticlePublishResponseFileError(
+                reason=reason, exit_code=exit_code, stdout_tail=tail,
+                result_path=result_path,
+            ) from e
+
+        try:
+            payload = json.loads(raw_text)
+        except json.JSONDecodeError as e:
+            reason = f"レスポンスファイルの JSON 解析に失敗しました: {e}"
+            logger.error("article_publish response file parse failed: %s", reason)
+            raise ArticlePublishResponseFileError(
+                reason=reason, exit_code=exit_code, stdout_tail=tail,
+                result_path=result_path,
+            ) from e
+
+        if not isinstance(payload, dict):
+            reason = (
+                f"レスポンスファイルの JSON が dict ではありません: "
+                f"type={type(payload).__name__}"
+            )
+            logger.error("article_publish response file shape error: %s", reason)
+            raise ArticlePublishResponseFileError(
+                reason=reason, exit_code=exit_code, stdout_tail=tail,
+                result_path=result_path,
+            )
+
+        if exit_code != 0:
+            logger.warning("article_publish failure: exit_code=%d", exit_code)
+            return ArticlePublishFailure(exit_code=exit_code, raw_json=payload)
+
+        result = ArticlePublishResult(
+            status=str(payload.get("status", "")),
+            article_path=_optional_str(payload.get("article_path")),
+            draft_url=_optional_str(payload.get("draft_url")),
+            pr_url=_optional_str(payload.get("pr_url")),
+            worktree_removed=bool(payload.get("worktree_removed", False)),
+            worktree_path=_optional_str(payload.get("worktree_path")),
+        )
+        logger.info(
+            "article_publish complete: status=%s, draft_url=%s, pr_url=%s",
+            result.status, result.draft_url, result.pr_url,
+        )
+        return result
+
+
+def _tail_lines(text: str, n: int) -> str:
+    """末尾 n 行を 1 つの文字列として返す（ログ表示用）."""
+    lines = text.splitlines()
+    return "\n".join(lines[-n:])
+
+
+def _optional_str(value: object) -> str | None:
+    """JSON の値を任意文字列に変換する（None / 非文字列は None として扱う）."""
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value
+    return str(value)

--- a/src/services/article_publisher.py
+++ b/src/services/article_publisher.py
@@ -135,6 +135,19 @@ class ArticleWriterPublisher:
             "--output-format", "text",
         )
 
+        # 防御的クリーンアップ: 前回実行の result.json が残っている状態で
+        # 今回 subprocess が result.json 未更新のまま失敗（Phase 0 到達前のクラッシュ等）した場合、
+        # 古い結果を誤読しないよう、起動直前に既存ファイルを削除する。
+        # article-writer 側スキルも Phase 0 で同等の削除を行うが、ai-assistant 側でも二重に防御する
+        result_path = self.result_path
+        try:
+            result_path.unlink(missing_ok=True)
+        except OSError as e:
+            logger.warning(
+                "article_publish failed to remove stale result file: %s, err=%s",
+                result_path, e,
+            )
+
         proc = await asyncio.create_subprocess_exec(
             *cmd,
             cwd=str(self._repo_path),
@@ -163,7 +176,6 @@ class ArticleWriterPublisher:
         )
 
         tail = _tail_lines(stdout_text, 10)
-        result_path = self.result_path
 
         if not result_path.is_file():
             reason = (
@@ -235,7 +247,11 @@ def _tail_lines(text: str, n: int) -> str:
 
 
 def _optional_str(value: object) -> str | None:
-    """JSON の値を任意文字列に変換する（None / 非文字列は None として扱う）."""
+    """JSON の値を任意文字列に変換する.
+
+    `None` はそのまま `None` を返す。文字列はそのまま返す。
+    非文字列（数値・bool 等）は `str(value)` で文字列化して返す（スキーマ違反データに対する防御的変換）。
+    """
     if value is None:
         return None
     if isinstance(value, str):

--- a/tests/settings_defaults.py
+++ b/tests/settings_defaults.py
@@ -28,6 +28,7 @@ TEST_SETTINGS_DEFAULTS: dict[str, object] = {
     "remote_control_allowed_users": "",
     "remote_control_repositories": "",
     "remote_control_log_dir": "",
+    "article_writer_repo_path": "",
     # config.toml フィールド
     "openai_model": "gpt-4o-mini",
     "anthropic_model": "claude-3-5-sonnet-20241022",
@@ -46,4 +47,5 @@ TEST_SETTINGS_DEFAULTS: dict[str, object] = {
     "claude_timeout": 120,
     "log_file_max_bytes": 10485760,
     "remote_control_url_timeout": 15,
+    "article_publish_timeout": 1200,
 }

--- a/tests/test_article_publisher.py
+++ b/tests/test_article_publisher.py
@@ -43,12 +43,26 @@ def _stub_proc(stdout: bytes = b"", stderr: bytes = b"", returncode: int = 0) ->
     return proc
 
 
-def _write_result(repo_path: Path, payload: dict[str, object]) -> Path:
-    """テスト用に repo_path 配下にレスポンスファイルを作成する."""
+def _make_subprocess_mock_writing_result(
+    repo_path: Path,
+    payload_text: str | None,
+    returncode: int = 0,
+    stdout: bytes = b"",
+) -> AsyncMock:
+    """create_subprocess_exec のモック.
+
+    呼び出されたタイミングで result.json を書き込む（実際のスキル動作のシミュレーション）。
+    `payload_text=None` の場合は書き込みをスキップ（result.json 不在ケース用）。
+    """
     result_path = repo_path / RESULT_FILE_RELATIVE
-    result_path.parent.mkdir(parents=True, exist_ok=True)
-    result_path.write_text(json.dumps(payload), encoding="utf-8")
-    return result_path
+
+    async def fake_exec(*_args: object, **_kwargs: object) -> AsyncMock:
+        if payload_text is not None:
+            result_path.parent.mkdir(parents=True, exist_ok=True)
+            result_path.write_text(payload_text, encoding="utf-8")
+        return _stub_proc(stdout=stdout, returncode=returncode)
+
+    return AsyncMock(side_effect=fake_exec)
 
 
 async def test_publish_diary_nonexistent_repo_raises(tmp_path: Path) -> None:
@@ -68,7 +82,7 @@ async def test_publish_diary_claude_binary_missing(tmp_path: Path) -> None:
 
 async def test_publish_diary_success_reads_result_file(tmp_path: Path) -> None:
     """終了コード 0 + レスポンスファイル解析成功時、ArticlePublishResult が返る."""
-    _write_result(tmp_path, {
+    payload = json.dumps({
         "status": "ok",
         "article_path": "articles/hatena/2026-05-20-diary.md",
         "draft_url": "https://example.hatenablog.com/entry/2026/05/20/152523",
@@ -82,7 +96,7 @@ async def test_publish_diary_success_reads_result_file(tmp_path: Path) -> None:
         "src.services.article_publisher.shutil.which", return_value="/usr/bin/claude",
     ), patch(
         "src.services.article_publisher.asyncio.create_subprocess_exec",
-        new=AsyncMock(return_value=_stub_proc(returncode=0)),
+        new=_make_subprocess_mock_writing_result(tmp_path, payload, returncode=0),
     ):
         result = await publisher.publish_diary()
 
@@ -97,9 +111,10 @@ async def test_publish_diary_success_reads_result_file(tmp_path: Path) -> None:
 
 async def test_publish_diary_passes_expected_args(tmp_path: Path) -> None:
     """claude -p に '/auto-publish-diary' + --dangerously-skip-permissions が渡される."""
-    _write_result(tmp_path, {"status": "ok"})
+    mock_exec = _make_subprocess_mock_writing_result(
+        tmp_path, json.dumps({"status": "ok"}), returncode=0,
+    )
     publisher = _make_publisher(tmp_path)
-    mock_exec = AsyncMock(return_value=_stub_proc(returncode=0))
     with patch(
         "src.services.article_publisher.shutil.which", return_value="/usr/bin/claude",
     ), patch(
@@ -117,7 +132,7 @@ async def test_publish_diary_passes_expected_args(tmp_path: Path) -> None:
 
 async def test_publish_diary_failure_returns_failure(tmp_path: Path) -> None:
     """終了コード非 0 + レスポンスファイル解析成功時、ArticlePublishFailure が返る."""
-    _write_result(tmp_path, {
+    payload = json.dumps({
         "status": "error",
         "failed_phase": "publish",
         "error": "phase publish failed",
@@ -129,7 +144,7 @@ async def test_publish_diary_failure_returns_failure(tmp_path: Path) -> None:
         "src.services.article_publisher.shutil.which", return_value="/usr/bin/claude",
     ), patch(
         "src.services.article_publisher.asyncio.create_subprocess_exec",
-        new=AsyncMock(return_value=_stub_proc(returncode=1)),
+        new=_make_subprocess_mock_writing_result(tmp_path, payload, returncode=1),
     ):
         result = await publisher.publish_diary()
 
@@ -161,15 +176,12 @@ async def test_publish_diary_missing_result_file_raises(tmp_path: Path) -> None:
 
 async def test_publish_diary_invalid_json_raises(tmp_path: Path) -> None:
     """レスポンスファイルが JSON として不正な場合、ResponseFileError が発生する."""
-    result_path = tmp_path / RESULT_FILE_RELATIVE
-    result_path.parent.mkdir(parents=True, exist_ok=True)
-    result_path.write_text("{not valid json", encoding="utf-8")
     publisher = _make_publisher(tmp_path)
     with patch(
         "src.services.article_publisher.shutil.which", return_value="/usr/bin/claude",
     ), patch(
         "src.services.article_publisher.asyncio.create_subprocess_exec",
-        new=AsyncMock(return_value=_stub_proc(returncode=1)),
+        new=_make_subprocess_mock_writing_result(tmp_path, "{not valid json", returncode=1),
     ):
         with pytest.raises(ArticlePublishResponseFileError) as exc_info:
             await publisher.publish_diary()
@@ -180,15 +192,12 @@ async def test_publish_diary_invalid_json_raises(tmp_path: Path) -> None:
 
 async def test_publish_diary_non_dict_json_raises(tmp_path: Path) -> None:
     """レスポンスファイルの JSON が dict でない場合、ResponseFileError が発生する."""
-    result_path = tmp_path / RESULT_FILE_RELATIVE
-    result_path.parent.mkdir(parents=True, exist_ok=True)
-    result_path.write_text('["array", "is", "wrong"]', encoding="utf-8")
     publisher = _make_publisher(tmp_path)
     with patch(
         "src.services.article_publisher.shutil.which", return_value="/usr/bin/claude",
     ), patch(
         "src.services.article_publisher.asyncio.create_subprocess_exec",
-        new=AsyncMock(return_value=_stub_proc(returncode=0)),
+        new=_make_subprocess_mock_writing_result(tmp_path, '["array", "is", "wrong"]', returncode=0),
     ):
         with pytest.raises(ArticlePublishResponseFileError) as exc_info:
             await publisher.publish_diary()
@@ -218,3 +227,29 @@ async def test_result_path_property_returns_absolute_path(tmp_path: Path) -> Non
     publisher = _make_publisher(tmp_path)
     assert publisher.result_path == tmp_path / RESULT_FILE_RELATIVE
     assert publisher.result_path.is_absolute()
+
+
+async def test_publish_diary_removes_stale_result_file_before_launch(tmp_path: Path) -> None:
+    """前回実行の result.json が残っている場合、起動直前に削除される（古い結果の誤読防止）."""
+    # 前回の result.json を残置
+    stale_path = tmp_path / RESULT_FILE_RELATIVE
+    stale_path.parent.mkdir(parents=True, exist_ok=True)
+    stale_path.write_text(
+        json.dumps({"status": "ok", "pr_url": "https://stale/old/pull/0"}),
+        encoding="utf-8",
+    )
+
+    publisher = _make_publisher(tmp_path)
+
+    # subprocess が result.json を書き戻さない場合、削除されているため ResponseFileError になる
+    with patch(
+        "src.services.article_publisher.shutil.which", return_value="/usr/bin/claude",
+    ), patch(
+        "src.services.article_publisher.asyncio.create_subprocess_exec",
+        new=AsyncMock(return_value=_stub_proc(returncode=0)),
+    ):
+        with pytest.raises(ArticlePublishResponseFileError):
+            await publisher.publish_diary()
+
+    # 前回の result.json が削除されていることを確認（subprocess の stub が書き戻さないため）
+    assert not stale_path.exists()

--- a/tests/test_article_publisher.py
+++ b/tests/test_article_publisher.py
@@ -1,0 +1,220 @@
+"""ArticleWriterPublisher のテスト (#841).
+
+テスト方針:
+- claude -p のプロセス呼び出しを subprocess モックで検証する
+- レスポンスファイル（`.tmp/auto-publish-diary/result.json`）の読み取り成功/失敗、
+  終了コード判定、タイムアウト、引数構成を検証する
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from src.services.article_publisher import (
+    RESULT_FILE_RELATIVE,
+    ArticlePublishBinaryNotFoundError,
+    ArticlePublishFailure,
+    ArticlePublishRepositoryNotFoundError,
+    ArticlePublishResponseFileError,
+    ArticlePublishResult,
+    ArticlePublishTimeoutError,
+    ArticleWriterPublisher,
+)
+
+
+def _make_publisher(
+    repo_path: Path,
+    timeout: int = 60,
+) -> ArticleWriterPublisher:
+    return ArticleWriterPublisher(repo_path=repo_path, timeout=timeout)
+
+
+def _stub_proc(stdout: bytes = b"", stderr: bytes = b"", returncode: int = 0) -> AsyncMock:
+    proc = AsyncMock()
+    proc.communicate.return_value = (stdout, stderr)
+    proc.returncode = returncode
+    proc.kill = MagicMock()
+    proc.wait = AsyncMock()
+    return proc
+
+
+def _write_result(repo_path: Path, payload: dict[str, object]) -> Path:
+    """テスト用に repo_path 配下にレスポンスファイルを作成する."""
+    result_path = repo_path / RESULT_FILE_RELATIVE
+    result_path.parent.mkdir(parents=True, exist_ok=True)
+    result_path.write_text(json.dumps(payload), encoding="utf-8")
+    return result_path
+
+
+async def test_publish_diary_nonexistent_repo_raises(tmp_path: Path) -> None:
+    """ARTICLE_WRITER_REPO_PATH が存在しない場合に RepositoryNotFoundError が発生."""
+    publisher = _make_publisher(tmp_path / "does-not-exist")
+    with pytest.raises(ArticlePublishRepositoryNotFoundError):
+        await publisher.publish_diary()
+
+
+async def test_publish_diary_claude_binary_missing(tmp_path: Path) -> None:
+    """claude が PATH 上に無い場合に BinaryNotFoundError が発生."""
+    publisher = _make_publisher(tmp_path)
+    with patch("src.services.article_publisher.shutil.which", return_value=None):
+        with pytest.raises(ArticlePublishBinaryNotFoundError):
+            await publisher.publish_diary()
+
+
+async def test_publish_diary_success_reads_result_file(tmp_path: Path) -> None:
+    """終了コード 0 + レスポンスファイル解析成功時、ArticlePublishResult が返る."""
+    _write_result(tmp_path, {
+        "status": "ok",
+        "article_path": "articles/hatena/2026-05-20-diary.md",
+        "draft_url": "https://example.hatenablog.com/entry/2026/05/20/152523",
+        "pr_url": "https://github.com/becky3/article-writer/pull/71",
+        "merged": True,
+        "worktree_removed": True,
+        "worktree_path": None,
+    })
+    publisher = _make_publisher(tmp_path)
+    with patch(
+        "src.services.article_publisher.shutil.which", return_value="/usr/bin/claude",
+    ), patch(
+        "src.services.article_publisher.asyncio.create_subprocess_exec",
+        new=AsyncMock(return_value=_stub_proc(returncode=0)),
+    ):
+        result = await publisher.publish_diary()
+
+    assert isinstance(result, ArticlePublishResult)
+    assert result.status == "ok"
+    assert result.article_path == "articles/hatena/2026-05-20-diary.md"
+    assert result.draft_url == "https://example.hatenablog.com/entry/2026/05/20/152523"
+    assert result.pr_url == "https://github.com/becky3/article-writer/pull/71"
+    assert result.worktree_removed is True
+    assert result.worktree_path is None
+
+
+async def test_publish_diary_passes_expected_args(tmp_path: Path) -> None:
+    """claude -p に '/auto-publish-diary' + --dangerously-skip-permissions が渡される."""
+    _write_result(tmp_path, {"status": "ok"})
+    publisher = _make_publisher(tmp_path)
+    mock_exec = AsyncMock(return_value=_stub_proc(returncode=0))
+    with patch(
+        "src.services.article_publisher.shutil.which", return_value="/usr/bin/claude",
+    ), patch(
+        "src.services.article_publisher.asyncio.create_subprocess_exec", new=mock_exec,
+    ):
+        await publisher.publish_diary()
+
+    args, kwargs = mock_exec.call_args
+    assert args[0] == "/usr/bin/claude"
+    assert "-p" in args
+    assert "/auto-publish-diary" in args
+    assert "--dangerously-skip-permissions" in args
+    assert kwargs["cwd"] == str(tmp_path)
+
+
+async def test_publish_diary_failure_returns_failure(tmp_path: Path) -> None:
+    """終了コード非 0 + レスポンスファイル解析成功時、ArticlePublishFailure が返る."""
+    _write_result(tmp_path, {
+        "status": "error",
+        "failed_phase": "publish",
+        "error": "phase publish failed",
+        "worktree_path": "../article-writer-wt-foo",
+        "merged": False,
+    })
+    publisher = _make_publisher(tmp_path)
+    with patch(
+        "src.services.article_publisher.shutil.which", return_value="/usr/bin/claude",
+    ), patch(
+        "src.services.article_publisher.asyncio.create_subprocess_exec",
+        new=AsyncMock(return_value=_stub_proc(returncode=1)),
+    ):
+        result = await publisher.publish_diary()
+
+    assert isinstance(result, ArticlePublishFailure)
+    assert result.exit_code == 1
+    assert result.raw_json["status"] == "error"
+    assert result.raw_json["worktree_path"] == "../article-writer-wt-foo"
+
+
+async def test_publish_diary_missing_result_file_raises(tmp_path: Path) -> None:
+    """レスポンスファイルが書き出されなかった場合、ResponseFileError が発生する."""
+    publisher = _make_publisher(tmp_path)
+    with patch(
+        "src.services.article_publisher.shutil.which", return_value="/usr/bin/claude",
+    ), patch(
+        "src.services.article_publisher.asyncio.create_subprocess_exec",
+        new=AsyncMock(return_value=_stub_proc(
+            stdout=b"some final response from claude\n", returncode=0,
+        )),
+    ):
+        with pytest.raises(ArticlePublishResponseFileError) as exc_info:
+            await publisher.publish_diary()
+    err = exc_info.value
+    assert "見つかりません" in err.reason
+    assert err.exit_code == 0
+    assert err.result_path == tmp_path / RESULT_FILE_RELATIVE
+    assert "some final response" in err.stdout_tail
+
+
+async def test_publish_diary_invalid_json_raises(tmp_path: Path) -> None:
+    """レスポンスファイルが JSON として不正な場合、ResponseFileError が発生する."""
+    result_path = tmp_path / RESULT_FILE_RELATIVE
+    result_path.parent.mkdir(parents=True, exist_ok=True)
+    result_path.write_text("{not valid json", encoding="utf-8")
+    publisher = _make_publisher(tmp_path)
+    with patch(
+        "src.services.article_publisher.shutil.which", return_value="/usr/bin/claude",
+    ), patch(
+        "src.services.article_publisher.asyncio.create_subprocess_exec",
+        new=AsyncMock(return_value=_stub_proc(returncode=1)),
+    ):
+        with pytest.raises(ArticlePublishResponseFileError) as exc_info:
+            await publisher.publish_diary()
+    err = exc_info.value
+    assert "JSON 解析に失敗" in err.reason
+    assert err.exit_code == 1
+
+
+async def test_publish_diary_non_dict_json_raises(tmp_path: Path) -> None:
+    """レスポンスファイルの JSON が dict でない場合、ResponseFileError が発生する."""
+    result_path = tmp_path / RESULT_FILE_RELATIVE
+    result_path.parent.mkdir(parents=True, exist_ok=True)
+    result_path.write_text('["array", "is", "wrong"]', encoding="utf-8")
+    publisher = _make_publisher(tmp_path)
+    with patch(
+        "src.services.article_publisher.shutil.which", return_value="/usr/bin/claude",
+    ), patch(
+        "src.services.article_publisher.asyncio.create_subprocess_exec",
+        new=AsyncMock(return_value=_stub_proc(returncode=0)),
+    ):
+        with pytest.raises(ArticlePublishResponseFileError) as exc_info:
+            await publisher.publish_diary()
+    assert "dict ではありません" in exc_info.value.reason
+
+
+async def test_publish_diary_timeout_raises(tmp_path: Path) -> None:
+    """タイムアウト時に ArticlePublishTimeoutError が発生し子プロセスが kill される."""
+    proc = AsyncMock()
+    proc.communicate.side_effect = asyncio.TimeoutError()
+    proc.kill = MagicMock()
+    proc.wait = AsyncMock()
+    publisher = _make_publisher(tmp_path, timeout=1)
+    with patch(
+        "src.services.article_publisher.shutil.which", return_value="/usr/bin/claude",
+    ), patch(
+        "src.services.article_publisher.asyncio.create_subprocess_exec",
+        new=AsyncMock(return_value=proc),
+    ):
+        with pytest.raises(ArticlePublishTimeoutError, match="タイムアウト"):
+            await publisher.publish_diary()
+    proc.kill.assert_called_once()
+
+
+async def test_result_path_property_returns_absolute_path(tmp_path: Path) -> None:
+    """result_path プロパティが親リポ + 相対パスの絶対パスを返す."""
+    publisher = _make_publisher(tmp_path)
+    assert publisher.result_path == tmp_path / RESULT_FILE_RELATIVE
+    assert publisher.result_path.is_absolute()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -65,6 +65,9 @@ def test_get_settings_loads_from_env_and_toml(monkeypatch: pytest.MonkeyPatch) -
             "REMOTE_CONTROL_REPOSITORIES",
             "ai-assistant=/path/to/ai-assistant,agent-commons=/path/to/agent-commons",
         )
+        monkeypatch.setenv(
+            "ARTICLE_WRITER_REPO_PATH", "/path/to/article-writer",
+        )
 
     # .env の代わりに git 管理されている .env.example を使用
     get_settings.cache_clear()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -231,3 +231,52 @@ def test_remote_control_repositories_accepts_valid_entries() -> None:
         },
     )
     assert s.get_remote_control_repositories() == {"ai-assistant": abs_path}
+
+
+def test_article_writer_repo_path_accepts_absolute_path() -> None:
+    """ARTICLE_WRITER_REPO_PATH: 絶対パスは受け入れる."""
+    import os
+
+    abs_path = "C:/abs/article-writer" if os.name == "nt" else "/abs/article-writer"
+    s = Settings(
+        **{
+            **TEST_SETTINGS_DEFAULTS,
+            "article_writer_repo_path": abs_path,
+        },
+    )
+    assert s.article_writer_repo_path == abs_path
+
+
+def test_article_writer_repo_path_accepts_empty_for_disable() -> None:
+    """ARTICLE_WRITER_REPO_PATH: 空文字は機能無効として受け入れる."""
+    s = Settings(
+        **{
+            **TEST_SETTINGS_DEFAULTS,
+            "article_writer_repo_path": "",
+        },
+    )
+    assert s.article_writer_repo_path == ""
+
+
+def test_article_writer_repo_path_normalizes_whitespace_to_empty() -> None:
+    """ARTICLE_WRITER_REPO_PATH: 空白のみの値は空文字に正規化される."""
+    s = Settings(
+        **{
+            **TEST_SETTINGS_DEFAULTS,
+            "article_writer_repo_path": "   ",
+        },
+    )
+    assert s.article_writer_repo_path == ""
+
+
+def test_article_writer_repo_path_rejects_relative_path() -> None:
+    """ARTICLE_WRITER_REPO_PATH: 相対パスは ValueError で拒否される（4 段防御のうち層 4）."""
+    import pydantic
+
+    with pytest.raises(pydantic.ValidationError, match="絶対パス"):
+        Settings(
+            **{
+                **TEST_SETTINGS_DEFAULTS,
+                "article_writer_repo_path": "../article-writer",
+            },
+        )

--- a/tests/test_db.py
+++ b/tests/test_db.py
@@ -76,6 +76,9 @@ async def test_init_db_and_get_session(monkeypatch: pytest.MonkeyPatch) -> None:
             "REMOTE_CONTROL_REPOSITORIES",
             "ai-assistant=/path/to/ai-assistant,agent-commons=/path/to/agent-commons",
         )
+        monkeypatch.setenv(
+            "ARTICLE_WRITER_REPO_PATH", "/path/to/article-writer",
+        )
     monkeypatch.setattr(
         _EnvLoader, "model_config",
         {**_EnvLoader.model_config, "env_file": ".env.example"},

--- a/tests/test_message_router.py
+++ b/tests/test_message_router.py
@@ -77,6 +77,7 @@ def _make_router(
     slack_client: AsyncMock | None = None,
     remote_control_launcher: object | None = None,
     remote_control_allowed_users: list[str] | None = None,
+    article_writer_publisher: object | None = None,
 ) -> tuple[MockAdapter, MessageRouter]:
     if adapter is None:
         adapter = MockAdapter()
@@ -104,6 +105,7 @@ def _make_router(
         rag_zenn_max_articles=10,
         remote_control_launcher=remote_control_launcher,  # type: ignore[arg-type]
         remote_control_allowed_users=remote_control_allowed_users or [],
+        article_writer_publisher=article_writer_publisher,  # type: ignore[arg-type]
     )
     return adapter, router
 
@@ -761,3 +763,281 @@ async def test_rc_command_url_timeout_reports_log_filename_only() -> None:
     text = adapter.sent_messages[0][0]
     assert "タイムアウト" in text
     assert "slack-foo-1.log" in text
+
+
+# --- article コマンドルーティングテスト (#841) ---
+
+
+def _make_article_publisher(
+    publish_result: object | None = None,
+    publish_exception: BaseException | None = None,
+    timeout: int = 60,
+) -> AsyncMock:
+    """ArticleWriterPublisher のモックを返す."""
+    publisher = AsyncMock()
+    publisher.timeout = timeout
+    if publish_exception is not None:
+        publisher.publish_diary.side_effect = publish_exception
+    else:
+        publisher.publish_diary.return_value = publish_result
+    return publisher
+
+
+async def test_article_command_disabled_returns_explicit_error() -> None:
+    """publisher が None の場合、fail-closed で機能無効メッセージを返し chat にフォールスルーしない."""
+    chat_service = AsyncMock()
+    chat_service.respond.return_value = "通常応答"
+    adapter, router = _make_router(
+        chat_service=chat_service,
+        article_writer_publisher=None,
+        remote_control_allowed_users=["U_AUTHORIZED"],
+    )
+
+    await router.process_message(
+        _make_msg("article write-hatena", user_id="U_AUTHORIZED"),
+    )
+
+    assert len(adapter.sent_messages) == 1
+    assert "記事自動投稿機能は現在無効です" in adapter.sent_messages[0][0]
+    chat_service.respond.assert_not_awaited()
+
+
+async def test_article_command_denied_for_unauthorized_user() -> None:
+    """認可ユーザー allowlist にない user_id からは権限拒否される."""
+    publisher = _make_article_publisher()
+    adapter, router = _make_router(
+        article_writer_publisher=publisher,
+        remote_control_allowed_users=["U_AUTHORIZED"],
+    )
+
+    await router.process_message(
+        _make_msg("article write-hatena", user_id="U_OTHER"),
+    )
+
+    assert len(adapter.sent_messages) == 1
+    assert "権限がありません" in adapter.sent_messages[0][0]
+    publisher.publish_diary.assert_not_called()
+
+
+async def test_article_command_missing_subcommand_returns_usage() -> None:
+    """article のみで subcommand が無い場合、使用方法を返す."""
+    publisher = _make_article_publisher()
+    adapter, router = _make_router(
+        article_writer_publisher=publisher,
+        remote_control_allowed_users=["U_AUTHORIZED"],
+    )
+
+    await router.process_message(_make_msg("article", user_id="U_AUTHORIZED"))
+
+    assert len(adapter.sent_messages) == 1
+    assert "使用方法" in adapter.sent_messages[0][0]
+    assert "write-hatena" in adapter.sent_messages[0][0]
+    publisher.publish_diary.assert_not_called()
+
+
+async def test_article_command_unknown_subcommand_returns_usage() -> None:
+    """article 直下に write-hatena 以外を指定した場合、使用方法を返す."""
+    publisher = _make_article_publisher()
+    adapter, router = _make_router(
+        article_writer_publisher=publisher,
+        remote_control_allowed_users=["U_AUTHORIZED"],
+    )
+
+    await router.process_message(
+        _make_msg("article write-zenn", user_id="U_AUTHORIZED"),
+    )
+
+    assert len(adapter.sent_messages) == 1
+    assert "使用方法" in adapter.sent_messages[0][0]
+    publisher.publish_diary.assert_not_called()
+
+
+async def test_article_write_hatena_success_message() -> None:
+    """正常系: 成功時に開始メッセージ + 完了メッセージが順に送信される."""
+    from src.services.article_publisher import ArticlePublishResult
+
+    publisher = _make_article_publisher(
+        publish_result=ArticlePublishResult(
+            status="ok",
+            article_path="articles/hatena/2026-02-10-diary.md",
+            draft_url="https://example.hatenablog.com/entry/2026/05/20/152523",
+            pr_url="https://github.com/becky3/article-writer/pull/71",
+            worktree_removed=True,
+            worktree_path=None,
+        ),
+    )
+    adapter, router = _make_router(
+        article_writer_publisher=publisher,
+        remote_control_allowed_users=["U_AUTHORIZED"],
+    )
+
+    await router.process_message(
+        _make_msg("article write-hatena", user_id="U_AUTHORIZED"),
+    )
+
+    assert len(adapter.sent_messages) == 2
+    assert "開始します" in adapter.sent_messages[0][0]
+    success_msg = adapter.sent_messages[1][0]
+    assert "成功しました" in success_msg
+    assert "articles/hatena/2026-02-10-diary.md" in success_msg
+    assert "https://example.hatenablog.com" in success_msg
+    assert "https://github.com/becky3/article-writer/pull/71" in success_msg
+
+
+async def test_article_write_hatena_success_with_cleanup_failure() -> None:
+    """成功 + worktree 削除失敗（status=ok, worktree_removed=False）時、残置 worktree を Slack 通知する."""
+    from src.services.article_publisher import ArticlePublishResult
+
+    publisher = _make_article_publisher(
+        publish_result=ArticlePublishResult(
+            status="ok",
+            article_path="articles/hatena/2026-05-20-diary.md",
+            draft_url="https://example.hatenablog.com/entry/2026/05/20/152523",
+            pr_url="https://github.com/becky3/article-writer/pull/71",
+            worktree_removed=False,
+            worktree_path="D:/GitHub/becky3/article-writer-wt-auto-20260520",
+        ),
+    )
+    adapter, router = _make_router(
+        article_writer_publisher=publisher,
+        remote_control_allowed_users=["U_AUTHORIZED"],
+    )
+
+    await router.process_message(
+        _make_msg("article write-hatena", user_id="U_AUTHORIZED"),
+    )
+
+    assert len(adapter.sent_messages) == 2
+    success_msg = adapter.sent_messages[1][0]
+    assert "成功しました（worktree 削除のみ失敗）" in success_msg
+    assert "残置 worktree: article-writer-wt-auto-20260520" in success_msg
+
+
+async def test_article_write_hatena_failure_includes_worktree_path() -> None:
+    """exit_code 非 0 + JSON 解析成功時、残置 worktree パスをメッセージに含める."""
+    from src.services.article_publisher import ArticlePublishFailure
+
+    publisher = _make_article_publisher(
+        publish_result=ArticlePublishFailure(
+            exit_code=1,
+            raw_json={
+                "status": "error",
+                "failed_phase": "git",
+                "error": "phase 3 failed",
+                "worktree_path": "../article-writer-wt-diary-20260520",
+                "merged": False,
+                "worktree_removed": False,
+            },
+        ),
+    )
+    adapter, router = _make_router(
+        article_writer_publisher=publisher,
+        remote_control_allowed_users=["U_AUTHORIZED"],
+    )
+
+    await router.process_message(
+        _make_msg("article write-hatena", user_id="U_AUTHORIZED"),
+    )
+
+    assert len(adapter.sent_messages) == 2
+    failure_msg = adapter.sent_messages[1][0]
+    assert "失敗" in failure_msg
+    assert "exit code: 1" in failure_msg
+    assert "失敗 Phase: git" in failure_msg
+    assert "phase 3 failed" in failure_msg
+    assert "../article-writer-wt-diary-20260520" in failure_msg
+
+
+async def test_article_write_hatena_timeout_includes_minutes() -> None:
+    """タイムアウト時にタイムアウト分数と worktree 残置の可能性を通知する."""
+    from src.services.article_publisher import ArticlePublishTimeoutError
+
+    publisher = _make_article_publisher(
+        publish_exception=ArticlePublishTimeoutError("timeout"),
+        timeout=1200,  # 20 分
+    )
+    adapter, router = _make_router(
+        article_writer_publisher=publisher,
+        remote_control_allowed_users=["U_AUTHORIZED"],
+    )
+
+    await router.process_message(
+        _make_msg("article write-hatena", user_id="U_AUTHORIZED"),
+    )
+
+    assert len(adapter.sent_messages) == 2
+    timeout_msg = adapter.sent_messages[1][0]
+    assert "タイムアウト" in timeout_msg
+    assert "20分" in timeout_msg
+    assert "worktree" in timeout_msg
+
+
+async def test_article_write_hatena_response_file_error_uses_spec_format() -> None:
+    """ArticlePublishResponseFileError 時、仕様書の「実行結果の解析失敗時」出力フォーマットで通知する."""
+    from pathlib import Path
+
+    from src.services.article_publisher import ArticlePublishResponseFileError
+
+    publisher = _make_article_publisher(
+        publish_exception=ArticlePublishResponseFileError(
+            reason="レスポンスファイルが見つかりません: .tmp/auto-publish-diary/result.json",
+            exit_code=0,
+            stdout_tail="some final claude response\nmore output",
+            result_path=Path("D:/GitHub/becky3/article-writer/.tmp/auto-publish-diary/result.json"),
+        ),
+    )
+    adapter, router = _make_router(
+        article_writer_publisher=publisher,
+        remote_control_allowed_users=["U_AUTHORIZED"],
+    )
+
+    await router.process_message(
+        _make_msg("article write-hatena", user_id="U_AUTHORIZED"),
+    )
+
+    assert len(adapter.sent_messages) == 2
+    msg = adapter.sent_messages[1][0]
+    assert msg.startswith("❌ 日記の自動投稿に失敗しました（実行結果の解析に失敗）")
+    assert "理由: レスポンスファイルが見つかりません" in msg
+    assert "exit code: 0" in msg
+    assert "stdout 末尾:" in msg
+    assert "some final claude response" in msg
+
+
+async def test_article_write_hatena_absolute_worktree_path_shows_basename_only() -> None:
+    """worktree_path が絶対パスの場合、Slack 通知には末尾セグメントのみ含める（情報露出防止）."""
+    from src.services.article_publisher import ArticlePublishFailure
+
+    for absolute_path, expected_basename in [
+        ("C:/foo/bar/article-writer-wt-diary-20260520", "article-writer-wt-diary-20260520"),
+        ("/abs/path/to/article-writer-wt-x", "article-writer-wt-x"),
+        ("C:\\foo\\bar\\article-writer-wt-y", "article-writer-wt-y"),
+    ]:
+        publisher = _make_article_publisher(
+            publish_result=ArticlePublishFailure(
+                exit_code=1,
+                raw_json={
+                    "status": "error",
+                    "failed_phase": "publish",
+                    "error": "phase failed",
+                    "worktree_path": absolute_path,
+                    "merged": False,
+                    "worktree_removed": False,
+                },
+            ),
+        )
+        adapter, router = _make_router(
+            article_writer_publisher=publisher,
+            remote_control_allowed_users=["U_AUTHORIZED"],
+        )
+
+        await router.process_message(
+            _make_msg("article write-hatena", user_id="U_AUTHORIZED"),
+        )
+
+        failure_msg = adapter.sent_messages[1][0]
+        assert expected_basename in failure_msg, f"Failed for: {absolute_path}"
+        # 絶対パスの親ディレクトリが漏れていないこと
+        assert "/foo/bar/" not in failure_msg, f"Leaked path for: {absolute_path}"
+        assert "\\foo\\bar\\" not in failure_msg, f"Leaked path for: {absolute_path}"
+        assert "/abs/path/to/" not in failure_msg, f"Leaked path for: {absolute_path}"

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -593,6 +593,7 @@ async def test_manual_deliver_command_passes_layout_from_router() -> None:
         rag_zenn_max_articles=10,
         remote_control_launcher=None,
         remote_control_allowed_users=[],
+        article_writer_publisher=None,
     )
 
     msg = IncomingMessage(


### PR DESCRIPTION
## Change type

- [x] feat: 新機能実装 ★
- [x] docs(pre-impl): 設計書先行更新（先行 commit 86dffb8 で article-publishing.md を新規作成）

## Summary

- Slack コマンド `@bot article write-hatena` を新設し、article-writer 側 `/auto-publish-diary` スキルを `claude -p` 経由で起動して結果を Slack に通知する受信ハンドラを実装
- `ArticleWriterPublisher` サービス層を新規追加。article-writer 親リポ直下の `.tmp/auto-publish-diary/result.json` をレスポンスファイルとして読む方式（article-writer #76 マージ後のスキーマに準拠）
- 認可ユーザーは既存 `REMOTE_CONTROL_ALLOWED_USERS` を流用（env を増やさない）
- 新規 env `ARTICLE_WRITER_REPO_PATH`（pydantic `field_validator` で絶対パスのみ許容）
- `claude -p` は `--dangerously-skip-permissions` 起動。緩和策として 4 段防御（allowlist / `cwd` 固定 / スキル名固定 / `Path.is_absolute()` 検証）
- 新規仕様書 `docs/specs/features/article-publishing.md` を先行 commit `docs(pre-impl)` で追加

## Test plan

- [x] pytest 420 件 PASS（新規 28 件: ArticleWriterPublisher 10 件 + router 14 件 + settings field_validator 4 件）
- [x] ruff / mypy / markdownlint clean
- [x] code-reviewer / doc-reviewer 実施・要修正全件対応済（triage 経由で要相談 7 件も確定済）
- [x] 実機 QA 通過（@bot article write-hatena → 記事生成 → Hatena 下書き登録 → PR マージ → result.json 解析 → Slack 通知。所要 10:43）

## Related issues

Closes #841

依存: article-writer #76（出力契約をレスポンスファイル方式に変更）— マージ済。本 PR の `ArticleWriterPublisher` は #76 の result.json スキーマに準拠する