### PR TITLE
fix(article-publishing): Slack レスポンス URL を編集ページ URL + 公開 URL に追従 (article-writer#223)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ RSS記事の自動収集・要約配信、チャットでの質問応答を行�
 | **Botプロセスガード** | PIDファイルによるプロセス管理で、多重起動の防止・グレースフルシャットダウン・子プロセスのクリーンアップを行う |
 | **Remote Control 起動** | Slack コマンド (`@bot rc start <repo-key>`) でホスト PC 上の指定リポジトリで `claude remote-control` を起動し、claude.ai/code 接続 URL を返す。外出先のスマホから PC 操作なしで Claude Code セッションを開始できる。許可ユーザーと対象リポジトリの allowlist 設定が必要 |
 | **ログ出力** | 全 handler・主要サービスにタイミングログを付与し、所要時間・実行段階の事後追跡を可能にする |
-| **記事自動投稿** | Slack コマンド (`@bot article write-hatena`) または Slack reminder からホスト PC 上の article-writer リポジトリで `/auto-publish-diary` スキルを起動し、Hatena への日記下書き登録・PR 作成・マージまでを無人実行。結果（下書き URL・PR URL）を Slack に通知する |
+| **記事自動投稿** | Slack コマンド (`@bot article write-hatena`) または Slack reminder からホスト PC 上の article-writer リポジトリで `/auto-publish-diary` スキルを起動し、Hatena への日記下書き登録・PR 作成・マージまでを無人実行。結果（下書き編集 URL・公開 URL・PR URL）を Slack に通知する |
 
 全機能の一覧と仕様書リンクは [全体仕様概要](docs/specs/overview.md) を参照。
 

--- a/docs/specs/features/article-publishing.md
+++ b/docs/specs/features/article-publishing.md
@@ -3,7 +3,7 @@
 ## 概要
 
 Slack コマンドにより、ホスト PC 上の article-writer リポジトリで `claude -p '/auto-publish-diary'` を起動し、日記記事の生成 → Hatena 下書き登録 → PR 作成 → 即マージ → worktree クリーンアップまでを無人実行する機能。
-実行結果（成功時の下書き URL・PR URL、失敗時の残置 worktree パス）を Slack に通知する。
+実行結果（成功時の下書き編集 URL・公開 URL・PR URL、失敗時の残置 worktree パス）を Slack に通知する。
 
 主用途は Slack reminder からの定時自動投稿。手動運用負荷を下げ、日記投稿の安定継続を実現する。
 
@@ -63,7 +63,7 @@ Slack コマンドにより、ホスト PC 上の article-writer リポジトリ
 6. `claude -p '/auto-publish-diary' --dangerously-skip-permissions --output-format text` を `cwd=ARTICLE_WRITER_REPO_PATH` で起動する。stdout / stderr を捕捉し、終了コードを取得する
 7. プロセスがタイムアウト時間内に終了しない場合は kill し、タイムアウトエラーを Slack に返す
 8. 親リポ直下のレスポンスファイル `<ARTICLE_WRITER_REPO_PATH>/.tmp/auto-publish-diary/result.json` を読み込み、JSON としてパースする。ファイル不在・読み取り失敗・JSON 解析失敗・dict 以外の値の場合は実行結果解析エラーを Slack に返す
-9. 終了コードが 0 + JSON 解析成功の場合は結果フィールド（`status` / `article_path` / `draft_url` / `pr_url` / `worktree_removed` / `worktree_path`）を Slack 通知に整形する
+9. 終了コードが 0 + JSON 解析成功の場合は結果フィールド（`status` / `article_path` / `edit_url` / `public_url` / `pr_url` / `worktree_removed` / `worktree_path`）を Slack 通知に整形する
 10. 終了コードが非 0 + JSON 解析成功の場合は失敗結果として Slack に返す。失敗時の JSON に `worktree_path` が含まれる場合は併せて通知する
 
 ステップ 4・5 が処理開始メッセージの後にあるのは、ホスト固有の前提（ディレクトリ実在・`claude` 実行ファイル PATH 解決）の検証を `ArticleWriterPublisher` サービス層に集約し、router 側を薄く保つ設計上の判断による。構成エラー時は「開始」「失敗」の 2 メッセージがユーザーに届くが、処理は正しく中断される。
@@ -75,7 +75,8 @@ Slack コマンドにより、ホスト PC 上の article-writer リポジトリ
 ```
 ✅ 日記の自動投稿に成功しました
 記事: articles/hatena/2026-05-20-diary.md
-下書き: https://example.hatenablog.com/entry/2026/05/20/152523
+下書き編集: https://blog.hatena.ne.jp/example/example.hatenablog.com/edit?entry=1234567890
+公開URL: https://example.hatenablog.com/entry/2026/05/20/000000
 PR: https://github.com/becky3/article-writer/pull/71
 ```
 
@@ -84,7 +85,8 @@ PR: https://github.com/becky3/article-writer/pull/71
 ```
 ✅ 日記の自動投稿に成功しました（worktree 削除のみ失敗）
 記事: articles/hatena/2026-05-20-diary.md
-下書き: https://example.hatenablog.com/entry/2026/05/20/152523
+下書き編集: https://blog.hatena.ne.jp/example/example.hatenablog.com/edit?entry=1234567890
+公開URL: https://example.hatenablog.com/entry/2026/05/20/000000
 PR: https://github.com/becky3/article-writer/pull/71
 残置 worktree: article-writer-wt-auto-20260520
 ```

--- a/src/messaging/router.py
+++ b/src/messaging/router.py
@@ -1326,8 +1326,10 @@ def _format_article_success(result: ArticlePublishResult) -> str:
     lines = [header]
     if result.article_path:
         lines.append(f"記事: {result.article_path}")
-    if result.draft_url:
-        lines.append(f"下書き: {result.draft_url}")
+    if result.edit_url:
+        lines.append(f"下書き編集: {result.edit_url}")
+    if result.public_url:
+        lines.append(f"公開URL: {result.public_url}")
     if result.pr_url:
         lines.append(f"PR: {result.pr_url}")
     if result.status and result.status != "ok":

--- a/src/services/article_publisher.py
+++ b/src/services/article_publisher.py
@@ -67,7 +67,8 @@ class ArticlePublishResult:
 
     status: str
     article_path: str | None
-    draft_url: str | None
+    edit_url: str | None
+    public_url: str | None
     pr_url: str | None
     worktree_removed: bool
     worktree_path: str | None
@@ -228,14 +229,15 @@ class ArticleWriterPublisher:
         result = ArticlePublishResult(
             status=str(payload.get("status", "")),
             article_path=_optional_str(payload.get("article_path")),
-            draft_url=_optional_str(payload.get("draft_url")),
+            edit_url=_optional_str(payload.get("edit_url")),
+            public_url=_optional_str(payload.get("public_url")),
             pr_url=_optional_str(payload.get("pr_url")),
             worktree_removed=bool(payload.get("worktree_removed", False)),
             worktree_path=_optional_str(payload.get("worktree_path")),
         )
         logger.info(
-            "article_publish complete: status=%s, draft_url=%s, pr_url=%s",
-            result.status, result.draft_url, result.pr_url,
+            "article_publish complete: status=%s, edit_url=%s, public_url=%s, pr_url=%s",
+            result.status, result.edit_url, result.public_url, result.pr_url,
         )
         return result
 

--- a/tests/test_article_publisher.py
+++ b/tests/test_article_publisher.py
@@ -85,7 +85,8 @@ async def test_publish_diary_success_reads_result_file(tmp_path: Path) -> None:
     payload = json.dumps({
         "status": "ok",
         "article_path": "articles/hatena/2026-05-20-diary.md",
-        "draft_url": "https://example.hatenablog.com/entry/2026/05/20/152523",
+        "edit_url": "https://blog.hatena.ne.jp/example/example.hatenablog.com/edit?entry=1234567890",
+        "public_url": "https://example.hatenablog.com/entry/2026/05/20/000000",
         "pr_url": "https://github.com/becky3/article-writer/pull/71",
         "merged": True,
         "worktree_removed": True,
@@ -103,7 +104,8 @@ async def test_publish_diary_success_reads_result_file(tmp_path: Path) -> None:
     assert isinstance(result, ArticlePublishResult)
     assert result.status == "ok"
     assert result.article_path == "articles/hatena/2026-05-20-diary.md"
-    assert result.draft_url == "https://example.hatenablog.com/entry/2026/05/20/152523"
+    assert result.edit_url == "https://blog.hatena.ne.jp/example/example.hatenablog.com/edit?entry=1234567890"
+    assert result.public_url == "https://example.hatenablog.com/entry/2026/05/20/000000"
     assert result.pr_url == "https://github.com/becky3/article-writer/pull/71"
     assert result.worktree_removed is True
     assert result.worktree_path is None

--- a/tests/test_message_router.py
+++ b/tests/test_message_router.py
@@ -881,7 +881,11 @@ async def test_article_write_hatena_success_message() -> None:
     success_msg = adapter.sent_messages[1][0]
     assert "成功しました" in success_msg
     assert "articles/hatena/2026-02-10-diary.md" in success_msg
-    assert "https://example.hatenablog.com" in success_msg
+    assert (
+        "下書き編集: https://blog.hatena.ne.jp/example/example.hatenablog.com/edit?entry=1234567890"
+        in success_msg
+    )
+    assert "公開URL: https://example.hatenablog.com/entry/2026/05/20/000000" in success_msg
     assert "https://github.com/becky3/article-writer/pull/71" in success_msg
 
 
@@ -912,6 +916,11 @@ async def test_article_write_hatena_success_with_cleanup_failure() -> None:
     assert len(adapter.sent_messages) == 2
     success_msg = adapter.sent_messages[1][0]
     assert "成功しました（worktree 削除のみ失敗）" in success_msg
+    assert (
+        "下書き編集: https://blog.hatena.ne.jp/example/example.hatenablog.com/edit?entry=1234567890"
+        in success_msg
+    )
+    assert "公開URL: https://example.hatenablog.com/entry/2026/05/20/000000" in success_msg
     assert "残置 worktree: article-writer-wt-auto-20260520" in success_msg
 
 

--- a/tests/test_message_router.py
+++ b/tests/test_message_router.py
@@ -860,7 +860,8 @@ async def test_article_write_hatena_success_message() -> None:
         publish_result=ArticlePublishResult(
             status="ok",
             article_path="articles/hatena/2026-02-10-diary.md",
-            draft_url="https://example.hatenablog.com/entry/2026/05/20/152523",
+            edit_url="https://blog.hatena.ne.jp/example/example.hatenablog.com/edit?entry=1234567890",
+            public_url="https://example.hatenablog.com/entry/2026/05/20/000000",
             pr_url="https://github.com/becky3/article-writer/pull/71",
             worktree_removed=True,
             worktree_path=None,
@@ -892,7 +893,8 @@ async def test_article_write_hatena_success_with_cleanup_failure() -> None:
         publish_result=ArticlePublishResult(
             status="ok",
             article_path="articles/hatena/2026-05-20-diary.md",
-            draft_url="https://example.hatenablog.com/entry/2026/05/20/152523",
+            edit_url="https://blog.hatena.ne.jp/example/example.hatenablog.com/edit?entry=1234567890",
+            public_url="https://example.hatenablog.com/entry/2026/05/20/000000",
             pr_url="https://github.com/becky3/article-writer/pull/71",
             worktree_removed=False,
             worktree_path="D:/GitHub/becky3/article-writer-wt-auto-20260520",


### PR DESCRIPTION
## Change type

- [x] fix（連携追従）

## Summary

article-writer #223 で auto-publish-diary の result.json スキーマが `draft_url` → `edit_url` + `public_url` に変わったことへの、消費者 ai-assistant 側の追従。

`draft_url` は POST 時刻ベースで実際の公開 URL と不一致・下書き中は 404 だったため、article-writer 側で編集ページ URL（下書きでもアクセス可）と公開 URL に分離された。本 PR はその新フィールドを読み、Slack 通知の表示を追従させる。

- `ArticlePublishResult`: `draft_url` → `edit_url` + `public_url`（`payload.get` で欠落耐性を維持）
- `_format_article_success`: `下書き編集:` + `公開URL:` の 2 行表示に
- spec（概要・ステップ 9・出力例）・README を新スキーマに整合
- tests を新フィールドに追従

## Test plan

- [x] pytest 全 421 件パス
- [x] ruff・mypy clean
- [x] markdownlint 0 error

## Related issues

Relates to becky3/article-writer#223（result.json 契約の SSoT は article-writer 側。本 PR は消費者側の追従）