### PR TITLE
fix(article-publishing): status=error 時の Slack 通知を汎用エラー表示に修正 (#848)

### DIFF
--- a/docs/specs/features/article-publishing.md
+++ b/docs/specs/features/article-publishing.md
@@ -63,7 +63,9 @@ Slack コマンドにより、ホスト PC 上の article-writer リポジトリ
 6. `claude -p '/auto-publish-diary' --dangerously-skip-permissions --output-format text` を `cwd=ARTICLE_WRITER_REPO_PATH` で起動する。stdout / stderr を捕捉し、終了コードを取得する
 7. プロセスがタイムアウト時間内に終了しない場合は kill し、タイムアウトエラーを Slack に返す
 8. 親リポ直下のレスポンスファイル `<ARTICLE_WRITER_REPO_PATH>/.tmp/auto-publish-diary/result.json` を読み込み、JSON としてパースする。ファイル不在・読み取り失敗・JSON 解析失敗・dict 以外の値の場合は実行結果解析エラーを Slack に返す
-9. 終了コードが 0 + JSON 解析成功の場合は結果フィールド（`status` / `article_path` / `edit_url` / `public_url` / `pr_url` / `worktree_removed` / `worktree_path`）を Slack 通知に整形する
+9. 終了コードが 0 + JSON 解析成功の場合は結果フィールド（`status` / `article_path` / `edit_url` / `public_url` / `pr_url` / `worktree_removed` / `worktree_path` / `error` / `failed_phase`）を Slack 通知に整形する。
+   `status` 値の判定は文字列 `"error"` と完全一致する場合のみ汎用エラー表示（ヘッダー + `failed_phase` + `error` + `worktree_path`）に分岐する。
+   `"ok"` / `"error"` 以外の値は article-writer 側で将来追加される可能性があるが、本リポでは追従改修を避けるため成功経路で `status` フィールドの値を `result.json` のまま表示する
 10. 終了コードが非 0 + JSON 解析成功の場合は失敗結果として Slack に返す。失敗時の JSON に `worktree_path` が含まれる場合は併せて通知する
 
 ステップ 4・5 が処理開始メッセージの後にあるのは、ホスト固有の前提（ディレクトリ実在・`claude` 実行ファイル PATH 解決）の検証を `ArticleWriterPublisher` サービス層に集約し、router 側を薄く保つ設計上の判断による。構成エラー時は「開始」「失敗」の 2 メッセージがユーザーに届くが、処理は正しく中断される。
@@ -118,6 +120,19 @@ exit code: {終了コード}
 理由: {error フィールド}
 残置 worktree: {worktree_path}
 ```
+
+失敗時（終了コード 0、`status="error"`、レスポンスファイル解析成功）:
+
+```
+❌ 日記の自動投稿に失敗しました
+失敗 Phase: {failed_phase}
+理由: {error フィールド}
+残置 worktree: {worktree_path}
+```
+
+`status="error"` 経路では `exit code` 行を出さない。
+article-writer 側で個別現象（マージ失敗・push 失敗等）ごとにエラー文言・分類が追加・変更されても、本リポは `error` / `failed_phase` をそのまま表示する汎用設計のため追従改修を不要とする（疎結合化）。
+`error` / `failed_phase` / `worktree_path` のいずれも欠落していた場合はヘッダーのみを返す（degrade 設計、article-writer 側のフィールド省略にもクラッシュせず最低限の通知を出す）。
 
 実行結果の解析失敗時（レスポンスファイル不在・JSON 解析失敗等）:
 

--- a/src/messaging/router.py
+++ b/src/messaging/router.py
@@ -1300,7 +1300,7 @@ class MessageRouter:
         if isinstance(outcome, ArticlePublishFailure):
             response = _format_article_failure(outcome)
         else:
-            response = _format_article_success(outcome)
+            response = _format_article_result(outcome)
 
         await self._messaging.send_message(response, thread_id, channel)
         logger.info(
@@ -1316,8 +1316,21 @@ def _build_article_usage() -> str:
     )
 
 
-def _format_article_success(result: ArticlePublishResult) -> str:
-    """成功時の Slack メッセージを組み立てる."""
+def _format_article_result(result: ArticlePublishResult) -> str:
+    """`ArticlePublishResult` を Slack メッセージに整形する.
+
+    `result.status == "error"` の場合は終了コードが 0 でも実態は失敗のため汎用エラー表示に分岐し、
+    それ以外は成功表示（worktree 削除のみ失敗のサブパターン含む）を返すディスパッチャ。
+    article-writer 側でエラー文言・分類を追加・変更しても本リポの追従改修が不要になる疎結合化の実装。
+    """
+    if result.status == "error":
+        return _format_article_failure_message(
+            exit_code=None,
+            failed_phase=result.failed_phase,
+            error=result.error,
+            worktree_path=result.worktree_path,
+        )
+
     header = (
         "✅ 日記の自動投稿に成功しました"
         if result.worktree_removed
@@ -1349,23 +1362,43 @@ def _format_article_response_file_error(err: ArticlePublishResponseFileError) ->
     )
 
 
-def _format_article_failure(failure: ArticlePublishFailure) -> str:
-    """失敗時の Slack メッセージを組み立てる（article-writer の result.json スキーマ準拠）."""
-    raw = failure.raw_json
-    lines = [
-        "❌ 日記の自動投稿に失敗しました",
-        f"exit code: {failure.exit_code}",
-    ]
-    failed_phase = raw.get("failed_phase")
-    if isinstance(failed_phase, str) and failed_phase:
+def _format_article_failure_message(
+    *,
+    exit_code: int | None,
+    failed_phase: str | None,
+    error: str | None,
+    worktree_path: str | None,
+) -> str:
+    """失敗時の Slack メッセージを組み立てる共通ロジック.
+
+    exit_code=非0 (ArticlePublishFailure 経由) と status=error + exit_code=0
+    (ArticlePublishResult 経由) の両方から呼び出される。
+    exit_code が None の場合は exit code 行を省略する（status=error 経路向け）。
+    """
+    lines = ["❌ 日記の自動投稿に失敗しました"]
+    if exit_code is not None:
+        lines.append(f"exit code: {exit_code}")
+    if failed_phase:
         lines.append(f"失敗 Phase: {failed_phase}")
-    error_text = raw.get("error")
-    if isinstance(error_text, str) and error_text:
-        lines.append(f"理由: {error_text}")
-    worktree_path = raw.get("worktree_path")
-    if isinstance(worktree_path, str) and worktree_path:
+    if error:
+        lines.append(f"理由: {error}")
+    if worktree_path:
         lines.append(f"残置 worktree: {_safe_worktree_label(worktree_path)}")
     return "\n".join(lines)
+
+
+def _format_article_failure(failure: ArticlePublishFailure) -> str:
+    """終了コード非 0 + JSON 解析成功時の Slack メッセージ."""
+    raw = failure.raw_json
+    failed_phase = raw.get("failed_phase")
+    error_text = raw.get("error")
+    worktree_path = raw.get("worktree_path")
+    return _format_article_failure_message(
+        exit_code=failure.exit_code,
+        failed_phase=failed_phase if isinstance(failed_phase, str) and failed_phase else None,
+        error=error_text if isinstance(error_text, str) and error_text else None,
+        worktree_path=worktree_path if isinstance(worktree_path, str) and worktree_path else None,
+    )
 
 
 def _safe_worktree_label(worktree_path: str) -> str:

--- a/src/services/article_publisher.py
+++ b/src/services/article_publisher.py
@@ -63,7 +63,12 @@ class ArticlePublishResponseFileError(ArticlePublishError):
 
 @dataclass(frozen=True)
 class ArticlePublishResult:
-    """起動成功時の結果（result.json のうち本機能が依存するフィールド）."""
+    """起動成功時の結果（result.json のうち本機能が依存するフィールド）.
+
+    `status` は通常 "ok"。`status="error"` の場合は終了コードが 0 でも実態は失敗で、
+    `error` / `failed_phase` フィールドにエラー情報が入る（article-writer 側の result.json 契約）。
+    本機能はこれらのフィールドを保持し、表示側で `status="error"` を検出して汎用エラー表示に分岐する。
+    """
 
     status: str
     article_path: str | None
@@ -72,6 +77,8 @@ class ArticlePublishResult:
     pr_url: str | None
     worktree_removed: bool
     worktree_path: str | None
+    error: str | None = None
+    failed_phase: str | None = None
 
 
 @dataclass(frozen=True)
@@ -234,6 +241,8 @@ class ArticleWriterPublisher:
             pr_url=_optional_str(payload.get("pr_url")),
             worktree_removed=bool(payload.get("worktree_removed", False)),
             worktree_path=_optional_str(payload.get("worktree_path")),
+            error=_optional_str(payload.get("error")),
+            failed_phase=_optional_str(payload.get("failed_phase")),
         )
         logger.info(
             "article_publish complete: status=%s, edit_url=%s, public_url=%s, pr_url=%s",

--- a/tests/test_article_publisher.py
+++ b/tests/test_article_publisher.py
@@ -137,7 +137,7 @@ async def test_publish_diary_status_error_with_zero_exit_returns_result(tmp_path
 
     article-writer 側が exit_code=0 で status=error を返すケース（例: cleanup phase の失敗）でも、
     本リポは ArticlePublishResult として受け取り、error / failed_phase を表示側に渡せるようにする。
-    表示側 (_format_article_success) が status="error" を検出して汎用エラー表示に分岐する。
+    表示側 (_format_article_result) が status="error" を検出して汎用エラー表示に分岐する。
     """
     payload = json.dumps({
         "status": "error",

--- a/tests/test_article_publisher.py
+++ b/tests/test_article_publisher.py
@@ -132,6 +132,38 @@ async def test_publish_diary_passes_expected_args(tmp_path: Path) -> None:
     assert kwargs["cwd"] == str(tmp_path)
 
 
+async def test_publish_diary_status_error_with_zero_exit_returns_result(tmp_path: Path) -> None:
+    """終了コード 0 + status=error の場合、ArticlePublishResult に error / failed_phase が入る (Issue #848).
+
+    article-writer 側が exit_code=0 で status=error を返すケース（例: cleanup phase の失敗）でも、
+    本リポは ArticlePublishResult として受け取り、error / failed_phase を表示側に渡せるようにする。
+    表示側 (_format_article_success) が status="error" を検出して汎用エラー表示に分岐する。
+    """
+    payload = json.dumps({
+        "status": "error",
+        "failed_phase": "cleanup",
+        "error": "gh pr merge failed: stale review",
+        "worktree_path": "../article-writer-wt-foo",
+        "merged": False,
+        "worktree_removed": False,
+    })
+    publisher = _make_publisher(tmp_path)
+    with patch(
+        "src.services.article_publisher.shutil.which", return_value="/usr/bin/claude",
+    ), patch(
+        "src.services.article_publisher.asyncio.create_subprocess_exec",
+        new=_make_subprocess_mock_writing_result(tmp_path, payload, returncode=0),
+    ):
+        result = await publisher.publish_diary()
+
+    assert isinstance(result, ArticlePublishResult)
+    assert result.status == "error"
+    assert result.error == "gh pr merge failed: stale review"
+    assert result.failed_phase == "cleanup"
+    assert result.worktree_removed is False
+    assert result.worktree_path == "../article-writer-wt-foo"
+
+
 async def test_publish_diary_failure_returns_failure(tmp_path: Path) -> None:
     """終了コード非 0 + レスポンスファイル解析成功時、ArticlePublishFailure が返る."""
     payload = json.dumps({

--- a/tests/test_message_router.py
+++ b/tests/test_message_router.py
@@ -1058,7 +1058,7 @@ async def test_article_write_hatena_status_error_uses_generic_failure_format() -
     """status="error" + exit_code=0 のとき、成功表示ではなく汎用エラー表示を使う (Issue #848).
 
     article-writer 側が status=error の result.json を返した場合、終了コードが 0 でも
-    実態は失敗のため、`_format_article_success` 経由で汎用エラー表示に分岐する。
+    実態は失敗のため、`_format_article_result` 経由で汎用エラー表示に分岐する。
     個別現象（マージ失敗等）の文言を本リポで分岐せず、result.json の `error` /
     `failed_phase` をそのまま表示することで article-writer 側の追加・変更に追従不要とする。
     """

--- a/tests/test_message_router.py
+++ b/tests/test_message_router.py
@@ -1052,3 +1052,83 @@ async def test_article_write_hatena_absolute_worktree_path_shows_basename_only()
         assert "/foo/bar/" not in failure_msg, f"Leaked path for: {absolute_path}"
         assert "\\foo\\bar\\" not in failure_msg, f"Leaked path for: {absolute_path}"
         assert "/abs/path/to/" not in failure_msg, f"Leaked path for: {absolute_path}"
+
+
+async def test_article_write_hatena_status_error_uses_generic_failure_format() -> None:
+    """status="error" + exit_code=0 のとき、成功表示ではなく汎用エラー表示を使う (Issue #848).
+
+    article-writer 側が status=error の result.json を返した場合、終了コードが 0 でも
+    実態は失敗のため、`_format_article_success` 経由で汎用エラー表示に分岐する。
+    個別現象（マージ失敗等）の文言を本リポで分岐せず、result.json の `error` /
+    `failed_phase` をそのまま表示することで article-writer 側の追加・変更に追従不要とする。
+    """
+    from src.services.article_publisher import ArticlePublishResult
+
+    publisher = _make_article_publisher(
+        publish_result=ArticlePublishResult(
+            status="error",
+            article_path=None,
+            edit_url=None,
+            public_url=None,
+            pr_url=None,
+            worktree_removed=False,
+            worktree_path="../article-writer-wt-diary-20260607",
+            error="gh pr merge failed: stale review",
+            failed_phase="publish",
+        ),
+    )
+    adapter, router = _make_router(
+        article_writer_publisher=publisher,
+        remote_control_allowed_users=["U_AUTHORIZED"],
+    )
+
+    await router.process_message(
+        _make_msg("article write-hatena", user_id="U_AUTHORIZED"),
+    )
+
+    assert len(adapter.sent_messages) == 2
+    msg = adapter.sent_messages[1][0]
+    # 汎用エラー表示が使われていること（成功ヘッダーが出ないこと）
+    assert msg.startswith("❌ 日記の自動投稿に失敗しました")
+    assert "✅" not in msg
+    assert "worktree 削除のみ失敗" not in msg
+    # result.json の error / failed_phase / worktree_path が表示されること
+    assert "失敗 Phase: publish" in msg
+    assert "理由: gh pr merge failed: stale review" in msg
+    assert "残置 worktree: ../article-writer-wt-diary-20260607" in msg
+    # exit_code=0 (ArticlePublishResult 経由) のときは exit code 行を出さない（status=error 経路向け設計）
+    assert "exit code:" not in msg
+
+
+async def test_article_write_hatena_status_error_without_optional_fields() -> None:
+    """status="error" で error / failed_phase が無い場合でも、汎用エラーヘッダーは表示される.
+
+    article-writer 側がフィールドを省略しても、ヘッダーのみは確実に出る (degrade 設計)。
+    """
+    from src.services.article_publisher import ArticlePublishResult
+
+    publisher = _make_article_publisher(
+        publish_result=ArticlePublishResult(
+            status="error",
+            article_path=None,
+            edit_url=None,
+            public_url=None,
+            pr_url=None,
+            worktree_removed=False,
+            worktree_path=None,
+            error=None,
+            failed_phase=None,
+        ),
+    )
+    adapter, router = _make_router(
+        article_writer_publisher=publisher,
+        remote_control_allowed_users=["U_AUTHORIZED"],
+    )
+
+    await router.process_message(
+        _make_msg("article write-hatena", user_id="U_AUTHORIZED"),
+    )
+
+    assert len(adapter.sent_messages) == 2
+    msg = adapter.sent_messages[1][0]
+    assert msg == "❌ 日記の自動投稿に失敗しました"


### PR DESCRIPTION
## Change type

- [x] fix: バグ修正 ★

## Summary

- article-writer の `/auto-publish-diary` が返す `result.json` で `status="error"` + 終了コード 0 のケースが「成功」分岐として処理され、「worktree 削除のみ失敗」と実態と異なる文言が Slack に表示されていた問題を修正
- `_format_article_success` を `_format_article_result` にリネームし、`status == "error"` を検出して `_format_article_failure_message` 共通 helper で汎用エラー表示に分岐する設計に変更
- `ArticlePublishResult` に `error: str | None = None` / `failed_phase: str | None = None` を追加し、payload からの読み取りを実装
- 仕様書（`docs/specs/features/article-publishing.md`）の振る舞いステップ 9 と出力セクションに `status="error"` 時の汎用エラー表示パターンを追記。`status` 値の判定基準（`"error"` 完全一致）と degrade 設計（全フィールド欠落時はヘッダーのみ）も明文化

article-writer 側で個別現象（マージ失敗・push 失敗等）ごとにエラー文言・分類が追加・変更されても、本リポは `error` / `failed_phase` をそのまま表示する汎用設計のため追従改修が不要になる疎結合化を実現します。

## Test plan

- [x] `tests/test_message_router.py`: `status="error"` + `exit_code=0` で汎用エラー形式が使われること（新規 1 件）
- [x] `tests/test_message_router.py`: degrade 設計（全 optional フィールド欠落時はヘッダーのみ）（新規 1 件）
- [x] `tests/test_article_publisher.py`: 終了コード 0 + `status="error"` で `error` / `failed_phase` が `ArticlePublishResult` に入ること（新規 1 件）
- [x] 既存テスト（`status="ok"` 系・`ArticlePublishFailure` 系）が全て pass（リグレッションなし）
- [x] pytest 424 件 / ruff / mypy / markdownlint-cli2 all green

## Related issues

Closes #848